### PR TITLE
feat: update title generation model and prompt

### DIFF
--- a/api/app/const/prompts.py
+++ b/api/app/const/prompts.py
@@ -25,4 +25,4 @@ TITLE_GENERATION_PROMPT = """You are a helpful assistant that generates titles f
 The title should be concise and reflect the main topic of the conversation.
 Use the following conversation to generate a suitable title.
 Titles should not be a question, but rather a statement summarizing the conversation.
-DO NOT ANSWER THE USER PROMPT, JUST GENERATE A TITLE. MAXIMUM 10 WORDS."""
+DO NOT ANSWER THE USER PROMPT, JUST GENERATE A TITLE. MAXIMUM 10 WORDS. NO PUNCTUATION, SPECIAL CHARACTERS OR QUOTATION MARKS."""


### PR DESCRIPTION
This pull request introduces updates to the title generation prompt, refines how user prompts are processed, and changes the language model used for chat completions. The most important changes focus on improving input validation, truncating overly long user prompts, and switching to a new AI model for better performance.

### Updates to title generation:

* [`api/app/const/prompts.py`](diffhunk://#diff-9516df93ac99af3251ffae365a1d14bfa2ee32bdf8201504d28822b3b42f0048L28-R28): Modified the title generation prompt to restrict punctuation, special characters, and quotation marks in generated titles.

### Enhancements to user prompt handling:

* [`api/app/services/stream.py`](diffhunk://#diff-bc15aef7e165d1a940257f6e64c65721b5a46d87210845a9c832e0ccd680ca59R82-R105): Added logic to extract text content from the first user prompt node and truncate it if it exceeds 2000 characters. This ensures that overly long inputs are handled gracefully.

### Model change for chat completion:

* [`api/app/services/stream.py`](diffhunk://#diff-bc15aef7e165d1a940257f6e64c65721b5a46d87210845a9c832e0ccd680ca59R82-R105): Updated the chat completion model from `openai/gpt-4.1-nano` to `google/gemini-2.5-flash-lite-preview-06-17` for improved performance and capabilities.

### Dependency addition:

* [`api/app/services/stream.py`](diffhunk://#diff-bc15aef7e165d1a940257f6e64c65721b5a46d87210845a9c832e0ccd680ca59R15): Imported `MessageContentTypeEnum` from `models.message` to support the new logic for handling message content types.…n and special characters