### PR TITLE
Feat: Enhance Docker workflows with caching for frontend and backend

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
-  pull_request:
-    branches: [ main ]
 
 env:
   REGISTRY: ghcr.io
@@ -38,7 +36,6 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
         tags: |
           type=ref,event=branch
-          type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=raw,value=latest,enable={{is_default_branch}}
@@ -50,7 +47,6 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}
         tags: |
           type=ref,event=branch
-          type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=raw,value=latest,enable={{is_default_branch}}
@@ -60,7 +56,7 @@ jobs:
       with:
         context: .
         file: ./docker/ui.Dockerfile
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta-frontend.outputs.tags }}
         labels: ${{ steps.meta-frontend.outputs.labels }}
 
@@ -69,6 +65,6 @@ jobs:
       with:
         context: .
         file: ./docker/api.Dockerfile
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta-backend.outputs.tags }}
         labels: ${{ steps.meta-backend.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,12 +22,36 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cache Frontend Dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ui/node_modules
+          ~/.pnpm-store
+        key: ${{ runner.os }}-frontend-deps-${{ hashFiles('ui/package.json', 'ui/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-frontend-deps-${{ hashFiles('ui/package.json') }}
+          ${{ runner.os }}-frontend-deps-
+
+    - name: Cache Backend Dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pip
+          api/requirements.txt
+        key: ${{ runner.os }}-backend-deps-${{ hashFiles('api/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-backend-deps-
 
     - name: Extract metadata for frontend
       id: meta-frontend
@@ -59,6 +83,9 @@ jobs:
         push: true
         tags: ${{ steps.meta-frontend.outputs.tags }}
         labels: ${{ steps.meta-frontend.outputs.labels }}
+        cache-from: type=gha,scope=frontend
+        cache-to: type=gha,mode=max,scope=frontend
+        platforms: linux/amd64
 
     - name: Build and push backend image
       uses: docker/build-push-action@v5
@@ -68,3 +95,6 @@ jobs:
         push: true
         tags: ${{ steps.meta-backend.outputs.tags }}
         labels: ${{ steps.meta-backend.outputs.labels }}
+        cache-from: type=gha,scope=backend
+        cache-to: type=gha,mode=max,scope=backend
+        platforms: linux/amd64

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# install openssh-client and git
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssh-client git \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,11 +1,16 @@
 FROM node:20-alpine
 
 WORKDIR /ui
-COPY ./ui /ui
-RUN rm -rf node_modules
+
+COPY ./ui/package.json ./ui/pnpm-lock.yaml* ./
 
 RUN npm install -g pnpm --no-cache
-RUN pnpm install
+
+RUN pnpm install --frozen-lockfile
+
+COPY ./ui .
+
+RUN rm -rf node_modules/.cache
 
 RUN pnpm run build
 


### PR DESCRIPTION
This pull request updates the Docker publishing GitHub Actions workflow and refines the Dockerfiles for both the frontend and backend. The main goals are to improve build efficiency, optimize caching, and standardize the build process for better reliability.

**Workflow and CI improvements:**

* Removed the workflow trigger for pull requests, so Docker images are now only built and pushed on direct pushes and tags to the main branch.
* Added caching steps for both frontend (`ui/node_modules`, `~/.pnpm-store`) and backend (`~/.cache/pip`, `api/requirements.txt`) dependencies to speed up CI builds.
* Set up Docker Buildx for multi-platform builds and added explicit `platforms: linux/amd64` to both frontend and backend image builds. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R25-L41) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L63-R100)
* Changed the Docker build step to always push images and enabled GitHub Actions cache for Docker layers to further accelerate builds.
* Removed PR-specific image tagging from both frontend and backend metadata extraction steps, simplifying tag management. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R25-L41) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L53)

**Dockerfile optimizations:**

* Updated `docker/ui.Dockerfile` to use a two-step copy/install process for more efficient dependency management, switched to `pnpm install --frozen-lockfile`, and cleaned up cache directories for smaller images.
* Removed a redundant comment in `docker/api.Dockerfile` for clarity.