### PR TITLE
Fix: Group Node related bugs

### DIFF
--- a/ui/components/ui/graph/node/utils/groupMenu.vue
+++ b/ui/components/ui/graph/node/utils/groupMenu.vue
@@ -10,6 +10,7 @@ const emit = defineEmits(['create-group']);
     <div
         class="absolute z-50 flex items-center justify-center px-14 py-10"
         :style="{ left: `${position.x - 56}px`, top: `${position.y - 40}px` }"
+        @contextmenu.prevent
     >
         <button
             class="hover:bg-soft-black bg-soft-silk/10 text-soft-silk/80 border-stone-gray/10 hover:bg-soft-silk/20

--- a/ui/composables/useGraphActions.ts
+++ b/ui/composables/useGraphActions.ts
@@ -213,7 +213,7 @@ export const useGraphActions = () => {
 
         // Create copies of the nodes
         const newNodes = nodes.map((node) => ({
-            id: generateId(),
+            id: node.id.startsWith('group-') ? `group-${generateId()}` : generateId(),
             position: {
                 x: node.position.x,
                 y: node.position.y,

--- a/ui/composables/useGraphActions.ts
+++ b/ui/composables/useGraphActions.ts
@@ -153,7 +153,7 @@ export const useGraphActions = () => {
 
         // Offset node by a few pixels
         const positionOffset = { x: 25, y: 25 };
-        const newNode = {
+        const newNode: Node & { selected?: boolean } = {
             id: generateId(),
             position: {
                 x: node.position.x + positionOffset.x,
@@ -167,6 +167,8 @@ export const useGraphActions = () => {
             },
             type: node.type,
             selected: true,
+            expandParent: true,
+            parentNode: node.parentNode,
         };
 
         addNodes(newNode);


### PR DESCRIPTION
This pull request introduces several improvements to the node and group copy-paste functionality in the graph UI, ensuring that group nodes and their child nodes are handled correctly during duplication. It also refines how node positions are offset and how parent-child relationships are maintained when copying and pasting nodes.

**Enhancements to copy-paste functionality:**

* When copying nodes, if a group node is selected, all its child nodes are also copied automatically, ensuring group structure is preserved.
* Group node IDs are regenerated with the `group-` prefix to avoid ID collisions, and child nodes are remapped to their new parent group IDs. [[1]](diffhunk://#diff-534354df246f12e19e4660bc58ae268f269921a5085fb6f573b19a2dd75be2a2R234-R235) [[2]](diffhunk://#diff-534354df246f12e19e4660bc58ae268f269921a5085fb6f573b19a2dd75be2a2R265-R273)
* When pasting, only top-level (non-child) nodes have their positions offset, so child nodes remain correctly positioned relative to their parent group. [[1]](diffhunk://#diff-534354df246f12e19e4660bc58ae268f269921a5085fb6f573b19a2dd75be2a2L292-R319) [[2]](diffhunk://#diff-534354df246f12e19e4660bc58ae268f269921a5085fb6f573b19a2dd75be2a2L319-R347)

**General improvements and bug fixes:**

* Added the `expandParent` and `parentNode` properties to new nodes during copy operations to maintain expanded group states and parent-child relationships. [[1]](diffhunk://#diff-534354df246f12e19e4660bc58ae268f269921a5085fb6f573b19a2dd75be2a2R170-R171) [[2]](diffhunk://#diff-534354df246f12e19e4660bc58ae268f269921a5085fb6f573b19a2dd75be2a2R234-R235)
* Prevented the context menu from appearing in the group menu UI by adding the `@contextmenu.prevent` directive.