### PR TITLE
fix: delete existing GitHub provider token before storing a new one

### DIFF
--- a/api/app/routers/github.py
+++ b/api/app/routers/github.py
@@ -128,6 +128,8 @@ async def github_callback(
     # Encrypt + store the token
     encrypted_token = encrypt_api_key(access_token)
     user_id_uuid = uuid.UUID(user_id)
+    await delete_provider_token(request.app.state.pg_engine, user_id_uuid, "github")
+
     await store_github_token_for_user(
         request.app.state.pg_engine, user_id_uuid, encrypted_token
     )


### PR DESCRIPTION
This pull request introduces an improvement to the GitHub authentication flow by ensuring that any previously stored GitHub tokens for a user are deleted before saving a new one. This helps prevent token duplication and potential security issues.

Authentication token management:

* In the `github_callback` function in `api/app/routers/github.py`, added a call to `delete_provider_token` to remove any existing GitHub tokens for the user before storing the new encrypted token.