### PR TITLE
feat(graph): Node duplication and copy-paste features

### DIFF
--- a/ui/components/ui/graph/node/utils/runToolbar.vue
+++ b/ui/components/ui/graph/node/utils/runToolbar.vue
@@ -13,6 +13,7 @@ defineProps<{
 
 // --- Composables ---
 const { setExecutionPlan } = useExecutionPlan();
+const { duplicateNode } = useGraphActions();
 </script>
 
 <template>
@@ -26,6 +27,7 @@ const { setExecutionPlan } = useExecutionPlan();
             class="bg-soft-silk/10 border-soft-silk/20 absolute -top-16 left-1/2 z-10 flex -translate-x-1/2
                 items-center justify-between rounded-2xl border-2 p-1 shadow-lg backdrop-blur-md"
         >
+            <!-- Run all nodes above button -->
             <button
                 class="hover:bg-soft-silk/20 flex cursor-pointer items-center justify-center rounded-xl p-2
                     transition-colors duration-200 ease-in-out"
@@ -36,6 +38,7 @@ const { setExecutionPlan } = useExecutionPlan();
                 <UiIcon name="CodiconRunAbove" class="text-soft-silk h-5 w-5"> </UiIcon>
             </button>
 
+            <!-- Run current node button -->
             <button
                 class="hover:bg-soft-silk/20 flex cursor-pointer items-center justify-center rounded-xl p-2
                     transition-colors duration-200 ease-in-out"
@@ -46,6 +49,7 @@ const { setExecutionPlan } = useExecutionPlan();
                 <UiIcon name="CodiconRunAll" class="text-soft-silk h-5 w-5"> </UiIcon>
             </button>
 
+            <!-- Run all nodes below button -->
             <button
                 class="hover:bg-soft-silk/20 flex cursor-pointer items-center justify-center rounded-xl p-2
                     transition-colors duration-200 ease-in-out"
@@ -59,6 +63,17 @@ const { setExecutionPlan } = useExecutionPlan();
                 class="bg-soft-silk/20 mx-2 h-6 w-[3px] self-center rounded-full text-transparent"
             />
 
+            <!-- Duplicate current node button -->
+            <button
+                class="hover:bg-soft-silk/20 text-soft-silk/80 hover:text-soft-silk flex cursor-pointer items-center
+                    justify-center rounded-xl p-2 transition-colors duration-200 ease-in-out"
+                title="Duplicate Node"
+                @click="duplicateNode(graphId, nodeId)"
+            >
+                <UiIcon name="MajesticonsDuplicateLine" class="h-5 w-5"> </UiIcon>
+            </button>
+
+            <!-- Delete current node button -->
             <button
                 class="hover:bg-terracotta-clay/25 text-terracotta-clay flex cursor-pointer items-center justify-center
                     rounded-xl p-2 transition-colors duration-200 ease-in-out"

--- a/ui/composables/useGraphActions.ts
+++ b/ui/composables/useGraphActions.ts
@@ -125,10 +125,57 @@ export const useGraphActions = () => {
         }).length;
     };
 
+    const duplicateNode = async (graphId: string, nodeId: string) => {
+        const { getNodes, addNodes, removeSelectedNodes } = useVueFlow('main-graph-' + graphId);
+        const node = getNodes.value.find((n) => n.id === nodeId);
+
+        if (!node) {
+            console.error(`Node not found: ${nodeId}`);
+            return;
+        }
+
+        // Offset node by a few pixels
+        const positionOffset = { x: 25, y: 25 };
+        const newNode = {
+            id: generateId(),
+            position: {
+                x: node.position.x + positionOffset.x,
+                y: node.position.y + positionOffset.y,
+            },
+            style: {
+                ...node.style,
+            },
+            data: {
+                ...node.data,
+            },
+            type: node.type,
+            selected: true,
+        };
+
+        addNodes(newNode);
+
+        // wait for div with data-id=newNode.id to be mounted
+        await new Promise((resolve) => {
+            const checkNode = () => {
+                const exists = document.querySelector(`[data-id="${newNode.id}"]`);
+                if (exists) {
+                    resolve(true);
+                } else {
+                    setTimeout(checkNode, 10);
+                }
+            };
+            checkNode();
+        });
+
+        // Unselect previously selected node
+        removeSelectedNodes([node]);
+    };
+
     return {
         placeBlock,
         placeEdge,
-        numberOfConnectionsFromHandle,
         toggleEdgeAnimation,
+        numberOfConnectionsFromHandle,
+        duplicateNode,
     };
 };


### PR DESCRIPTION
This pull request introduces new node duplication and copy-paste features to the graph UI, making it easier to duplicate nodes and copy/paste nodes (and their edges) using both toolbar buttons and keyboard shortcuts. The changes span the graph toolbar, composables, and main graph page, and include logic for copying, pasting, and duplicating nodes, as well as handling keyboard and mouse events for a smooth user experience.

**Node duplication and copy-paste functionality:**

* Added a `duplicateNode` function in `useGraphActions` to duplicate a node with a slight offset and update selection state.
* Implemented `copyNode` and `pasteNodes` functions in `useGraphActions` to support copying selected nodes (and their internal edges) to localStorage and pasting them at the mouse cursor position, including correct placement for single or multiple nodes.
* Exposed `duplicateNode`, `copyNode`, and `pasteNodes` from `useGraphActions` and integrated `duplicateNode` into the graph node toolbar UI as a new button. [[1]](diffhunk://#diff-433cd13e5ecb3867fae6b0a4770c35c5c2f78e72c03ac1c1710db95bdf2d3a89R16) [[2]](diffhunk://#diff-433cd13e5ecb3867fae6b0a4770c35c5c2f78e72c03ac1c1710db95bdf2d3a89R66-R76)

**Keyboard and mouse event integration:**

* Added `handleKeyDown` and `handleMouseMove` event handlers in the main graph page to support CTRL+C (copy) and CTRL+V (paste) shortcuts, using the current mouse position for paste placement. ([ui/pages/graph/[id].vueR163-R189](diffhunk://#diff-4ee79ba4cbf472ea09b338c811c2347006ee2440fb23f4250c715dac3bbf914fR163-R189))
* Registered and cleaned up these event listeners on mount/unmount of the graph page to ensure proper behavior and avoid memory leaks. ([ui/pages/graph/[id].vueR292-R299](diffhunk://#diff-4ee79ba4cbf472ea09b338c811c2347006ee2440fb23f4250c715dac3bbf914fR292-R299))

**UI enhancements:**

* Updated the graph node toolbar to clearly label and separate run, duplicate, and delete actions with comments and new buttons for improved usability. [[1]](diffhunk://#diff-433cd13e5ecb3867fae6b0a4770c35c5c2f78e72c03ac1c1710db95bdf2d3a89R30) [[2]](diffhunk://#diff-433cd13e5ecb3867fae6b0a4770c35c5c2f78e72c03ac1c1710db95bdf2d3a89R41) [[3]](diffhunk://#diff-433cd13e5ecb3867fae6b0a4770c35c5c2f78e72c03ac1c1710db95bdf2d3a89R52) [[4]](diffhunk://#diff-433cd13e5ecb3867fae6b0a4770c35c5c2f78e72c03ac1c1710db95bdf2d3a89R66-R76)

These changes collectively provide a more efficient and intuitive workflow for managing nodes in the graph UI.