### PR TITLE
fix(prompt): savegraph on focusout in prompt textarea

### DIFF
--- a/ui/components/ui/graph/node/prompt.vue
+++ b/ui/components/ui/graph/node/prompt.vue
@@ -22,8 +22,12 @@ const graphId = computed(() => (route.params.id as string) ?? '');
 const props = defineProps<NodeProps<DataPrompt>>();
 
 // --- Methods ---
-const doneAction = async () => {
+const doneAction = async (generateNext: boolean) => {
     await saveGraph();
+    if (!generateNext) {
+        emit('updateNodeInternals');
+        return;
+    }
     const nodes = await searchNode(graphId.value, props.id, 'downstream', [
         NodeTypeEnum.PARALLELIZATION,
         NodeTypeEnum.ROUTING,

--- a/ui/components/ui/graph/node/utils/textarea.vue
+++ b/ui/components/ui/graph/node/utils/textarea.vue
@@ -8,7 +8,6 @@ const props = defineProps<{
     color?: 'olive-grove' | 'terracotta-clay' | 'slate-blue' | 'sunbaked-sand' | null;
     placeholder: string;
     autoscroll: boolean;
-    doneAction?: () => void;
 }>();
 
 // --- Local State ---
@@ -23,8 +22,7 @@ function handleInput(event: Event) {
 function handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Enter' && event.ctrlKey) {
         event.preventDefault();
-        props.doneAction?.();
-        emit('update:doneAction');
+        emit('update:doneAction', true);
     }
 }
 
@@ -60,7 +58,7 @@ if (props.autoscroll) {
                 'bg-[#49545f]': color === 'slate-blue',
                 'bg-sunbaked-sand-dark !text-obsidian': color === 'sunbaked-sand',
             }"
-            @focusout="doneAction"
+            @focusout="emit('update:doneAction', false);"
         ></textarea>
     </div>
 </template>


### PR DESCRIPTION
This pull request refactors the way the "done" action is triggered and handled for node prompts and textareas in the graph UI. The main change is to pass a boolean flag indicating whether the action was triggered by generating the next node or simply by finishing input, improving clarity and control of user interactions.

**Done Action Refactoring:**

* The `doneAction` method in `prompt.vue` now takes a `generateNext` boolean parameter to distinguish between different completion triggers.
* The `doneAction` prop and related logic were removed from `textarea.vue`, and completion is now communicated via the `update:doneAction` event with a boolean value.

**Event Handling Improvements:**

* Pressing Ctrl+Enter in the textarea now emits `update:doneAction` with `true`, indicating the user wants to generate the next node.
* Blurring (focus out) of the textarea emits `update:doneAction` with `false`, indicating simple completion without generating the next node.