### PR TITLE
fix: support both Control and Meta keys for hover state

### DIFF
--- a/ui/components/ui/graph/node/utils/wheel.vue
+++ b/ui/components/ui/graph/node/utils/wheel.vue
@@ -46,12 +46,12 @@ const handleOptionClick = (option: WheelOption) => {
 };
 
 const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Control') {
+    if (e.key === 'Control' || e.key === 'Meta') {
         isCtrlPressed.value = true;
     }
 };
 const handleKeyUp = (e: KeyboardEvent) => {
-    if (e.key === 'Control') {
+    if (e.key === 'Control' || e.key === 'Meta') {
         isCtrlPressed.value = false;
     }
 };


### PR DESCRIPTION
This pull request updates keyboard handling logic in `wheel.vue` to improve compatibility with macOS by recognizing the `Meta` key (Command key) in addition to the `Control` key.

Keyboard handling updates:

* [`ui/components/ui/graph/node/utils/wheel.vue`](diffhunk://#diff-534c9e73ff700da2b0a9ddfbcd084233f8ab4b88d857a8c725eb46da62fe7a79L49-R54): Modified `handleKeyDown` and `handleKeyUp` functions to check for both `Control` and `Meta` keys, ensuring macOS users can use the Command key for the same functionality as the Control key.