### PR TITLE
OpenRouter Model Refresh Integration & Codebase Refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Environment files
+env/
+config.toml
+config.local.toml
+
+# VSCode workspace files
+.vscode/
+.settings/

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -71,3 +71,7 @@ Thumbs.db
 
 # Data files
 uploads/
+
+# VSCode workspace files
+.vscode/
+.settings/

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,3 +1,0 @@
-env/
-config.toml
-config.local.toml

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -22,3 +22,7 @@ logs
 .env
 .env.*
 !.env.example
+
+# VSCode workspace files
+.vscode/
+.settings/

--- a/ui/components/ui/settings/section/models.vue
+++ b/ui/components/ui/settings/section/models.vue
@@ -3,13 +3,51 @@ import { ReasoningEffortEnum } from '@/types/enums';
 
 // --- Stores ---
 const globalSettingsStore = useSettingsStore();
+const modelStore = useModelStore();
+const settingsStore = useSettingsStore();
 
 // --- State from Stores (Reactive Refs) ---
+const { modelsDropdownSettings, appearanceSettings } = storeToRefs(settingsStore);
 const { modelsSettings } = storeToRefs(globalSettingsStore);
+
+// --- Actions/Methods from Stores ---
+const { setModels, sortModels, triggerFilter } = modelStore;
+
+// --- Composables ---
+const { refreshOpenRouterModels } = useAPI();
+const { success } = useToast();
+
+// --- Core functions ---
+const refreshModels = async () => {
+    const modelList = await refreshOpenRouterModels();
+    setModels(modelList.data);
+    sortModels(modelsDropdownSettings.value.sortBy);
+    triggerFilter();
+    success(`Refreshed OpenRouter models successfully (${modelList.data.length} models)`);
+};
 </script>
 
 <template>
     <div class="grid h-full w-full grid-cols-[33%_66%] content-start items-start gap-y-8">
+        <label class="flex gap-2" for="models-refresh">
+            <h3 class="text-stone-gray font-bold">Refresh OpenRouter Models</h3>
+            <UiSettingsInfobubble>
+                Refresh the list of models from OpenRouter. This will update the list of available
+                models in the dropdown.
+            </UiSettingsInfobubble>
+        </label>
+        <div id="models-refresh">
+            <button
+                @click="refreshModels"
+                class="border-stone-gray/20 bg-anthracite/20 text-stone-gray hover:bg-anthracite focus:border-ember-glow
+                    flex h-10 w-fit items-center justify-center gap-2 rounded-lg border-2 px-8 transition-colors
+                    duration-200 ease-in-out focus:border-2 focus:outline-none"
+            >
+                <UiIcon name="MaterialSymbolsChangeCircleRounded" class="h-5 w-5" />
+                Refresh Models
+            </button>
+        </div>
+
         <label class="flex gap-2" for="models-default-model">
             <h3 class="text-stone-gray font-bold">Default Model</h3>
             <UiSettingsInfobubble>

--- a/ui/composables/useAPI.ts
+++ b/ui/composables/useAPI.ts
@@ -287,6 +287,19 @@ export const useAPI = () => {
     };
 
     /**
+     * Refreshes the list of models from the OpenRouter API.
+     * @returns The refreshed list of models.
+     */
+    const refreshOpenRouterModels = async (): Promise<ResponseModel> => {
+        return apiFetch<ResponseModel>('/models/refresh', {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+            },
+        });
+    };
+
+    /**
      * Get user settings.
      */
     const getUserSettings = async (): Promise<Settings> => {
@@ -393,6 +406,7 @@ export const useAPI = () => {
         getGenerateRoutingStream,
         getChat,
         getOpenRouterModels,
+        refreshOpenRouterModels,
         getUserSettings,
         updateUserSettings,
         uploadFile,

--- a/ui/pages/index.vue
+++ b/ui/pages/index.vue
@@ -244,8 +244,8 @@ onBeforeUnmount(() => {
                     :to="{ name: 'graph-id', params: { id: graph.id } }"
                 >
                     <div class="text-stone-gray flex gap-3">
-                        <UiIcon name="MaterialSymbolsFlowchartSharp" class="h-7 w-7" />
-                        <span class="text-lg font-bold">
+                        <UiIcon name="MaterialSymbolsFlowchartSharp" class="h-7 w-7 shrink-0" />
+                        <span class="line-clamp-2 text-lg font-bold break-all">
                             {{ graph.name }}
                         </span>
                     </div>


### PR DESCRIPTION
This pull request introduces several changes across different areas of the codebase, including updates to `.gitignore` files, backend API enhancements, and frontend UI improvements. The most significant updates involve adding functionality to refresh model lists from the OpenRouter API and integrating this feature into the frontend interface.

### `.gitignore` updates:
* Added exclusions for VSCode workspace files (`.vscode/`, `.settings/`) in `api/.gitignore` and `ui/.gitignore`. [[1]](diffhunk://#diff-29170f7d39ee9a02f2f12814848e5e109bb0c0d48e9ac643e1e22dd5683cc72bR74-R77) [[2]](diffhunk://#diff-d22b04fb83bfe8cd444e3dd3b9d3c3a2f7431a193bd7d677f35d59e8b7d1a6e1R25-R28)
* Removed unused entries (`env/`, `config.toml`, `config.local.toml`) from `docker/.gitignore`.

### Backend API enhancements:
* Added a new POST endpoint `/models/refresh` in `api/app/routers/models.py` to refresh the list of available models from the OpenRouter API.

### Frontend UI improvements:
* Integrated the model refresh functionality into the settings section of the UI (`ui/components/ui/settings/section/models.vue`). Added a button and supporting logic to refresh the OpenRouter models list, including user feedback via a toast notification.
* Added the `refreshOpenRouterModels` method in `ui/composables/useAPI.ts` to handle API calls for refreshing models. [[1]](diffhunk://#diff-c0dc74df42e85d4f0cd7e57a915c7c65e39df103c591edaa36a9b49d112ba7dfR289-R301) [[2]](diffhunk://#diff-c0dc74df42e85d4f0cd7e57a915c7c65e39df103c591edaa36a9b49d112ba7dfR409)

### Minor UI adjustments:
* Improved text wrapping in the graph name display on the index page (`ui/pages/index.vue`) by adding `line-clamp-2` and `break-all` for better readability.