### PR TITLE
fix: ensure streaming session response in reset before starting new stream

### DIFF
--- a/ui/components/ui/chat/chatBox.vue
+++ b/ui/components/ui/chat/chatBox.vue
@@ -202,6 +202,8 @@ const generate = async () => {
     }
 
     streamingSession.value = retrieveCurrentSession(session.value.fromNodeId);
+    if (streamingSession.value) streamingSession.value.response = '';
+
     isStreaming.value = true;
     generationError.value = null;
     renderedMessageCount.value = 0;
@@ -259,6 +261,8 @@ const regenerate = async (index: number) => {
 
     removeAllMessagesFromIndex(index);
     goBackToBottom('auto');
+
+    await nextTick();
 
     updateNodeModel(session.value.fromNodeId, currentModel.value);
 


### PR DESCRIPTION
This pull request makes minor improvements to the chat box behavior in `chatBox.vue`, specifically related to message streaming and regeneration. The changes ensure a smoother user experience when generating or regenerating chat responses.

Chat streaming improvements:

* When starting a new streaming session, the response field of the current session is reset to an empty string to clear any previous content.

Chat regeneration improvements:

* During message regeneration, a call to `nextTick()` is added to ensure the UI updates correctly before proceeding with model updates and new message generation.