### PR TITLE
fix: update infobubble component to bypass overflow hidden parents

### DIFF
--- a/ui/components/ui/graph/sidebar/canvasConfig.vue
+++ b/ui/components/ui/graph/sidebar/canvasConfig.vue
@@ -78,7 +78,7 @@ const updateSidebarConfig = () => {
                 <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">
                     Canvas Custom Instructions
                 </h3>
-                <UiSettingsInfobubble direction="left">
+                <UiSettingsInfobubble direction="right">
                     Custom instructions for the canvas. This will be used as a system prompt for all
                     models in the canvas. Warning: this will override the global system prompt.
                 </UiSettingsInfobubble>
@@ -90,8 +90,9 @@ const updateSidebarConfig = () => {
                         sidebarConfig.custom_instructions = value;
                     }
                 "
-                class="border-stone-gray/20 bg-anthracite/20 text-stone-gray focus:border-ember-glow h-52 w-full rounded-lg
-                    border-2 p-2 transition-colors duration-200 ease-in-out outline-none focus:border-2"
+                class="border-stone-gray/20 bg-anthracite/20 text-stone-gray focus:border-ember-glow dark-scrollbar h-52
+                    w-full rounded-lg border-2 p-2 transition-colors duration-200 ease-in-out outline-none
+                    focus:border-2"
                 id="models-global-system-prompt"
                 placeholder="Enter custom instructions for the canvas..."
             ></textarea>
@@ -100,7 +101,7 @@ const updateSidebarConfig = () => {
         <div>
             <label class="mb-2 flex gap-2" for="canvas-reasoning-effort">
                 <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">Reasoning Effort</h3>
-                <UiSettingsInfobubble direction="left">
+                <UiSettingsInfobubble direction="right">
                     The reasoning effort to use for the chat response. This value controls how much
                     effort the model will put into reasoning before generating a response.
                 </UiSettingsInfobubble>
@@ -123,7 +124,7 @@ const updateSidebarConfig = () => {
             <div>
                 <label class="mb-2 flex gap-2" for="canvas-max-tokens">
                     <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">Max Tokens</h3>
-                    <UiSettingsInfobubble direction="left">
+                    <UiSettingsInfobubble direction="right">
                         The maximum number of tokens to generate in the chat response.
                     </UiSettingsInfobubble>
                 </label>
@@ -144,7 +145,7 @@ const updateSidebarConfig = () => {
             <div>
                 <label class="mb-2 flex gap-2" for="canvas-temperature">
                     <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">Temperature</h3>
-                    <UiSettingsInfobubble direction="left">
+                    <UiSettingsInfobubble direction="right">
                         The temperature to use for the chat response. Higher values will make the
                         response more random, while lower values will make it more deterministic.
                     </UiSettingsInfobubble>
@@ -169,7 +170,7 @@ const updateSidebarConfig = () => {
             <div>
                 <label class="mb-2 flex gap-2" for="canvas-top-p">
                     <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">Top P</h3>
-                    <UiSettingsInfobubble direction="left">
+                    <UiSettingsInfobubble direction="right">
                         The Top P value to use for the chat response. Top P is a filter that
                         controls how many different words or phrases the language model considers
                         when it’s trying to predict the next word. A lower value means the model
@@ -196,7 +197,7 @@ const updateSidebarConfig = () => {
             <div>
                 <label class="mb-2 flex gap-2" for="canvas-top-k">
                     <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">Top K</h3>
-                    <UiSettingsInfobubble direction="left">
+                    <UiSettingsInfobubble direction="right">
                         The Top K value to use for the chat response. Top K sample from the k most
                         likely next tokens at each step. Lower k focuses on higher probability
                         tokens.
@@ -223,7 +224,7 @@ const updateSidebarConfig = () => {
                     <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">
                         Frequency Penalty
                     </h3>
-                    <UiSettingsInfobubble direction="left">
+                    <UiSettingsInfobubble direction="right">
                         The frequency penalty to use for the chat response. This value penalizes new
                         tokens based on their existing frequency in the text so far, decreasing the
                         model's likelihood to repeat the same line verbatim.
@@ -250,7 +251,7 @@ const updateSidebarConfig = () => {
                     <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">
                         Presence Penalty
                     </h3>
-                    <UiSettingsInfobubble direction="left">
+                    <UiSettingsInfobubble direction="right">
                         The presence penalty to use for the chat response. This value penalizes new
                         tokens based on whether they appear in the text so far, decreasing the
                         model's likelihood to repeat the same line verbatim.
@@ -279,7 +280,7 @@ const updateSidebarConfig = () => {
                     <h3 class="dark:text-stone-gray text-soft-silk/80 font-bold">
                         Repetition Penalty
                     </h3>
-                    <UiSettingsInfobubble direction="left">
+                    <UiSettingsInfobubble direction="right">
                         The repetition penalty to use for the chat response. This value penalizes
                         new tokens based on their existing frequency in the text so far, decreasing
                         the model's likelihood to repeat the same line verbatim.

--- a/ui/components/ui/settings/infobubble.vue
+++ b/ui/components/ui/settings/infobubble.vue
@@ -4,11 +4,31 @@ const open = ref(false);
 const props = defineProps<{
     direction?: 'left' | 'right';
 }>();
+
+const buttonRef = ref<HTMLElement | null>(null);
+const panelRef = ref<HTMLElement | null>(null);
+
+const updatePanelPosition = () => {
+    if (props.direction === 'left' && buttonRef.value && panelRef.value) {
+        const rect = buttonRef.value.getBoundingClientRect();
+        panelRef.value.style.left = `${rect.left - 500}px`;
+        panelRef.value.style.top = `${rect.top}px`;
+    }
+};
+
+watch(open, (newVal) => {
+    if (newVal && props.direction === 'left') {
+        nextTick(() => {
+            updatePanelPosition();
+        });
+    }
+});
 </script>
 
 <template>
     <HeadlessPopover class="relative">
         <HeadlessPopoverButton
+            ref="buttonRef"
             as="div"
             class="flex h-6 w-6 cursor-pointer items-center justify-center"
             @mouseover="open = true"
@@ -17,19 +37,18 @@ const props = defineProps<{
             <UiIcon name="MaterialSymbolsInfoRounded" class="text-stone-gray h-4 w-4" />
         </HeadlessPopoverButton>
 
-        <div v-if="open">
-            <HeadlessPopoverPanel
-                static
-                class="bg-anthracite/75 text-stone-gray absolute left-0 z-30 flex w-[500px] flex-col items-start rounded-lg
-                    p-4 shadow-lg backdrop-blur-md"
-                :class="{
-                    '-translate-x-[480px]': props.direction === 'left',
-                }"
-            >
-                <slot name="default"></slot>
-            </HeadlessPopoverPanel>
-        </div>
+        <!-- IMPORTANT: When above a context that already has a backdrop-blur, this component backdrop-blur will not work -->
+        <HeadlessPopoverPanel
+            ref="panelRef"
+            static
+            class="bg-anthracite/75 text-stone-gray fixed z-30 flex w-[500px] flex-col items-start rounded-lg p-4
+                shadow-lg backdrop-blur"
+            :class="{
+                '-translate-x-[480px]': props.direction === 'right',
+            }"
+            v-if="open"
+        >
+            <slot name="default"></slot>
+        </HeadlessPopoverPanel>
     </HeadlessPopover>
 </template>
-
-<style scoped></style>


### PR DESCRIPTION
This pull request updates the sidebar settings and info bubble components to improve UI consistency and user experience. The main changes involve aligning info bubbles to the right instead of the left in the canvas configuration sidebar, and refactoring the `UiSettingsInfobubble` component to better handle positioning and display. Below are the most important changes grouped by theme.

**UI Alignment and Consistency:**

* All `UiSettingsInfobubble` components in `canvasConfig.vue` are now aligned to the right instead of the left, making the sidebar configuration more visually consistent. [[1]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL81-R81) [[2]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL103-R104) [[3]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL126-R127) [[4]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL147-R148) [[5]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL172-R173) [[6]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL199-R200) [[7]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL226-R227) [[8]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL253-R254) [[9]](diffhunk://#diff-8d315a7437cbed2375d85221975a2568dc37d43f98d4560fd2ab2ba11f5d0d6bL282-R283)

* Added the `dark-scrollbar` class to the custom instructions textarea for improved appearance in dark mode.

**Info Bubble Component Refactor:**

* Refactored `UiSettingsInfobubble` (`infobubble.vue`) to use `ref` for both the button and panel, enabling more precise positioning logic.

* Implemented logic to position the info bubble panel when the direction is set to left, using `getBoundingClientRect` for accurate placement.

* Changed the info bubble panel from `absolute` to `fixed` positioning, and updated translation logic so right-aligned bubbles use `-translate-x-[480px]`.

* Improved conditional rendering of the info bubble panel to only display when open, and removed unnecessary wrapper `<div>`.