### PR TITLE
refactor: replace waitForSave with ensureGraphSaved for improved graph saving logic

### DIFF
--- a/ui/components/ui/chat/chatBox.vue
+++ b/ui/components/ui/chat/chatBox.vue
@@ -33,7 +33,7 @@ const {
     getSession,
     migrateSessionId,
 } = chatStore;
-const { saveGraph, waitForSave } = canvasSaveStore;
+const { ensureGraphSaved, saveGraph } = canvasSaveStore;
 const {
     setChatCallback,
     startStream,
@@ -370,7 +370,7 @@ watch(isStreaming, async (newValue) => {
     if (!newValue && session.value.messages[session.value.messages.length - 1].content[0].text) {
         // After a session ends, we need to refetch the chat
         // to get the chat messages of pre-agregation models
-        await waitForSave();
+        await ensureGraphSaved();
 
         await refreshChat(graphId.value, session.value.fromNodeId);
 

--- a/ui/components/ui/graph/node/parallelization.vue
+++ b/ui/components/ui/graph/node/parallelization.vue
@@ -16,10 +16,10 @@ const globalSettingsStore = useSettingsStore();
 
 // --- State from Stores ---
 const { currentModel } = storeToRefs(chatStore);
-const { blockSettings, isReady } = storeToRefs(globalSettingsStore);
+const { blockSettings } = storeToRefs(globalSettingsStore);
 
 // --- Actions/Methods from Stores ---
-const { saveGraph } = canvasSaveStore;
+const { ensureGraphSaved, saveGraph } = canvasSaveStore;
 const { startStream, setCanvasCallback, preStreamSession, removeChatCallback, cancelStream } =
     streamStore;
 const { loadAndOpenChat } = chatStore;
@@ -121,6 +121,8 @@ const sendPrompt = async () => {
     isStreaming.value = true;
     doneModels.value = 0;
     props.data.aggregator.reply = '';
+
+    await ensureGraphSaved();
 
     let jobs: Promise<StreamSession | undefined>[] = [];
 

--- a/ui/components/ui/graph/node/routing.vue
+++ b/ui/components/ui/graph/node/routing.vue
@@ -22,7 +22,7 @@ const { blockSettings, isReady, blockRoutingSettings } = storeToRefs(globalSetti
 // --- Actions/Methods from Stores ---
 const { loadAndOpenChat } = chatStore;
 const { startStream, setCanvasCallback, removeChatCallback, cancelStream } = streamStore;
-const { saveGraph } = canvasSaveStore;
+const { ensureGraphSaved, saveGraph } = canvasSaveStore;
 
 // --- Composables ---
 const { getBlockById } = useBlocks();
@@ -66,6 +66,8 @@ const sendPrompt = async () => {
     selectedRoute.value = null;
     isFetchingModel.value = true;
     isStreaming.value = true;
+
+    await ensureGraphSaved();
 
     const routingSession = await startStream(
         props.id,

--- a/ui/components/ui/graph/node/textToText.vue
+++ b/ui/components/ui/graph/node/textToText.vue
@@ -16,12 +16,12 @@ const globalSettingsStore = useSettingsStore();
 
 // --- State from Stores ---
 const { currentModel, openChatId } = storeToRefs(chatStore);
-const { blockSettings, isReady } = storeToRefs(globalSettingsStore);
+const { blockSettings } = storeToRefs(globalSettingsStore);
 
 // --- Actions/Methods from Stores ---
 const { loadAndOpenChat } = chatStore;
 const { startStream, setCanvasCallback, removeChatCallback, cancelStream } = streamStore;
-const { saveGraph } = canvasSaveStore;
+const { saveGraph, ensureGraphSaved } = canvasSaveStore;
 
 // --- Composables ---
 const { getBlockById } = useBlocks();
@@ -56,6 +56,8 @@ const addChunk = addChunkCallbackBuilder(
 
 const sendPrompt = async () => {
     if (!props.data) return;
+
+    await ensureGraphSaved();
 
     setCanvasCallback(props.id, NodeTypeEnum.TEXT_TO_TEXT, addChunk);
 


### PR DESCRIPTION
This pull request refactors how graph saving is handled across several UI components and the canvas save store. The main change is the introduction of a new `ensureGraphSaved` method, which replaces the previous `waitForSave` approach. This update ensures that graph save operations are properly awaited and avoids redundant or overlapping saves, improving reliability and consistency when triggering chat or node actions that depend on a saved graph state.

**Graph Saving Logic Improvements**
* Added a new `ensureGraphSaved` method to `canvasSaveStore`, which checks the current save status and triggers a save only when necessary, replacing the old `waitForSave` polling approach. The `saveGraph` method now tracks ongoing save operations with a promise to prevent duplicate saves. (`ui/stores/canvasSave.ts`) [[1]](diffhunk://#diff-88f6ae9eb128aff1b78d2518c1eb8bc4cc833dab8b10fe4b9410c485680a1e1bL8-R8) [[2]](diffhunk://#diff-88f6ae9eb128aff1b78d2518c1eb8bc4cc833dab8b10fe4b9410c485680a1e1bL33-L62) [[3]](diffhunk://#diff-88f6ae9eb128aff1b78d2518c1eb8bc4cc833dab8b10fe4b9410c485680a1e1bL73-R80)

**UI Component Updates for Graph Save**
* Updated chat and node components (`chatBox.vue`, `parallelization.vue`, `routing.vue`, `textToText.vue`) to use `ensureGraphSaved` instead of `waitForSave` before performing actions that require the graph to be saved, such as sending prompts or refreshing chat. (`ui/components/ui/chat/chatBox.vue`, `ui/components/ui/graph/node/parallelization.vue`, `ui/components/ui/graph/node/routing.vue`, `ui/components/ui/graph/node/textToText.vue`) [[1]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8L36-R36) [[2]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8L373-R373) [[3]](diffhunk://#diff-a3e445cff34b6157b69fb569da0b6c4920a61ed61cd136c6a4ba20d05b232235L19-R22) [[4]](diffhunk://#diff-a3e445cff34b6157b69fb569da0b6c4920a61ed61cd136c6a4ba20d05b232235R125-R126) [[5]](diffhunk://#diff-dcb4de96e7f18e5a046d868da7c50867adb1a96d59c288f1da4d6ac3e45e9ef2L25-R25) [[6]](diffhunk://#diff-dcb4de96e7f18e5a046d868da7c50867adb1a96d59c288f1da4d6ac3e45e9ef2R70-R71) [[7]](diffhunk://#diff-88ae03c2f8b05f93ecb2775752cc3cf9439505331a2a15adbee8454b2c439efbL19-R24) [[8]](diffhunk://#diff-88ae03c2f8b05f93ecb2775752cc3cf9439505331a2a15adbee8454b2c439efbR60-R61)

**Store Interface Clean-up**
* Removed unused or redundant properties and methods (`isAlreadySaving`, `waitForSave`) from the canvas save store, simplifying the store interface and reducing confusion for future maintenance. (`ui/stores/canvasSave.ts`) [[1]](diffhunk://#diff-88f6ae9eb128aff1b78d2518c1eb8bc4cc833dab8b10fe4b9410c485680a1e1bL8-R8) [[2]](diffhunk://#diff-88f6ae9eb128aff1b78d2518c1eb8bc4cc833dab8b10fe4b9410c485680a1e1bL33-L62) [[3]](diffhunk://#diff-88f6ae9eb128aff1b78d2518c1eb8bc4cc833dab8b10fe4b9410c485680a1e1bL73-R80)

**State Usage Simplification**
* Cleaned up state references in node components by removing unused `isReady` references from the settings store, focusing only on the necessary state for graph saving and node actions. (`ui/components/ui/graph/node/parallelization.vue`, `ui/components/ui/graph/node/routing.vue`, `ui/components/ui/graph/node/textToText.vue`) [[1]](diffhunk://#diff-a3e445cff34b6157b69fb569da0b6c4920a61ed61cd136c6a4ba20d05b232235L19-R22) [[2]](diffhunk://#diff-dcb4de96e7f18e5a046d868da7c50867adb1a96d59c288f1da4d6ac3e45e9ef2L25-R25) [[3]](diffhunk://#diff-88ae03c2f8b05f93ecb2775752cc3cf9439505331a2a15adbee8454b2c439efbL19-R24)