### PR TITLE
Feat: General Enhancement on keyboard events handling

### DIFF
--- a/ui/components/ui/graph/node/utils/textarea.vue
+++ b/ui/components/ui/graph/node/utils/textarea.vue
@@ -80,7 +80,7 @@ watch(
             ref="textareaRef"
             :value="!isError ? displayValue : ''"
             @input="handleInput"
-            @keydown="handleKeydown"
+            @keydown.stop="handleKeydown"
             :readonly="readonly"
             class="dark:text-soft-silk text-anthracite nodrag nowheel hide-scrollbar h-full w-full flex-grow
                 resize-none rounded-2xl px-3 py-2 text-sm caret-current focus:ring-0 focus:outline-none"

--- a/ui/pages/graph/[id].vue
+++ b/ui/pages/graph/[id].vue
@@ -180,9 +180,21 @@ const handleKeyDown = (event: KeyboardEvent) => {
     // Prevent node paste if chat is open
     if (openChatId.value) return;
 
-    // Prevent node paste if hovering textarea
-    const hoveredElement = document.elementFromPoint(mousePosition.value.x, mousePosition.value.y);
-    if (hoveredElement?.classList.contains('nodrag')) return;
+    // Check if the currently focused element is a textarea, input, or has nodrag class
+    const activeElement = document.activeElement;
+    if (activeElement) {
+        if (activeElement.tagName === 'TEXTAREA' || activeElement.tagName === 'INPUT') {
+            return;
+        }
+
+        let element = activeElement as HTMLElement;
+        while (element) {
+            if (element.classList?.contains('nodrag')) {
+                return;
+            }
+            element = element.parentElement as HTMLElement;
+        }
+    }
 
     const isCtrlOrCmd = event.ctrlKey || event.metaKey;
 


### PR DESCRIPTION
This pull request improves how keyboard events are handled in the graph node textarea and the main graph page, specifically to prevent unintended node paste actions when users are interacting with text inputs. The changes enhance user experience and reliability by more accurately detecting when keyboard shortcuts should be ignored.

**Keyboard event handling improvements:**

* In `ui/components/ui/graph/node/utils/textarea.vue`, updated the `@keydown` event to use `.stop` modifier, preventing event propagation when handling keydown in the textarea.
* In `ui/pages/graph/[id].vue`, replaced mouse position-based detection with a more robust check for focused elements: now prevents node paste if the active element is a textarea, input, or has a parent with the `nodrag` class, ensuring keyboard shortcuts do not interfere with text editing. ([ui/pages/graph/[id].vueL183-R197](diffhunk://#diff-4ee79ba4cbf472ea09b338c811c2347006ee2440fb23f4250c715dac3bbf914fL183-R197))