### PR TITLE
feat: implement 'Remember Me' functionality in login process

### DIFF
--- a/api/app/services/auth.py
+++ b/api/app/services/auth.py
@@ -12,14 +12,17 @@ from database.pg.crud import does_user_exist
 from models.auth import UserPass
 
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 22  # 22 hours
+ACCESS_TOKEN_EXPIRE_REMEMBER_ME = 60 * 24 * 30  # 30 days
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/users/auth/token")
 
 logger = logging.getLogger("uvicorn.error")
 
 
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+def create_access_token(
+    data: dict, stay_signed_in: bool = False, expires_delta: Optional[timedelta] = None
+):
     """
     Creates a JWT token with the provided data and expiration time.
     Args:
@@ -39,7 +42,9 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
         expire = datetime.now(timezone.utc) + expires_delta
     else:
         expire = datetime.now(timezone.utc) + timedelta(
-            minutes=ACCESS_TOKEN_EXPIRE_MINUTES
+            minutes=ACCESS_TOKEN_EXPIRE_REMEMBER_ME
+            if stay_signed_in
+            else ACCESS_TOKEN_EXPIRE_MINUTES
         )
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(claims=to_encode, key=SECRET_KEY, algorithm=ALGORITHM)

--- a/ui/components/ui/settings/section/blocks.vue
+++ b/ui/components/ui/settings/section/blocks.vue
@@ -30,6 +30,7 @@ const { blockSettings } = storeToRefs(globalSettingsStore);
                                     : blockSettings.wheel.filter((item) => item !== wheel.value);
                             }
                         "
+                        :style="'white'"
                     ></UiSettingsUtilsCheckbox>
                 </li>
             </ul>

--- a/ui/components/ui/settings/utils/checkbox.vue
+++ b/ui/components/ui/settings/utils/checkbox.vue
@@ -4,38 +4,43 @@ defineProps<{
     label: string;
     state: boolean;
     setState: (val: boolean) => void;
+    style: 'white' | 'dark';
 }>();
-
-// --- Local State ---
-const mounted = ref(false);
-
-onMounted(() => {
-    mounted.value = true;
-});
 </script>
 
 <template>
-    <label class="relative inline-flex cursor-pointer items-center" v-if="mounted">
+    <label class="relative inline-flex cursor-pointer items-center">
         <input
             type="checkbox"
             :checked="state"
             @change="setState(($event.target as HTMLInputElement).checked)"
             class="sr-only"
         />
+
         <div
-            :class="state ? 'bg-ember-glow border-ember-glow' : 'border-stone-gray bg-white'"
             class="flex h-5 w-5 items-center justify-center rounded border-2 transition duration-200 ease-in-out"
+            :class="{
+                'bg-ember-glow border-ember-glow': state,
+                'border-stone-gray bg-white': style === 'white' && !state,
+                'border-stone-gray/20 bg-obsidian/50': style === 'dark' && !state,
+            }"
         >
             <UiIcon
                 v-if="state"
                 name="MaterialSymbolsCheckSmallRounded"
                 class="h-5 w-5 text-white"
             />
-            <div v-if="!state" class="h-5 w-5 rounded-full bg-white"></div>
+            <div
+                v-if="!state"
+                class="h-4 w-4 rounded"
+                :class="{
+                    'bg-white': style === 'white',
+                    'bg-obsidian/50': style === 'dark',
+                }"
+            ></div>
         </div>
         <span class="text-stone-gray ml-2 font-medium">{{ label }}</span>
     </label>
-    <div v-else class="bg-stone-gray/20 h-5 w-5 animate-pulse rounded"></div>
 </template>
 
 <style scoped></style>

--- a/ui/pages/auth/login.vue
+++ b/ui/pages/auth/login.vue
@@ -3,6 +3,7 @@ const isOAuthDisabled = ref<boolean>(useRuntimeConfig().public.isOAuthDisabled);
 const username = ref('');
 const password = ref('');
 const errorMessage = ref<string | null>(null);
+const rememberMe = ref<boolean>(false);
 
 const { fetch: fetchUserSession } = useUserSession();
 
@@ -14,6 +15,7 @@ const loginWithPassword = async () => {
             body: {
                 username: username.value,
                 password: password.value,
+                rememberMe: rememberMe.value,
             },
         });
 
@@ -98,6 +100,7 @@ const loginWithPassword = async () => {
                     type="text"
                     v-model="username"
                     placeholder="Username"
+                    autocomplete="username"
                     class="bg-obsidian/50 text-stone-gray border-stone-gray/20 focus:border-ember-glow h-10 rounded-lg border-2
                         px-4 transition-colors duration-200 focus:outline-none"
                 />
@@ -105,8 +108,16 @@ const loginWithPassword = async () => {
                     type="password"
                     v-model="password"
                     placeholder="Password"
+                    autocomplete="current-password"
                     class="bg-obsidian/50 text-stone-gray border-stone-gray/20 focus:border-ember-glow h-10 rounded-lg border-2
                         px-4 transition-colors duration-200 focus:outline-none"
+                />
+
+                <UiSettingsUtilsCheckbox
+                    label="Remember me"
+                    :state="rememberMe"
+                    :setState="(value) => (rememberMe = value)"
+                    :style="'dark'"
                 />
 
                 <!-- NEW: Error Message Display -->

--- a/ui/server/api/auth/login.post.ts
+++ b/ui/server/api/auth/login.post.ts
@@ -2,7 +2,7 @@ import { SyncUserResponse } from '@/types/user';
 
 export default defineEventHandler(async (event) => {
     const API_BASE_URL = useRuntimeConfig().apiInternalBaseUrl;
-    const { username, password } = await readBody(event);
+    const { username, password, rememberMe } = await readBody(event);
 
     if (!username || !password) {
         throw createError({
@@ -14,7 +14,7 @@ export default defineEventHandler(async (event) => {
     try {
         const apiUser = (await $fetch(`${API_BASE_URL}/auth/login`, {
             method: 'POST',
-            body: { username, password },
+            body: { username, password, rememberMe },
         })) as SyncUserResponse;
 
         if (!apiUser || !apiUser.user || !apiUser.token) {


### PR DESCRIPTION
This pull request introduces a "Remember Me" feature to the login flow, allowing users to stay signed in for an extended period. It involves changes to both backend and frontend code, including API adjustments, authentication logic, and UI updates. Additionally, it improves the login form's usability with proper autocomplete attributes and refines the checkbox component to support different visual styles.

<img width="300" height="718" alt="ShoT_2025-08-12-10-12-39_5120x1440" src="https://github.com/user-attachments/assets/ca0b4eaa-a97a-49f6-b7ce-41c3f07f7860" />


**Authentication and API changes:**
- Added a `rememberMe` boolean to the login payload and API endpoint, updating the backend to accept and validate this field. The JWT token expiration is now extended to 30 days if "Remember Me" is selected, otherwise defaults to 22 hours. [[1]](diffhunk://#diff-49d5ecceb7022d909515c7429382875900b0d0fa067096ee2772fb7d5ed0587eL5-R5) [[2]](diffhunk://#diff-49d5ecceb7022d909515c7429382875900b0d0fa067096ee2772fb7d5ed0587eR32-R55) [[3]](diffhunk://#diff-49d5ecceb7022d909515c7429382875900b0d0fa067096ee2772fb7d5ed0587eL57-R74) [[4]](diffhunk://#diff-631fdc9254b97d7123bd2028d18dab59c1d8b82ae94dacf847efc9162e006f60L15-R25) [[5]](diffhunk://#diff-631fdc9254b97d7123bd2028d18dab59c1d8b82ae94dacf847efc9162e006f60L42-R47) [[6]](diffhunk://#diff-76efcba57da58f8023b09c5fbfb03af6230aa1b6a047b6c16b99cf230a68f181L5-R5) [[7]](diffhunk://#diff-76efcba57da58f8023b09c5fbfb03af6230aa1b6a047b6c16b99cf230a68f181L17-R17)

**Frontend UI and UX improvements:**
- Added a "Remember me" checkbox to the login form, wired to the backend, and ensured the `username` and `password` fields have appropriate `autocomplete` attributes for better browser autofill support. [[1]](diffhunk://#diff-1166d4c455d691d458d488604001c79ffbc744f4007b17f4ee741bd61a0342e7R6) [[2]](diffhunk://#diff-1166d4c455d691d458d488604001c79ffbc744f4007b17f4ee741bd61a0342e7R18) [[3]](diffhunk://#diff-1166d4c455d691d458d488604001c79ffbc744f4007b17f4ee741bd61a0342e7R103-R122)
- Updated the `UiSettingsUtilsCheckbox` component to support "white" and "dark" styles, and applied the new style in the login form and settings section. [[1]](diffhunk://#diff-af7d4498e58e5a678de851c342412775db3ee371188ff53cf0ac47ca886ddd95R33) [[2]](diffhunk://#diff-c4a2e139724944b612d229fc97c7a271a5cd21c3cb6700b9ea89cb73521a9d8dR7-L38)