### PR TITLE
fix: update get_settings function to return a dictionary and handle JSON parsing

### DIFF
--- a/api/app/database/pg/settings_ops/settings_crud.py
+++ b/api/app/database/pg/settings_ops/settings_crud.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import uuid
 
@@ -55,7 +56,7 @@ async def update_settings(
             return user
 
 
-async def get_settings(pg_engine: SQLAlchemyAsyncEngine, user_id: str) -> str:
+async def get_settings(pg_engine: SQLAlchemyAsyncEngine, user_id: str) -> dict:
     """
     Retrieve user settings from the database.
 
@@ -78,4 +79,9 @@ async def get_settings(pg_engine: SQLAlchemyAsyncEngine, user_id: str) -> str:
             raise HTTPException(status_code=404, detail=f"Settings for user {user_id} not found")
 
         raw_settings: Settings = settings[0]
-        return raw_settings.settings_data  # type: ignore
+
+        settings_data = raw_settings.settings_data
+        if isinstance(raw_settings.settings_data, str):
+            settings_data = json.loads(raw_settings.settings_data)
+
+        return settings_data


### PR DESCRIPTION
This pull request updates the way user settings are retrieved from the database in `settings_crud.py` to ensure the returned data is always a dictionary, improving consistency and reliability for downstream consumers.

Improvements to settings retrieval:

* Changed the return type of the `get_settings` function from `str` to `dict`, ensuring that settings are always returned as a dictionary.
* Added logic to parse JSON strings in `settings_data` to a dictionary, so callers always receive a consistent data structure.
* Imported the `json` module to support parsing of settings data.