### PR TITLE
fix: add cloned_repos volume to docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,6 +43,7 @@ services:
         condition: service_healthy
     volumes:
       - file_uploads:/app/data/uploads
+      - cloned_repos:/app/data/cloned_repos
     environment:
       - ENV=${ENV}
       - USERPASS=${USERPASS}
@@ -110,6 +111,7 @@ services:
 
 volumes:
   file_uploads:
+  cloned_repos:
   postgres_data:
   neo4j_data:
   neo4j_logs:


### PR DESCRIPTION
This pull request updates the Docker Compose configuration to support persistent storage for cloned repositories. The main change is the addition of a new volume for cloned repositories, ensuring that any repositories cloned by the application are stored persistently and are available across container restarts.

Docker volume management:

* Added a new `cloned_repos` volume to the `volumes` section in `docker/docker-compose.yml` to persistently store cloned repositories.
* Mounted the `cloned_repos` volume to `/app/data/cloned_repos` in the relevant service, enabling the application to access and retain cloned repository data.