### PR TITLE
Feat: Support multiple attachement input nodes

### DIFF
--- a/ui/composables/useEdgeCompatibility.ts
+++ b/ui/composables/useEdgeCompatibility.ts
@@ -1,4 +1,5 @@
 import { type GraphNode, type Connection, type GraphEdge } from '@vue-flow/core';
+import { NodeCategoryEnum } from '@/types/enums';
 
 const acceptedMapping: Record<string, string[]> = {
     prompt: ['prompt'],
@@ -8,6 +9,12 @@ const acceptedMapping: Record<string, string[]> = {
 
 export const useEdgeCompatibility = () => {
     const { warning } = useToast();
+
+    const acceptMultipleInputEdges: Record<NodeCategoryEnum, boolean> = {
+        [NodeCategoryEnum.PROMPT]: false,
+        [NodeCategoryEnum.CONTEXT]: false,
+        [NodeCategoryEnum.ATTACHMENT]: true,
+    };
 
     /**
      * Checks if a connection between two nodes is compatible based on node types.
@@ -58,6 +65,9 @@ export const useEdgeCompatibility = () => {
     ): boolean => {
         if (handleType !== 'target') return true;
 
+        const isMultipleAccepted = acceptMultipleInputEdges[handleCategory as NodeCategoryEnum];
+        if (isMultipleAccepted) return true;
+
         const handleId = `${handleCategory}_${node.id}`;
         return !connectedEdges.some((edge) => edge.targetHandle === handleId);
     };
@@ -65,5 +75,6 @@ export const useEdgeCompatibility = () => {
     return {
         checkEdgeCompatibility,
         handleConnectableInput,
+        acceptMultipleInputEdges,
     };
 };

--- a/ui/composables/useGraphActions.ts
+++ b/ui/composables/useGraphActions.ts
@@ -13,7 +13,7 @@ export const useGraphActions = () => {
         positionOffset: { x: number; y: number } = { x: 0, y: 0 },
         center: boolean = false,
         data: Record<string, any> = {},
-        forcedId: string | null = null
+        forcedId: string | null = null,
     ) => {
         const { addNodes } = useVueFlow('main-graph-' + graphId);
 
@@ -228,7 +228,13 @@ export const useGraphActions = () => {
             ...edge,
             id: generateId(),
             source: oldIdToNewIdMap.get(edge.source)!,
+            sourceHandle: edge.sourceHandle
+                ? edge.sourceHandle.split('_')[0] + '_' + oldIdToNewIdMap.get(edge.source)!
+                : undefined,
             target: oldIdToNewIdMap.get(edge.target)!,
+            targetHandle: edge.targetHandle
+                ? edge.targetHandle.split('_')[0] + '_' + oldIdToNewIdMap.get(edge.target)!
+                : undefined,
             selected: false,
         }));
 

--- a/ui/composables/useGraphDragAndDrop.ts
+++ b/ui/composables/useGraphDragAndDrop.ts
@@ -14,7 +14,7 @@ export function useGraphDragAndDrop() {
     const { error, warning } = useToast();
     const { placeBlock, placeEdge, numberOfConnectionsFromHandle } = useGraphActions();
     const { nodeTypeEnumToHandleCategory } = graphMappers();
-    const { checkEdgeCompatibility } = useEdgeCompatibility();
+    const { checkEdgeCompatibility, acceptMultipleInputEdges } = useEdgeCompatibility();
     const graphEvents = useGraphEvents();
 
     /**
@@ -250,7 +250,7 @@ export function useGraphDragAndDrop() {
                     targetHandleId,
                 );
 
-                if (numberOfConnections > 0) {
+                if (numberOfConnections > 0 && !acceptMultipleInputEdges[handleCategory]) {
                     warning(
                         'This handle already has connections and does not support multiple connections.',
                         {


### PR DESCRIPTION
This pull request introduces improvements to the graph node connection logic, specifically by adding support for node categories that can accept multiple input edges. The changes ensure that nodes such as attachments can have multiple connections, while prompts and context nodes remain restricted to single connections. Additionally, edge cloning now correctly updates handle identifiers to match new node IDs.

### Edge compatibility and connection logic improvements

* Added a new mapping `acceptMultipleInputEdges` in `useEdgeCompatibility.ts` to specify which node categories (defined in `NodeCategoryEnum`) allow multiple input edges, enabling more flexible graph structures.
* Updated the `checkEdgeCompatibility` function to allow connections if the node category supports multiple input edges, preventing unnecessary connection restrictions.
* Modified the drag-and-drop connection logic in `useGraphDragAndDrop.ts` to check `acceptMultipleInputEdges` before warning about multiple connections, ensuring accurate feedback for users.
* Exposed `acceptMultipleInputEdges` from `useEdgeCompatibility` and used it in `useGraphDragAndDrop.ts` to maintain consistent logic across composables.

### Edge cloning enhancements

* Updated edge cloning in `useGraphActions.ts` so that `sourceHandle` and `targetHandle` are correctly rebuilt using the new node IDs, ensuring handles remain valid after node duplication.