### PR TITLE
feat: can connect multiple prompt node

### DIFF
--- a/ui/components/ui/graph/node/prompt.vue
+++ b/ui/components/ui/graph/node/prompt.vue
@@ -66,6 +66,7 @@ const props = defineProps<NodeProps<DataPrompt>>();
         ></UiGraphNodeUtilsTextarea>
     </div>
 
+    <UiGraphNodeUtilsHandlePrompt type="target" :id="props.id" />
     <UiGraphNodeUtilsHandlePrompt type="source" :id="props.id" />
 </template>
 

--- a/ui/components/ui/graph/node/utils/handlePrompt.vue
+++ b/ui/components/ui/graph/node/utils/handlePrompt.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 // --- Composables ---
 const { handleConnectableInput } = useEdgeCompatibility();
 
-const compatibleSourceNodeTypes = [NodeTypeEnum.TEXT_TO_TEXT, NodeTypeEnum.PARALLELIZATION, NodeTypeEnum.ROUTING];
+const compatibleSourceNodeTypes = [NodeTypeEnum.TEXT_TO_TEXT, NodeTypeEnum.PARALLELIZATION, NodeTypeEnum.ROUTING, NodeTypeEnum.PROMPT];
 const compatibleTargetNodeTypes = [NodeTypeEnum.PROMPT];
 </script>
 

--- a/ui/composables/useGraphDragAndDrop.ts
+++ b/ui/composables/useGraphDragAndDrop.ts
@@ -206,8 +206,12 @@ export function useGraphDragAndDrop() {
             if (orientation === 'horizontal') {
                 positionOffset.y = type === 'source' ? 450 : -450;
                 if (dragBlockHandleCategory === 'prompt') {
-                    positionOffset.x = -250;
-                    positionOffset.y = -175;
+                    if (type === 'target') {
+                        positionOffset.x = -250;
+                        positionOffset.y = -175;
+                    } else {
+                        positionOffset.y = 150;
+                    }
                 }
             } else {
                 positionOffset.x = type === 'source' ? 400 : -250;


### PR DESCRIPTION
This pull request introduces key updates to the `graph_service.py` backend and the front-end handling of graph nodes, focusing on improving message history construction and enhancing graph node compatibility and drag-and-drop functionality.

### Backend Changes: Improvements to Message History Construction

* **Added new enums for message roles and content types**: Introduced `MessageContentTypeEnum` and `MessageRoleEnum` to improve message handling and categorization in `graph_service.py`.
* **Merged consecutive user messages**: Updated the `construct_message_history` function to merge consecutive user messages into a single message, ensuring a cleaner conversation structure. This involves combining text content and appending other content types. [[1]](diffhunk://#diff-d10e4dc39c4b482eb354fc7a38f5e2aea393ab319678ae2a91fc135e3202e781L39-R42) [[2]](diffhunk://#diff-d10e4dc39c4b482eb354fc7a38f5e2aea393ab319678ae2a91fc135e3202e781L95-R137)

### Front-End Changes: Enhancements to Graph Node Functionality

* **Added target handle for prompt nodes**: Updated `prompt.vue` to include a target handle for prompt nodes, enabling connections to other nodes.
* **Expanded compatible node types**: Modified `handlePrompt.vue` to include `NodeTypeEnum.PROMPT` as a compatible source node type, improving the flexibility of graph connections.
* **Adjusted drag-and-drop offsets for prompt nodes**: Refined drag-and-drop behavior in `useGraphDragAndDrop.ts` to account for different orientations and handle types for prompt nodes, ensuring better placement during graph interactions.