### PR TITLE
feat: Add node type selection in chat view

### DIFF
--- a/api/app/const/settings.py
+++ b/api/app/const/settings.py
@@ -15,6 +15,7 @@ from models.usersDTO import (
     RouteGroup,
     Route,
 )
+from models.message import NodeTypeEnum
 from const.prompts import GLOBAL_SYSTEM_PROMPT, PARALLELIZATION_AGGREGATOR_PROMPT
 
 DEFAULT_SETTINGS = SettingsDTO(
@@ -22,6 +23,7 @@ DEFAULT_SETTINGS = SettingsDTO(
         openChatViewOnNewCanvas=True,
         alwaysThinkingDisclosures=False,
         includeThinkingInContext=False,
+        defaultNodeType=NodeTypeEnum.TEXT_TO_TEXT,
     ),
     account=AccountSettings(
         openRouterApiKey=None,
@@ -59,9 +61,7 @@ DEFAULT_SETTINGS = SettingsDTO(
     ),
     blockParallelization=BlockParallelizationSettings(
         models=[
-            BlockParallelizationModelSettings(
-                model="google/gemini-2.5-flash"
-            ),
+            BlockParallelizationModelSettings(model="google/gemini-2.5-flash"),
             BlockParallelizationModelSettings(model="openai/gpt-4o-mini"),
         ],
         aggregator=BlockParallelizationAggregatorSettings(

--- a/api/app/models/usersDTO.py
+++ b/api/app/models/usersDTO.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from enum import Enum
 
 from models.chatDTO import EffortEnum
+from models.message import NodeTypeEnum
 
 
 class ModelsDropdownSortBy(str, Enum):
@@ -16,14 +17,17 @@ class GeneralSettings(BaseModel):
     openChatViewOnNewCanvas: bool
     alwaysThinkingDisclosures: bool = False
     includeThinkingInContext: bool = False
+    defaultNodeType: NodeTypeEnum = NodeTypeEnum.TEXT_TO_TEXT
 
 
 class AccountSettings(BaseModel):
     openRouterApiKey: Optional[str] = None
 
+
 class AppearanceSettings(BaseModel):
     theme: str = "standard"
     accentColor: str = "#eb5e28"
+
 
 class ModelsSettings(BaseModel):
     defaultModel: str

--- a/ui/components/ui/chat/chatBox.vue
+++ b/ui/components/ui/chat/chatBox.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
-import { DEFAULT_NODE_ID } from '@/constants';
-import type { MessageContent } from '@/types/graph';
-import type { File } from '@/types/files';
 import { NodeTypeEnum, MessageRoleEnum, MessageContentTypeEnum } from '@/types/enums';
+import type { MessageContent, BlockDefinition } from '@/types/graph';
+import { DEFAULT_NODE_ID } from '@/constants';
+import type { File } from '@/types/files';
 
 const emit = defineEmits(['update:canvasName']);
 
@@ -36,9 +36,9 @@ const {
 const { ensureGraphSaved, saveGraph } = canvasSaveStore;
 const {
     setChatCallback,
-    startStream,
     isNodeStreaming,
     retrieveCurrentSession,
+    ensureSession,
     removeChatCallback,
     cancelStream,
 } = streamStore;
@@ -54,6 +54,7 @@ const {
     updatePromptNodeText,
     addTextToTextInputNodes,
     addFilesPromptInputNodes,
+    createNodeFromVariant,
     isCanvasEmpty,
     waitForRender,
 } = useGraphChat();
@@ -68,6 +69,7 @@ const {
     isLockedToBottom,
     chatContainer,
 } = useChatScroll();
+const nodeRegistry = useNodeRegistry();
 const { error } = useToast();
 
 // --- Local State ---
@@ -78,6 +80,7 @@ const streamingSession = ref<StreamSession | null>();
 const generationError = ref<string | null>(null);
 const session = shallowRef(getSession(openChatId.value || ''));
 const currentEditModeIdx = ref<number | null>(null);
+const selectedNodeType = ref<BlockDefinition | null>(null);
 
 // --- Core Logic Functions ---
 const handleMessageRendered = () => {
@@ -113,7 +116,7 @@ const generateNew = async (
     message: string | null = null,
     files: File[] | null = null,
 ) => {
-    let textToTextNodeId: string | undefined;
+    let newNodeId: string | undefined;
 
     // When forcedTextToTextNodeId is provided, it means the message is already
     // in the node and we want to use it as the input for the generation
@@ -124,7 +127,7 @@ const generateNew = async (
             return;
         }
 
-        textToTextNodeId = addTextToTextInputNodes(
+        newNodeId = addTextToTextInputNodes(
             getTextFromMessage(lastestMessage),
             openChatId.value,
             forcedTextToTextNodeId,
@@ -140,15 +143,15 @@ const generateNew = async (
     // If no forcedTextToTextNodeId is provided, we create a new text-to-text node
     // from the message provided
     else if (message) {
-        textToTextNodeId = addTextToTextInputNodes(
+        newNodeId = createNodeFromVariant(
+            selectedNodeType.value?.id as string,
+            openChatId.value as string,
             message,
-            openChatId.value,
-            forcedTextToTextNodeId,
         );
 
         let filesContent: MessageContent[] = [];
         if (files && files.length > 0) {
-            addFilesPromptInputNodes(files, textToTextNodeId || DEFAULT_NODE_ID);
+            addFilesPromptInputNodes(files, newNodeId || DEFAULT_NODE_ID);
             filesContent = files.map((file) => fileToMessageContent(file));
         }
 
@@ -162,25 +165,25 @@ const generateNew = async (
                 ...filesContent,
             ],
             model: currentModel.value,
-            node_id: textToTextNodeId || '',
+            node_id: newNodeId || '',
             type: NodeTypeEnum.TEXT_TO_TEXT,
             data: null,
             usageData: null,
         });
     }
 
-    if (!textToTextNodeId) {
+    if (!newNodeId) {
         console.warn('No text-to-text node ID found, skipping message send.');
         return;
     }
 
-    session.value.fromNodeId = textToTextNodeId;
+    session.value.fromNodeId = newNodeId;
 
     // When creating a new text-to-text node, we need to change the current
     // node ID to the new one, so we can stream the response to the new node
-    if (openChatId.value && openChatId.value !== textToTextNodeId) {
-        migrateSessionId(openChatId.value, textToTextNodeId);
-        openChatId.value = textToTextNodeId;
+    if (openChatId.value && openChatId.value !== newNodeId) {
+        migrateSessionId(openChatId.value, newNodeId);
+        openChatId.value = newNodeId;
     }
 
     await waitForRender();
@@ -201,7 +204,10 @@ const generate = async () => {
         return;
     }
 
-    streamingSession.value = retrieveCurrentSession(session.value.fromNodeId);
+    streamingSession.value = ensureSession(
+        session.value.fromNodeId,
+        selectedNodeType.value?.nodeType || NodeTypeEnum.TEXT_TO_TEXT,
+    );
     if (streamingSession.value) streamingSession.value.response = '';
 
     isStreaming.value = true;
@@ -221,34 +227,12 @@ const generate = async () => {
 
     await saveGraph();
 
-    try {
-        setChatCallback(session.value.fromNodeId, NodeTypeEnum.TEXT_TO_TEXT, addChunk);
+    setChatCallback(session.value.fromNodeId, NodeTypeEnum.TEXT_TO_TEXT, addChunk);
 
-        const streamSession = await startStream(
-            session.value.fromNodeId,
-            NodeTypeEnum.TEXT_TO_TEXT,
-            {
-                graph_id: graphId.value,
-                node_id: session.value.fromNodeId,
-                model: currentModel.value,
-            },
-            props.isGraphNameDefault,
-        );
+    await nodeRegistry.execute(session.value.fromNodeId);
 
-        if (props.isGraphNameDefault) {
-            emit('update:canvasName', streamSession?.titleResponse);
-        }
-    } catch (err) {
-        console.error('Error during chat generation or saving:', error);
-        error('An error occurred while generating the response. Please try again.', {
-            title: 'Generation Error',
-        });
-        generationError.value =
-            'An error occurred while generating the response. Please try again.';
-    } finally {
-        isStreaming.value = false;
-        triggerScroll();
-    }
+    isStreaming.value = false;
+    triggerScroll();
 };
 
 const regenerate = async (index: number) => {
@@ -529,6 +513,11 @@ watch(
                 "
                 @goBackToBottom="goBackToBottom"
                 @cancelStream="handleCancelStream"
+                @select-node-type="
+                    (newType) => {
+                        selectedNodeType = newType;
+                    }
+                "
                 class="!max-h-[600px]"
             ></UiChatTextInput>
         </div>

--- a/ui/components/ui/chat/chatBox.vue
+++ b/ui/components/ui/chat/chatBox.vue
@@ -112,31 +112,32 @@ const addChunk = addChunkCallbackBuilder(
 );
 
 const generateNew = async (
-    forcedTextToTextNodeId: string | null = null,
+    forcedNodeId: string | null = null,
     message: string | null = null,
     files: File[] | null = null,
 ) => {
     let newNodeId: string | undefined;
 
-    // When forcedTextToTextNodeId is provided, it means the message is already
+    // When forcedNodeId is provided, it means the message is already
     // in the node and we want to use it as the input for the generation
-    if (forcedTextToTextNodeId) {
+    if (forcedNodeId) {
         const lastestMessage = getLatestMessage();
         if (!lastestMessage?.content) {
             console.warn('No message found, skipping generation.');
             return;
         }
 
-        newNodeId = addTextToTextInputNodes(
+        newNodeId = createNodeFromVariant(
+            lastestMessage.type,
+            openChatId.value as string,
             getTextFromMessage(lastestMessage),
-            openChatId.value,
-            forcedTextToTextNodeId,
+            forcedNodeId,
         );
 
         if (lastestMessage.data.files && lastestMessage.data.files.length > 0) {
             addFilesPromptInputNodes(
                 lastestMessage.data.files || [],
-                forcedTextToTextNodeId || DEFAULT_NODE_ID,
+                forcedNodeId || DEFAULT_NODE_ID,
             );
         }
     }
@@ -144,7 +145,7 @@ const generateNew = async (
     // from the message provided
     else if (message) {
         newNodeId = createNodeFromVariant(
-            selectedNodeType.value?.id as string,
+            selectedNodeType.value?.nodeType as string,
             openChatId.value as string,
             message,
         );

--- a/ui/components/ui/chat/messageFooter.vue
+++ b/ui/components/ui/chat/messageFooter.vue
@@ -20,7 +20,7 @@ const { getTextFromMessage } = useMessage();
 const open = ref(false);
 const usageDataTotal = computed(() => {
     // For parallelization, we combine usage data from all models
-    if (props.message.type === NodeTypeEnum.PARALLELIZATION) {
+    if (props.message.type === NodeTypeEnum.PARALLELIZATION && props.message.data) {
         const modelsUsageData = props.message.data.map((data: any) => data.usageData);
         const aggregatorUsageData = props.message.usageData;
         const allUsageData = [...modelsUsageData, aggregatorUsageData];
@@ -66,7 +66,7 @@ const usageDataTotal = computed(() => {
                 {{ message.model }}
             </div>
             <!-- Usage Data Popover -->
-            <HeadlessPopover class="relative">
+            <HeadlessPopover class="relative" v-if="usageDataTotal?.prompt_tokens">
                 <HeadlessPopoverButton
                     as="div"
                     class="dark:border-anthracite border-stone-gray dark:text-stone-gray/50 text-stone-gray cursor-pointer

--- a/ui/components/ui/chat/textInput.vue
+++ b/ui/components/ui/chat/textInput.vue
@@ -2,7 +2,13 @@
 import type { File } from '@/types/files';
 import { NodeTypeEnum } from '@/types/enums';
 
-const emit = defineEmits(['triggerScroll', 'generate', 'goBackToBottom', 'cancelStream']);
+const emit = defineEmits([
+    'triggerScroll',
+    'generate',
+    'goBackToBottom',
+    'cancelStream',
+    'selectNodeType',
+]);
 
 defineProps<{
     isLockedToBottom: boolean;
@@ -227,26 +233,18 @@ const addFiles = async (newFiles: globalThis.FileList) => {
                 autofocus
             ></div>
 
-            <button
-                v-if="!isStreaming"
-                :disabled="isEmpty || isUploading"
-                @click="sendMessage"
-                class="dark:bg-stone-gray dark:hover:bg-stone-gray/80 bg-soft-silk hover:bg-soft-silk/80 flex h-12 w-12
-                    items-center justify-center rounded-2xl shadow transition duration-200 ease-in-out
-                    hover:cursor-pointer disabled:opacity-50 disabled:hover:cursor-not-allowed"
-            >
-                <UiIcon name="IconamoonSendFill" class="text-obsidian h-6 w-6" />
-            </button>
-            <button
-                v-else
-                :disabled="nodeType !== NodeTypeEnum.TEXT_TO_TEXT"
-                @click="emit('cancelStream')"
-                class="dark:bg-stone-gray dark:hover:bg-stone-gray/80 bg-soft-silk hover:bg-soft-silk/80 flex h-12 w-12
-                    items-center justify-center rounded-2xl shadow transition duration-200 ease-in-out
-                    hover:cursor-pointer disabled:opacity-50 disabled:hover:cursor-not-allowed"
-            >
-                <UiIcon name="MaterialSymbolsStopRounded" class="h-6 w-6" />
-            </button>
+            <UiChatUtilsSendChatButton
+                :is-streaming="isStreaming"
+                :is-empty="isEmpty"
+                :is-uploading="isUploading"
+                @send="sendMessage"
+                @cancel-stream="emit('cancelStream')"
+                @select-node-type="
+                    (newType) => {
+                        emit('selectNodeType', newType);
+                    }
+                "
+            ></UiChatUtilsSendChatButton>
         </div>
     </div>
 </template>

--- a/ui/components/ui/chat/utils/sendChatButton.vue
+++ b/ui/components/ui/chat/utils/sendChatButton.vue
@@ -93,7 +93,7 @@ watch(
                     },
                 }"
                 :transition="{ type: 'spring', stiffness: 400, damping: 25 }"
-                class="bg-soft-silk/80 absolute right-0 bottom-14 z-10 mt-2 w-48 rounded-lg shadow-lg backdrop-blur"
+                class="bg-soft-silk/80 absolute right-0 bottom-14 z-50 mt-2 w-48 rounded-lg shadow-lg backdrop-blur"
             >
                 <ul class="py-1 pl-1">
                     <template
@@ -133,6 +133,12 @@ watch(
                 </ul>
             </motion.div>
         </AnimatePresence>
+
+        <span
+            v-if="selectMenuOpen"
+            class="fixed top-0 right-0 z-40 h-full w-full"
+            @click="selectMenuOpen = false"
+        ></span>
     </div>
 </template>
 

--- a/ui/components/ui/chat/utils/sendChatButton.vue
+++ b/ui/components/ui/chat/utils/sendChatButton.vue
@@ -1,0 +1,139 @@
+<script lang="ts" setup>
+import type { BlockDefinition } from '@/types/graph';
+import { motion } from 'motion-v';
+
+const emit = defineEmits(['send', 'cancelStream', 'selectNodeType']);
+
+defineProps<{
+    isStreaming: boolean;
+    isEmpty: boolean;
+    isUploading: boolean;
+}>();
+
+// --- Composables ---
+const { getBlockById } = useBlocks();
+
+// --- Local state ---
+const selectMenuOpen = ref(false);
+const selectedNodeType = ref<BlockDefinition>(
+    getBlockById('primary-model-text-to-text') as BlockDefinition,
+);
+
+watch(
+    selectedNodeType,
+    (newType) => {
+        emit('selectNodeType', newType);
+    },
+    { immediate: true },
+);
+</script>
+
+<template>
+    <div class="relative flex gap-1">
+        <button
+            v-if="!isStreaming"
+            :disabled="isEmpty || isUploading"
+            title="Send message"
+            @click="emit('send')"
+            class="dark:bg-stone-gray dark:hover:bg-stone-gray/80 bg-soft-silk hover:bg-soft-silk/80 flex h-12 w-12
+                items-center justify-center rounded-l-2xl rounded-r-sm shadow transition duration-200 ease-in-out
+                hover:cursor-pointer disabled:opacity-50 disabled:hover:cursor-not-allowed"
+        >
+            <UiIcon name="IconamoonSendFill" class="text-obsidian h-6 w-6" />
+        </button>
+        <button
+            v-else
+            title="Cancel streaming"
+            @click="emit('cancelStream')"
+            class="dark:bg-stone-gray dark:hover:bg-stone-gray/80 bg-soft-silk hover:bg-soft-silk/80 flex h-12 w-12
+                items-center justify-center rounded-l-2xl rounded-r-sm shadow transition duration-200 ease-in-out
+                hover:cursor-pointer disabled:opacity-50 disabled:hover:cursor-not-allowed"
+        >
+            <UiIcon name="MaterialSymbolsStopRounded" class="h-6 w-6" />
+        </button>
+
+        <button
+            class="relative flex h-12 w-4 items-center justify-center rounded-l-sm rounded-r-2xl shadow transition
+                duration-200 ease-in-out hover:cursor-pointer disabled:opacity-50 disabled:hover:cursor-not-allowed"
+            :style="{
+                backgroundColor: selectedNodeType.color,
+            }"
+            :class="{
+                'hover:brightness-80': !selectMenuOpen,
+            }"
+            title="Select node type"
+            @click="selectMenuOpen = !selectMenuOpen"
+        ></button>
+
+        <AnimatePresence>
+            <motion.div
+                v-if="selectMenuOpen"
+                key="chat-select-node-menu"
+                :initial="{
+                    opacity: 0,
+                    scale: 0.3,
+                    transformOrigin: 'bottom right',
+                }"
+                :animate="{
+                    opacity: 1,
+                    scale: 1,
+                    transition: {
+                        type: 'spring',
+                        stiffness: 300,
+                        damping: 25,
+                        mass: 0.8,
+                    },
+                }"
+                :exit="{
+                    opacity: 0,
+                    scale: 0.3,
+                    transition: {
+                        duration: 0.15,
+                        ease: 'easeInOut',
+                    },
+                }"
+                :transition="{ type: 'spring', stiffness: 400, damping: 25 }"
+                class="bg-soft-silk/80 absolute right-0 bottom-14 z-10 mt-2 w-48 rounded-lg shadow-lg backdrop-blur"
+            >
+                <ul class="py-1 pl-1">
+                    <template
+                        v-for="bloc in [
+                            getBlockById('primary-model-text-to-text'),
+                            getBlockById('primary-model-routing'),
+                            getBlockById('primary-model-parallelization'),
+                        ]"
+                    >
+                        <li
+                            v-if="bloc"
+                            class="text-obsidian hover:bg-anthracite/20 group relative flex cursor-pointer gap-2 rounded px-3 py-2
+                                text-sm transition-colors duration-200"
+                            @click="selectedNodeType = bloc"
+                        >
+                            <UiIcon
+                                :name="bloc.icon"
+                                class="dark:text-obsidian text-soft-silk h-4 w-4 self-center"
+                            />
+                            <p class="dark:text-obsidian text-soft-silk self-center">
+                                {{ bloc.name }}
+                            </p>
+
+                            <span
+                                class="absolute top-1/2 right-0 flex h-6 w-2 -translate-y-1/2 items-center justify-center rounded-l-lg
+                                    text-transparent transition-all duration-200 group-hover:w-3"
+                                :class="{
+                                    '!text-soft-silk !w-5':
+                                        selectedNodeType.nodeType === bloc.nodeType,
+                                }"
+                                :style="'background-color: ' + bloc.color"
+                            >
+                                ✓
+                            </span>
+                        </li>
+                    </template>
+                </ul>
+            </motion.div>
+        </AnimatePresence>
+    </div>
+</template>
+
+<style scoped></style>

--- a/ui/components/ui/settings/section/general.vue
+++ b/ui/components/ui/settings/section/general.vue
@@ -1,9 +1,21 @@
 <script lang="ts" setup>
+import { NodeTypeEnum } from '@/types/enums';
+
 // --- Stores ---
 const globalSettingsStore = useSettingsStore();
 
 // --- State from Stores (Reactive Refs) ---
 const { generalSettings } = storeToRefs(globalSettingsStore);
+
+const nodeTypeOptions = [
+    { id: NodeTypeEnum.TEXT_TO_TEXT, name: 'Text to Text', icon: 'FluentCodeText16Filled' },
+    { id: NodeTypeEnum.ROUTING, name: 'Routing', icon: 'MaterialSymbolsAltRouteRounded' },
+    {
+        id: NodeTypeEnum.PARALLELIZATION,
+        name: 'Parallelization',
+        icon: 'HugeiconsDistributeHorizontalCenter',
+    },
+];
 </script>
 
 <template>
@@ -64,6 +76,23 @@ const { generalSettings } = storeToRefs(globalSettingsStore);
             "
             id="general-include-thinking-in-context"
         ></UiSettingsUtilsSwitch>
+
+        <label class="flex gap-2" for="general-default-node-type">
+            <h3 class="text-stone-gray font-bold">Default Node Type</h3>
+            <UiSettingsInfobubble>
+                The default node type to use when creating new nodes in chat view.
+            </UiSettingsInfobubble>
+        </label>
+        <UiSettingsUtilsSelect
+            :item-list="nodeTypeOptions"
+            :selected="generalSettings.defaultNodeType"
+            @update:item-value="
+                (value: NodeTypeEnum) => {
+                    generalSettings.defaultNodeType = value;
+                }
+            "
+            class="w-[20rem]"
+        ></UiSettingsUtilsSelect>
     </div>
 </template>
 

--- a/ui/components/ui/settings/utils/select.vue
+++ b/ui/components/ui/settings/utils/select.vue
@@ -37,7 +37,7 @@ watch(
             >
                 <div class="flex items-center">
                     <span v-if="selected?.icon" class="ml-3 flex flex-shrink-0 items-center">
-                        <UiIcon :name="'models/' + selected.icon" class="h-4 w-4" />
+                        <UiIcon :name="selected.icon" class="h-4 w-4" />
                     </span>
 
                     <HeadlessComboboxInput

--- a/ui/composables/useBlocks.ts
+++ b/ui/composables/useBlocks.ts
@@ -119,6 +119,15 @@ export function useBlocks() {
         return block ? structuredClone(block) : undefined;
     };
 
+    const getBlockByNodeType = (nodeType: NodeTypeEnum): BlockDefinition | undefined => {
+        for (const block of blockMap!.value.values()) {
+            if (block.nodeType === nodeType) {
+                return structuredClone(block);
+            }
+        }
+        return undefined;
+    };
+
     const getBlockDefinitions = (): BlockCategories => {
         return structuredClone(blockDefinitions!.value);
     };
@@ -128,6 +137,7 @@ export function useBlocks() {
         blockMap: blockMap!,
 
         getBlockById,
+        getBlockByNodeType,
         getBlockDefinitions,
     };
 }

--- a/ui/composables/useGraphActions.ts
+++ b/ui/composables/useGraphActions.ts
@@ -12,6 +12,8 @@ export const useGraphActions = () => {
         positionFrom: { x: number; y: number },
         positionOffset: { x: number; y: number } = { x: 0, y: 0 },
         center: boolean = false,
+        data: Record<string, any> = {},
+        forcedId: string | null = null
     ) => {
         const { addNodes } = useVueFlow('main-graph-' + graphId);
 
@@ -30,14 +32,14 @@ export const useGraphActions = () => {
         }
 
         const newNode: NodeWithDimensions = {
-            id: generateId(),
+            id: forcedId || generateId(),
             type: blockData.nodeType,
             position: {
                 x: positionFrom.x + positionOffset.x,
                 y: positionFrom.y + positionOffset.y,
             },
             label: blockData.name,
-            data: { ...blockData.defaultData },
+            data: { ...blockData.defaultData, ...data },
         };
 
         if (blockData?.forcedInitialDimensions) {

--- a/ui/composables/useGraphChat.ts
+++ b/ui/composables/useGraphChat.ts
@@ -1,10 +1,7 @@
 import { useVueFlow } from '@vue-flow/core';
-import type { Node, Edge } from '@vue-flow/core';
 
 import { DEFAULT_NODE_ID } from '@/constants';
-import { NodeTypeEnum } from '@/types/enums';
 import type { File } from '@/types/files';
-import type { DataFilePrompt, NodeWithDimensions } from '@/types/graph';
 
 export const useGraphChat = () => {
     const route = useRoute();
@@ -12,8 +9,8 @@ export const useGraphChat = () => {
 
     const chatStore = useChatStore();
     const settingsStore = useSettingsStore();
-    const { getBlockById } = useBlocks();
     const { error } = useToast();
+    const { placeBlock, placeEdge } = useGraphActions();
 
     const { currentModel } = storeToRefs(chatStore);
     const { blockParallelizationSettings } = storeToRefs(settingsStore);
@@ -33,10 +30,9 @@ export const useGraphChat = () => {
     };
 
     const addNodeFromNodeId = (input: string, fromNodeId: string) => {
-        const { findNode, addEdges, addNodes } = useVueFlow('main-graph-' + graphId.value);
+        const { findNode } = useVueFlow('main-graph-' + graphId.value);
 
         const inputNode = findNode(fromNodeId);
-
         if (!inputNode) {
             console.error(`Cannot add nodes: Input node with ID ${fromNodeId} not found.`);
             error(`Failed to add nodes: Input node with ID ${fromNodeId} not found.`, {
@@ -45,114 +41,99 @@ export const useGraphChat = () => {
             return;
         }
 
-        const verticalDistance = 350;
-        const horizontalDistance = 200;
-        const verticalOffsetForPrompt = 25;
-
         const inputNodeHeight = getNodeHeight(inputNode.id);
         const inputNodeBaseX = inputNode.position?.x ?? 0;
         const inputNodeBaseY = inputNode.position?.y ?? 0;
 
-        const textToTextNodeId = generateId();
-        const promptNodeId = generateId();
-
-        const newTextToTextNode: Node = {
-            id: textToTextNodeId,
-            type: NodeTypeEnum.TEXT_TO_TEXT,
-            position: {
+        const newTextToTextNode = placeBlock(
+            graphId.value,
+            'primary-model-text-to-text',
+            {
                 x: inputNodeBaseX,
-                y: inputNodeBaseY + inputNodeHeight + verticalDistance,
+                y: inputNodeBaseY,
             },
-            data: {
+            { x: 0, y: inputNodeHeight + 350 },
+            false,
+            {
                 model: currentModel.value,
-                reply: '',
             },
-        };
+        );
 
-        const newPromptNode: Node = {
-            id: promptNodeId,
-            type: NodeTypeEnum.PROMPT,
-            position: {
-                x: inputNodeBaseX - horizontalDistance,
-                y: inputNodeBaseY + inputNodeHeight + verticalOffsetForPrompt,
+        const newPromptNode = placeBlock(
+            graphId.value,
+            'primary-prompt-text',
+            {
+                x: inputNodeBaseX,
+                y: inputNodeBaseY,
             },
-            data: {
+            { x: -200, y: inputNodeHeight + 25 },
+            false,
+            {
                 prompt: input,
             },
-        };
+        );
 
-        const edge1: Edge = {
-            id: `e-${inputNode.id}-${textToTextNodeId}`,
-            source: inputNode.id,
-            target: textToTextNodeId,
-            targetHandle: 'context_' + textToTextNodeId,
-            type: 'custom',
-        };
-        const edge2: Edge = {
-            id: `e-${promptNodeId}-${textToTextNodeId}`,
-            source: promptNodeId,
-            target: textToTextNodeId,
-            targetHandle: 'prompt_' + textToTextNodeId,
-            type: 'custom',
-        };
-
-        addNodes([newTextToTextNode, newPromptNode]);
-        addEdges([edge1, edge2]);
+        placeEdge(
+            graphId.value,
+            inputNode.id,
+            newTextToTextNode?.id,
+            null,
+            'context_' + newTextToTextNode?.id,
+        );
+        placeEdge(
+            graphId.value,
+            newPromptNode?.id,
+            newTextToTextNode?.id,
+            null,
+            'prompt_' + newTextToTextNode?.id,
+        );
 
         setTimeout(() => {
-            resolveOverlaps(textToTextNodeId, [promptNodeId]);
+            resolveOverlaps(newTextToTextNode?.id, [newPromptNode?.id]);
         }, 1);
 
-        return textToTextNodeId;
+        return newTextToTextNode?.id;
     };
 
     const addNodeFromEmptyGraph = (input: string, forcedTextToTextNodeId: string | null) => {
-        const { addEdges, addNodes } = useVueFlow('main-graph-' + graphId.value);
-
-        const verticalDistance = 350;
-        const horizontalDistance = 200;
-        const verticalOffsetForPrompt = 25;
-
-        const textToTextNodeId = forcedTextToTextNodeId || generateId();
-        const promptNodeId = generateId();
-
-        const newTextToTextNode: Node = {
-            id: textToTextNodeId,
-            type: NodeTypeEnum.TEXT_TO_TEXT,
-            position: {
+        const newTextToTextNode = placeBlock(
+            graphId.value,
+            'primary-model-text-to-text',
+            {
                 x: 0,
-                y: verticalDistance,
+                y: 350,
             },
-            data: {
+            { x: 0, y: 0 },
+            false,
+            {
                 model: currentModel.value,
-                reply: '',
             },
-        };
+            forcedTextToTextNodeId,
+        );
 
-        const newPromptNode: Node = {
-            id: promptNodeId,
-            type: NodeTypeEnum.PROMPT,
-            position: {
-                x: -horizontalDistance,
-                y: verticalOffsetForPrompt,
+        const newPromptNode = placeBlock(
+            graphId.value,
+            'primary-prompt-text',
+            {
+                x: -200,
+                y: 25,
             },
-            data: {
+            { x: 0, y: 0 },
+            false,
+            {
                 prompt: input,
             },
-        };
+        );
 
-        const edge1: Edge = {
-            id: `e-${promptNodeId}-${textToTextNodeId}`,
-            source: promptNodeId,
-            target: textToTextNodeId,
-            targetHandle: 'prompt_' + textToTextNodeId,
-            type: 'custom',
-        };
+        placeEdge(
+            graphId.value,
+            newPromptNode?.id,
+            newTextToTextNode?.id,
+            null,
+            'prompt_' + newTextToTextNode?.id,
+        );
 
-        addNodes([newTextToTextNode, newPromptNode]);
-        addEdges([edge1]);
-
-        return textToTextNodeId;
+        return newTextToTextNode?.id;
     };
 
     const addTextToTextInputNodes = (
@@ -168,7 +149,7 @@ export const useGraphChat = () => {
     };
 
     const addFilesPromptInputNodes = (files: File[], textToTextNodeId: string) => {
-        const { findNode, addEdges, addNodes } = useVueFlow('main-graph-' + graphId.value);
+        const { findNode } = useVueFlow('main-graph-' + graphId.value);
 
         const textToTextNode = findNode(textToTextNodeId);
         if (!textToTextNode) {
@@ -182,43 +163,33 @@ export const useGraphChat = () => {
             return;
         }
 
-        const horizontalDistance = 450;
-        const textToTextNodeY = textToTextNode.position?.y ?? 0;
-
-        const filePromptNodeId = generateId();
-        const fileNodeDefinition = getBlockById('primary-prompt-file');
-
-        const newFilePromptNode: NodeWithDimensions = {
-            id: filePromptNodeId,
-            type: NodeTypeEnum.FILE_PROMPT,
-            position: {
-                x: -horizontalDistance,
-                y: textToTextNodeY,
+        const newBlock = placeBlock(
+            graphId.value,
+            'primary-prompt-file',
+            {
+                x: -450,
+                y: textToTextNode.position?.y ?? 0,
             },
-            data: { files: files } as DataFilePrompt,
-        };
+            { x: 0, y: 0 },
+            false,
+            {
+                files: files,
+            },
+        );
 
-        if (fileNodeDefinition?.forcedInitialDimensions) {
-            newFilePromptNode.width = fileNodeDefinition.minSize.width;
-            newFilePromptNode.height = fileNodeDefinition.minSize.height;
-        }
+        placeEdge(
+            graphId.value,
+            newBlock?.id,
+            textToTextNodeId,
+            null,
+            'attachment_' + textToTextNodeId,
+        );
 
-        const edge1: Edge = {
-            id: `e-${filePromptNodeId}-${textToTextNodeId}`,
-            source: filePromptNodeId,
-            target: textToTextNodeId,
-            targetHandle: 'attachment_' + textToTextNodeId,
-            type: 'custom',
-        };
-
-        addNodes([newFilePromptNode]);
-        addEdges([edge1]);
-
-        return filePromptNodeId;
+        return newBlock?.id;
     };
 
     const addParallelizationInputNode = (input: string, fromNodeId: string | null) => {
-        const { findNode, addEdges, addNodes } = useVueFlow('main-graph-' + graphId.value);
+        const { findNode } = useVueFlow('main-graph-' + graphId.value);
 
         const inputNode = findNode(fromNodeId);
 
@@ -235,25 +206,20 @@ export const useGraphChat = () => {
             return;
         }
 
-        const verticalDistance = 350;
-        const horizontalDistance = 200;
-        const verticalOffsetForPrompt = 25;
-
         const inputNodeHeight = getNodeHeight(inputNode.id);
         const inputNodeBaseX = inputNode.position?.x ?? 0;
         const inputNodeBaseY = inputNode.position?.y ?? 0;
 
-        const parallelizationNodeId = generateId();
-        const promptNodeId = generateId();
-
-        const newParallelizationNode: Node = {
-            id: parallelizationNodeId,
-            type: NodeTypeEnum.PARALLELIZATION,
-            position: {
+        const newParallelizationNode = placeBlock(
+            graphId.value,
+            'primary-model-parallelization',
+            {
                 x: inputNodeBaseX,
-                y: inputNodeBaseY + inputNodeHeight + verticalDistance,
+                y: inputNodeBaseY,
             },
-            data: {
+            { x: 0, y: inputNodeHeight + 350 },
+            false,
+            {
                 models:
                     blockParallelizationSettings.value?.models.map(({ model }) => ({
                         model: model,
@@ -267,54 +233,47 @@ export const useGraphChat = () => {
                     usageData: null,
                 },
             },
-        };
+        );
 
-        const parallelizationNodeDefinition = getBlockById('primary-model-parallelization');
-        if (parallelizationNodeDefinition?.forcedInitialDimensions) {
-            newParallelizationNode.width = parallelizationNodeDefinition.minSize.width;
-            newParallelizationNode.height = parallelizationNodeDefinition.minSize.height;
-        }
-
-        const newPromptNode: Node = {
-            id: promptNodeId,
-            type: NodeTypeEnum.PROMPT,
-            position: {
-                x: inputNodeBaseX - horizontalDistance,
-                y: inputNodeBaseY + inputNodeHeight + verticalOffsetForPrompt,
+        const newPromptNode = placeBlock(
+            graphId.value,
+            'primary-prompt-text',
+            {
+                x: inputNodeBaseX,
+                y: inputNodeBaseY,
             },
-            data: {
+            { x: -200, y: inputNodeHeight + 25 },
+            false,
+            {
                 prompt: input,
             },
-        };
+        );
 
-        const edge1: Edge = {
-            id: `e-${inputNode.id}-${parallelizationNodeId}`,
-            source: inputNode.id,
-            target: parallelizationNodeId,
-            targetHandle: 'context_' + parallelizationNodeId,
-            type: 'custom',
-        };
-        const edge2: Edge = {
-            id: `e-${promptNodeId}-${parallelizationNodeId}`,
-            source: promptNodeId,
-            target: parallelizationNodeId,
-            targetHandle: 'prompt_' + parallelizationNodeId,
-            type: 'custom',
-        };
-
-        addNodes([newParallelizationNode, newPromptNode]);
-        addEdges([edge1, edge2]);
+        placeEdge(
+            graphId.value,
+            inputNode.id,
+            newParallelizationNode?.id,
+            null,
+            'context_' + newParallelizationNode?.id,
+        );
+        placeEdge(
+            graphId.value,
+            newPromptNode?.id,
+            newParallelizationNode?.id,
+            null,
+            'prompt_' + newParallelizationNode?.id,
+        );
 
         setTimeout(() => {
-            resolveOverlaps(parallelizationNodeId, [promptNodeId]);
+            resolveOverlaps(newParallelizationNode?.id, [newPromptNode?.id]);
         }, 1);
 
-        return parallelizationNodeId;
+        return newParallelizationNode?.id;
     };
 
     const updateNodeModel = (nodeId: string, model: string) => {
-        const { updateNode } = useVueFlow('main-graph-' + graphId.value);
-        const node = useVueFlow('main-graph-' + graphId.value).findNode(nodeId);
+        const { updateNode, findNode } = useVueFlow('main-graph-' + graphId.value);
+        const node = findNode(nodeId);
         if (node) {
             node.data.model = model;
             updateNode(nodeId, {
@@ -330,8 +289,8 @@ export const useGraphChat = () => {
     };
 
     const updatePromptNodeText = (nodeId: string, text: string) => {
-        const { updateNode } = useVueFlow('main-graph-' + graphId.value);
-        const node = useVueFlow('main-graph-' + graphId.value).findNode(nodeId);
+        const { updateNode, findNode } = useVueFlow('main-graph-' + graphId.value);
+        const node = findNode(nodeId);
         if (node) {
             node.data.prompt = text;
             updateNode(nodeId, {

--- a/ui/composables/useGraphOverlaps.ts
+++ b/ui/composables/useGraphOverlaps.ts
@@ -18,8 +18,8 @@ export const useGraphOverlaps = () => {
     };
 
     const resolveOverlaps = (
-        nodeId: string,
-        attachedNodeIds: string[],
+        nodeId: string | undefined,
+        attachedNodeIds: (string | undefined)[],
         options?: { offsetX?: number; offsetY?: number; maxIterations?: number },
     ) => {
         const { findNode, updateNode, getNodes, isNodeIntersecting } = useVueFlow(
@@ -69,6 +69,7 @@ export const useGraphOverlaps = () => {
 
             // Move all attached nodes
             for (const attachedId of attachedNodeIds) {
+                if (!attachedId) continue;
                 const attachedNode = findNode(attachedId);
                 if (attachedNode) {
                     attachedNode.position.x += aOptions.offsetX;

--- a/ui/constants/index.ts
+++ b/ui/constants/index.ts
@@ -10,7 +10,7 @@ export const AVAILABLE_WHEELS = [
     },
     {
         icon: 'FluentCodeText16Filled',
-        value: 'text-to-text',
+        value: 'textToText',
         label: 'Text to Text',
     },
     {

--- a/ui/pages/graph/[id].vue
+++ b/ui/pages/graph/[id].vue
@@ -36,6 +36,10 @@ let lastSavedData: any;
 const currentlyDraggedNodeId = ref<string | null>(null);
 const currentHoveredZone = ref<DragZoneHoverEvent | null>(null);
 
+let unsubscribeNodeCreate: (() => void) | null = null;
+let unsubscribeDragZoneHover: (() => void) | null = null;
+let unsubscribeEnterHistorySidebar: (() => void) | null = null;
+
 // --- Composables ---
 const { checkEdgeCompatibility } = useEdgeCompatibility();
 const { onDragOver, onDrop, onDragStopOnDragZone } = useGraphDragAndDrop();
@@ -281,18 +285,18 @@ onNodeDrag((event) => {
 
 onMounted(async () => {
     // Subscribe to graph events
-    const unsubscribeNodeCreate = graphEvents.on(
+    unsubscribeNodeCreate = graphEvents.on(
         'node-create',
         async ({ variant, fromNodeId }: { variant: string; fromNodeId: string }) => {
             createNodeFromVariant(variant, fromNodeId);
         },
     );
 
-    const unsubscribeDragZoneHover = graphEvents.on('drag-zone-hover', (hoverData) => {
+    unsubscribeDragZoneHover = graphEvents.on('drag-zone-hover', (hoverData) => {
         currentHoveredZone.value = hoverData;
     });
 
-    const unsubscribeEnterHistorySidebar = graphEvents.on(
+    unsubscribeEnterHistorySidebar = graphEvents.on(
         'enter-history-sidebar',
         ({ over }: { over: boolean }) => {
             isMouseOverLeftSidebar.value = over;
@@ -325,17 +329,15 @@ onMounted(async () => {
 
     document.addEventListener('keydown', handleKeyDown);
     document.addEventListener('mousemove', handleMouseMove);
-
-    onUnmounted(() => {
-        unsubscribeNodeCreate();
-        unsubscribeDragZoneHover();
-        unsubscribeEnterHistorySidebar();
-    });
 });
 
 onUnmounted(() => {
+    if (unsubscribeNodeCreate) unsubscribeNodeCreate();
+    if (unsubscribeDragZoneHover) unsubscribeDragZoneHover();
+    if (unsubscribeEnterHistorySidebar) unsubscribeEnterHistorySidebar();
+
     document.removeEventListener('keydown', handleKeyDown);
-    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mousemove', handleMouseMove); 
 });
 </script>
 

--- a/ui/pages/index.vue
+++ b/ui/pages/index.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { DEFAULT_NODE_ID } from '@/constants';
 import { NodeTypeEnum, MessageRoleEnum, MessageContentTypeEnum } from '@/types/enums';
-import type { Graph, MessageContent } from '@/types/graph';
+import type { Graph, MessageContent, BlockDefinition } from '@/types/graph';
 import type { File } from '@/types/files';
 import type { User } from '@/types/user';
 
@@ -37,6 +37,7 @@ const isLoading = ref(true);
 const animWords = ref(Array(10).fill(false));
 const pageRef = ref<HTMLElement | null>(null);
 const recentCanvasSectionRef = ref<HTMLElement | null>(null);
+const selectedNodeType = ref<BlockDefinition | null>(null);
 
 // Motion state for scroll animation
 const recentCanvasHeight = useSpring(40, { stiffness: 200, damping: 30 });
@@ -121,7 +122,7 @@ const openNewFromInput = async (message: string, files: File[]) => {
             ],
             model: currentModel.value,
             node_id: textToTextNodeId,
-            type: NodeTypeEnum.TEXT_TO_TEXT,
+            type: selectedNodeType.value?.nodeType || NodeTypeEnum.TEXT_TO_TEXT,
             data: {
                 reply: '',
                 model: currentModel.value,
@@ -254,6 +255,11 @@ onBeforeUnmount(() => {
                 :nodeType="NodeTypeEnum.TEXT_TO_TEXT"
                 @trigger-scroll="() => {}"
                 @generate="openNewFromInput"
+                @select-node-type="
+                    (newType) => {
+                        selectedNodeType = newType;
+                    }
+                "
                 class="max-h-[300px]"
             ></UiChatTextInput>
 

--- a/ui/stores/stream.ts
+++ b/ui/stores/stream.ts
@@ -279,6 +279,7 @@ export const useStreamStore = defineStore('Stream', () => {
 
     return {
         // Actions
+        ensureSession,
         setChatCallback,
         removeChatCallback,
         setCanvasCallback,

--- a/ui/types/settings.d.ts
+++ b/ui/types/settings.d.ts
@@ -1,9 +1,10 @@
-import { ReasoningEffortEnum } from '@/types/enums';
+import { ReasoningEffortEnum, NodeTypeEnum } from '@/types/enums';
 
 export interface GeneralSettings {
     openChatViewOnNewCanvas: boolean;
     alwaysThinkingDisclosures: boolean;
     includeThinkingInContext: boolean;
+    defaultNodeType: NodeTypeEnum;
 }
 
 export interface AccountSettings {


### PR DESCRIPTION
This pull request introduces improvements to how node types are managed and selected in the chat UI, adds support for user-configurable default node types in settings, and refactors chat message generation logic to be more flexible and maintainable. The most important changes are grouped below.

<img width="251" height="228" alt="ShoT_2025-08-15-03-05-35_5120x1440" src="https://github.com/user-attachments/assets/7d7b07e3-dc62-4c92-a9c3-f965cf836f28" />


**Node Type Selection and Chat UI Refactor**

* Added a new `UiChatUtilsSendChatButton` component that allows users to select the node type directly from the chat input, improving usability and flexibility for creating different node types. The selection is visually represented and triggers updates throughout the chat workflow. [[1]](diffhunk://#diff-1ea194c8a0b6960083c96ede8fb1ce14d6ef19e20814b2e3d53ebe4fc118e7ddR1-R164) [[2]](diffhunk://#diff-41435a52aa6c45c67c41d7f8d9aefd3170c38014565167d4a39401a5043519bcL230-R247) [[3]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8R517-R521)
* Refactored the chat message generation logic in `chatBox.vue` to use the selected node type for node creation and session management, replacing hardcoded text-to-text logic with a more general approach. This includes switching from `addTextToTextInputNodes` to `createNodeFromVariant`, and ensuring node type is passed to session creation and execution. [[1]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8R57) [[2]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8R83) [[3]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8L112-R155) [[4]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8L165-R187) [[5]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8L204-R211) [[6]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8L224-L251)

**Settings and Data Model Updates**

* Added a `defaultNodeType` field to `GeneralSettings` in both backend (`settings.py`, `usersDTO.py`) and frontend settings, allowing users to configure their preferred node type for new chat canvases. This is now respected throughout the chat UI and initialization. [[1]](diffhunk://#diff-79a1336db536e921bf92cf60894962eddc341cca202b51221a2303c7a66ffd98R18-R26) [[2]](diffhunk://#diff-6b5ab744f8e0fdbeb59be6ee2c092111f671c5e8bab67aff3aa242db32a692bdR6) [[3]](diffhunk://#diff-6b5ab744f8e0fdbeb59be6ee2c092111f671c5e8bab67aff3aa242db32a692bdR20-R31) [[4]](diffhunk://#diff-a7b6486148b75975d7c2a9b33cb36bd3a19f86930b4e273c821f11d4d057920cR2-R18)

**Parallelization and Usage Data Improvements**

* Improved usage data handling in `messageFooter.vue` by ensuring data is only combined for parallelization nodes when relevant, and only showing the usage popover when usage data is present. [[1]](diffhunk://#diff-90abbb5639474090c1c3d2c1aa79efd723eeead246abe16766484b25ad99e7dfL23-R23) [[2]](diffhunk://#diff-90abbb5639474090c1c3d2c1aa79efd723eeead246abe16766484b25ad99e7dfL69-R69)

**Minor Codebase Cleanups**

* Minor formatting and import order improvements in several files for consistency and readability. [[1]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8R2-L5) [[2]](diffhunk://#diff-79a1336db536e921bf92cf60894962eddc341cca202b51221a2303c7a66ffd98L62-R64) [[3]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8L39-R41) [[4]](diffhunk://#diff-3121e8f622e2e4bfa49a7887c11caac767a9072306480e07ff4854a8969b88c8R72)

These changes collectively make node type handling more robust and user-friendly, and lay the groundwork for future extensibility in the chat system.