### PR TITLE
fix: Improve scrollbar handling in right sidebar components

### DIFF
--- a/ui/components/ui/graph/sidebar/blocks.vue
+++ b/ui/components/ui/graph/sidebar/blocks.vue
@@ -12,7 +12,7 @@ const { onDragStart, onDragEnd } = useGraphDragAndDrop();
 </script>
 
 <template>
-    <div class="w-full overflow-hidden">
+    <div class="hide-scrollbar max-h-full w-full overflow-x-hidden overflow-y-auto">
         <div
             class="flex w-[28rem] flex-col items-center px-4 pb-10 transition-opacity duration-300 ease-in-out"
             :class="{

--- a/ui/components/ui/graph/sidebar/canvasConfig.vue
+++ b/ui/components/ui/graph/sidebar/canvasConfig.vue
@@ -65,8 +65,8 @@ const updateSidebarConfig = () => {
 
 <template>
     <div
-        class="grid max-h-full w-full grid-rows-[1fr_1fr_1fr_1fr_1fr_1fr_10fr] flex-col gap-6 overflow-hidden px-4
-            transition-opacity duration-300 ease-in-out"
+        class="hide-scrollbar grid max-h-full w-full grid-rows-[1fr_1fr_1fr_1fr_1fr_1fr_10fr] flex-col gap-6
+            overflow-y-auto px-4 transition-opacity duration-300 ease-in-out"
         :class="{
             'opacity-0': !isOpen,
             'opacity-100': isOpen,

--- a/ui/components/ui/graph/sidebar/wrapper.vue
+++ b/ui/components/ui/graph/sidebar/wrapper.vue
@@ -42,7 +42,7 @@ defineProps<{
                 </HeadlessTab>
             </HeadlessTabList>
 
-            <HeadlessTabPanels class="h-[calc(100%-1rem-3.5rem)] w-full">
+            <HeadlessTabPanels class="h-[calc(100%-1rem-3.5rem)] w-full overflow-y-hidden">
                 <HeadlessTabPanel class="h-full w-full">
                     <UiGraphSidebarBlocks></UiGraphSidebarBlocks>
                 </HeadlessTabPanel>


### PR DESCRIPTION
This pull request improves the scrolling behavior and visual consistency of the graph sidebar components by refining how overflow and scrollbars are handled across related Vue files.

**UI/UX Improvements to Sidebar Scrolling:**

* [`ui/components/ui/graph/sidebar/blocks.vue`](diffhunk://#diff-442e5cdfde9c12b34ead603e75aa9987f314e58377cd4aa5fe6541e271f5cb84L15-R15): Adds `hide-scrollbar`, `max-h-full`, and refines overflow classes to ensure the sidebar content is scrollable vertically and scrollbars are hidden for a cleaner appearance.
* [`ui/components/ui/graph/sidebar/canvasConfig.vue`](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL68-R69): Updates the main container to use `hide-scrollbar` and `overflow-y-auto` for improved vertical scrolling, removing unnecessary `overflow-hidden`.
* [`ui/components/ui/graph/sidebar/wrapper.vue`](diffhunk://#diff-4cd20d71143610b0a02f6be933bbe49eb36afd97170411ab7c591d105b05814eL45-R45): Sets `overflow-y-hidden` on the tab panels to prevent unwanted vertical scrollbars within tab content.