### PR TITLE
fix: remove styling when pasting text in chatbox text input

### DIFF
--- a/ui/components/ui/chat/textInput.vue
+++ b/ui/components/ui/chat/textInput.vue
@@ -71,6 +71,26 @@ const handleDrop = async (event: DragEvent) => {
     }
 };
 
+const handlePaste = (event: ClipboardEvent) => {
+    event.preventDefault();
+
+    // Remove formatting from pasted text
+    const text = event.clipboardData?.getData('text/plain');
+    if (!text) return;
+
+    document.execCommand('insertText', false, text);
+
+    onInput();
+
+    // After the DOM updates from the paste, scroll the input field to the bottom
+    const el = textareaRef.value;
+    if (el) {
+        nextTick(() => {
+            el.scrollTop = el.scrollHeight;
+        });
+    }
+};
+
 const addFiles = async (newFiles: globalThis.FileList) => {
     if (!newFiles) return;
 
@@ -203,6 +223,7 @@ const addFiles = async (newFiles: globalThis.FileList) => {
                 @dragover.prevent="isDraggingOver = true"
                 @dragleave.prevent="isDraggingOver = false"
                 @drop.prevent="handleDrop"
+                @paste="handlePaste"
                 autofocus
             ></div>
 


### PR DESCRIPTION
This pull request adds support for pasting plain text into the chat input, ensuring that any formatting from the clipboard is removed. This improves the user experience by preventing unwanted formatting when users paste text.

**Before**
<img width="1189" height="642" alt="ShoT_2025-08-11-06-53-07_5120x1440" src="https://github.com/user-attachments/assets/d8973482-7f3d-46e7-a77d-07c57bf0e7ee" />

**After**
<img width="1163" height="645" alt="ShoT_2025-08-11-06-53-24_5120x1440" src="https://github.com/user-attachments/assets/ef0fb586-6dff-4eda-a1fd-02dbe691d8e0" />


Text input improvements:

* Added a new `handlePaste` function to intercept paste events, strip formatting, and insert plain text into the chat input. After pasting, the input field scrolls to the bottom to show the newly inserted text. (`textInput.vue`)
* Registered the `handlePaste` function as a handler for the `paste` event on the chat input element. (`textInput.vue`)