### PR TITLE
Fix: repository's default branch when pulling

### DIFF
--- a/ui/components/ui/chat/markdownRenderer.vue
+++ b/ui/components/ui/chat/markdownRenderer.vue
@@ -317,7 +317,7 @@ onMounted(() => {
         :class="{
             'hide-code-scrollbar': isStreaming,
         }"
-        class="prose prose-invert custom_scroll min-w-full overflow-x-auto"
+        class="prose prose-invert custom_scroll min-w-full overflow-x-auto overflow-y-hidden"
         v-html="responseHtml"
         ref="contentRef"
     ></div>


### PR DESCRIPTION
This pull request introduces improvements to how the repository's default branch is determined when pulling updates, and includes a minor UI adjustment to the markdown renderer component. The main change ensures that the correct branch is used for git operations, making the code more robust for repositories that do not use `main` as their default branch.

**GitHub service improvements:**

* The `pull_repo` function now dynamically determines the default branch of the repository instead of assuming it is `main`, by calling the new `get_default_branch` async helper. This makes the code compatible with repositories using different default branches.
* Added the `get_default_branch` async function to `github.py`, which attempts to retrieve the current branch name and falls back to parsing the remote HEAD symbolic ref or using `"main"` if all else fails.

**UI update:**

* In `markdownRenderer.vue`, the code scroll area now explicitly hides vertical overflow (`overflow-y-hidden`), improving the appearance when code is streaming.