### PR TITLE
fix: pass nodeId in GitHub file selection events for better context handling

### DIFF
--- a/ui/components/ui/graph/node/github.vue
+++ b/ui/components/ui/graph/node/github.vue
@@ -81,6 +81,7 @@ const blockDefinition = getBlockById('primary-github-context');
                     }
                 "
                 :repo="props.data.repo"
+                :nodeId="props.id"
             />
 
             <div

--- a/ui/components/ui/graph/node/utils/github/fileList.vue.vue
+++ b/ui/components/ui/graph/node/utils/github/fileList.vue.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
     files: FileTreeNode[];
     setFiles: (files: FileTreeNode[]) => void;
     repo: Repo;
+    nodeId: string;
 }>();
 
 // --- Composables ---
@@ -35,6 +36,7 @@ const fetchRepoTree = async () => {
         }
         graphEvents.emit('open-github-file-select', {
             repoContent: { repo: props.repo, files: fileTree, selectedFiles: selectedFiles.value },
+            nodeId: props.nodeId,
         });
     } catch (err) {
         error.value = 'Failed to fetch repository structure';
@@ -53,9 +55,14 @@ watch(
 
 // --- Lifecycle Hooks ---
 onMounted(() => {
-    const unsubscribe = graphEvents.on('close-github-file-select', async (selectedFilePaths) => {
-        selectedFiles.value = selectedFilePaths.selectedFilePaths;
-    });
+    const unsubscribe = graphEvents.on(
+        'close-github-file-select',
+        ({ selectedFilePaths, nodeId }) => {
+            if (nodeId === props.nodeId) {
+                selectedFiles.value = selectedFilePaths;
+            }
+        },
+    );
 
     onUnmounted(unsubscribe);
 });

--- a/ui/components/ui/graph/node/utils/github/fileSelectMountpoint.vue
+++ b/ui/components/ui/graph/node/utils/github/fileSelectMountpoint.vue
@@ -10,24 +10,28 @@ const isOpen = ref(false);
 const repoContent = ref<RepoContent | null>(null);
 const selectedFiles = ref<FileTreeNode[]>([]);
 const initialSelectedFiles = ref<FileTreeNode[]>([]);
+const activeNodeId = ref<string | null>(null);
 
 // --- Core Logic Functions ---
 const closeFullscreen = (finalSelection?: FileTreeNode[]) => {
     graphEvents.emit('close-github-file-select', {
         selectedFilePaths: finalSelection || initialSelectedFiles.value,
+        nodeId: activeNodeId.value || '',
     });
 
     repoContent.value = null;
     isOpen.value = false;
     selectedFiles.value = [];
+    activeNodeId.value = null;
 };
 
 // --- Lifecycle Hooks ---
 onMounted(() => {
-    const unsubscribe = graphEvents.on('open-github-file-select', async (repoContentData) => {
+    const unsubscribe = graphEvents.on('open-github-file-select', async (payload) => {
         isOpen.value = true;
-        repoContent.value = repoContentData.repoContent;
-        selectedFiles.value = repoContentData.repoContent.selectedFiles || [];
+        repoContent.value = payload.repoContent;
+        selectedFiles.value = payload.repoContent.selectedFiles || [];
+        activeNodeId.value = payload.nodeId;
         initialSelectedFiles.value = [...selectedFiles.value];
     });
 

--- a/ui/composables/useGraphEvents.ts
+++ b/ui/composables/useGraphEvents.ts
@@ -17,8 +17,8 @@ type BusEvents = {
     'enter-history-sidebar': { over: boolean };
     'open-fullscreen': { open: boolean; rawElement?: string };
     'drag-zone-hover': DragZoneHoverEvent | null;
-    'open-github-file-select': { repoContent: RepoContent };
-    'close-github-file-select': { selectedFilePaths: FileTreeNode[] };
+    'open-github-file-select': { repoContent: RepoContent; nodeId: string };
+    'close-github-file-select': { selectedFilePaths: FileTreeNode[]; nodeId: string };
 };
 
 const listeners: { [key in keyof BusEvents]?: Array<(arg: BusEvents[key]) => void> } = {};


### PR DESCRIPTION
This pull request updates the GitHub file selection workflow in the graph UI to support multiple nodes by tracking the active node ID during file selection events. This ensures that file selection and closing events are correctly associated with the relevant node, preventing state conflicts when multiple nodes are present.

**File selection workflow improvements:**

* Updated the event payloads for `open-github-file-select` and `close-github-file-select` to include a `nodeId` property in `useGraphEvents.ts`, ensuring events are scoped to individual nodes.
* Modified `fileList.vue.vue` to pass `nodeId` through props and event emissions, and to update selected files only if the node ID matches, preventing cross-node interference. [[1]](diffhunk://#diff-ce8cbb7a2ad2d0dca71e857584f67b5605821d484fa5d91448814e708be19183R10) [[2]](diffhunk://#diff-ce8cbb7a2ad2d0dca71e857584f67b5605821d484fa5d91448814e708be19183R39) [[3]](diffhunk://#diff-ce8cbb7a2ad2d0dca71e857584f67b5605821d484fa5d91448814e708be19183L56-R65)
* Updated `github.vue` to pass the node ID to the file list component, enabling correct event scoping.
* Enhanced `fileSelectMountpoint.vue` to track the active node ID, include it in event emissions, and reset it on close, ensuring the modal state is tied to the correct node.