### PR TITLE
fix: update Docker registry configuration to use GitHub Container Registry and streamline image push logic

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,9 +8,9 @@ on:
     branches: [ main ]
 
 env:
-  REGISTRY: docker.io
-  FRONTEND_IMAGE_NAME: mathisverstrepen/meridian-frontend
-  BACKEND_IMAGE_NAME: mathisverstrepen/meridian-backend
+  REGISTRY: ghcr.io
+  FRONTEND_IMAGE_NAME: ${{ github.repository }}/frontend
+  BACKEND_IMAGE_NAME: ${{ github.repository }}/backend
 
 jobs:
   build-and-push:
@@ -18,16 +18,18 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Log in to Docker Hub
+    - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract metadata for frontend
       id: meta-frontend
@@ -39,6 +41,7 @@ jobs:
           type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Extract metadata for backend
       id: meta-backend
@@ -50,13 +53,14 @@ jobs:
           type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push frontend image
       uses: docker/build-push-action@v5
       with:
         context: .
         file: ./docker/ui.Dockerfile
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta-frontend.outputs.tags }}
         labels: ${{ steps.meta-frontend.outputs.labels }}
 
@@ -65,6 +69,6 @@ jobs:
       with:
         context: .
         file: ./docker/api.Dockerfile
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta-backend.outputs.tags }}
         labels: ${{ steps.meta-backend.outputs.labels }}


### PR DESCRIPTION
This pull request updates the Docker publishing workflow to use the GitHub Container Registry instead of Docker Hub and improves the tagging and publishing logic for frontend and backend images. The changes ensure that images are only pushed on non-pull request events and use repository-specific naming conventions.

**Migration to GitHub Container Registry:**

* Changed the registry from Docker Hub (`docker.io`) to GitHub Container Registry (`ghcr.io`), and updated image names to use the repository path for both frontend and backend images. (`.github/workflows/docker-publish.yml`)
* Updated the Docker login step to authenticate with GitHub Container Registry using the GitHub actor and token, replacing Docker Hub credentials. (`.github/workflows/docker-publish.yml`)

**Tagging and publishing improvements:**

* Added logic to generate a `latest` tag only for the default branch, improving image versioning. (`.github/workflows/docker-publish.yml`) [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R44) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R56-R63)
* Modified the build-and-push steps so images are only pushed when the workflow is not triggered by a pull request event, preventing unwanted pushes for PR builds. (`.github/workflows/docker-publish.yml`) [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R56-R63) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L68-R72)