### PR TITLE
fix(github): update file tree building to handle null character in paths

### DIFF
--- a/api/app/services/github.py
+++ b/api/app/services/github.py
@@ -269,6 +269,7 @@ async def build_file_tree_for_branch(repo_dir: Path, branch: str) -> FileTreeNod
         "-r",
         "--full-tree",
         "--name-only",
+        "-z",
         ref,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -280,7 +281,7 @@ async def build_file_tree_for_branch(repo_dir: Path, branch: str) -> FileTreeNod
             raise FileNotFoundError(f"Branch '{branch}' not found in repository.")
         raise Exception(f"Git ls-tree failed: {stderr.decode()}")
 
-    paths = stdout.decode().strip().split("\n")
+    paths = stdout.decode().strip("\0").split("\0")
     # Filter out empty strings and .git paths
     paths = [p for p in paths if p and ".git" not in p.split("/")]
     return _build_tree_from_paths(paths)


### PR DESCRIPTION
This pull request updates the logic for building a file tree from a Git branch to improve handling of file names, especially those containing special characters like newlines. The main change is switching the output delimiter from newline to null character, which is more robust and aligns with best practices for parsing file lists from Git.

Improvements to file name parsing:

* Added the `-z` flag to the `git ls-tree` command to output file names separated by null characters, preventing issues with file names that contain newlines. (`api/app/services/github.py`)
* Updated the code to split the output from `git ls-tree` using the null character (`* Updated the code to split the output from `git ls-tree` using the null character (`\0`) instead of newline (`\n`), ensuring accurate parsing of all file names. (`api/app/services/github.py`) ([api/app/services/github.pyL283-R284](diffhunk://#diff-d90501a3d780e77b893cbcd014983c9ecce1ddfd85efb97f1d55577133cc3fefL283-R284))`) instead of newline (`\n`), ensuring accurate parsing of all file names. (`api/app/services/github.py`)