### PR TITLE
refactor: remove node-group-hover event handling and simplify drag-and-drop logic

### DIFF
--- a/ui/components/ui/graph/node/nodeGroup.vue
+++ b/ui/components/ui/graph/node/nodeGroup.vue
@@ -46,16 +46,12 @@ const onCommentChange = (event: Event) => {
 const handleMouseEnter = () => {
     if (isDragging.value) {
         isDraggingOver.value = true;
-        graphEvents.emit('node-group-hover', {
-            nodeId: props.id,
-        });
     }
 };
 
 const handleMouseLeave = () => {
     if (isDragging.value) {
         isDraggingOver.value = false;
-        graphEvents.emit('node-group-hover', null);
     }
 };
 

--- a/ui/composables/useGraphEvents.ts
+++ b/ui/composables/useGraphEvents.ts
@@ -27,8 +27,6 @@ type BusEvents = {
 
     'open-attachment-select': { nodeId: string | null; selectedFiles: FileSystemObject[] };
     'close-attachment-select': { nodeId: string | null; selectedFiles: FileSystemObject[] };
-
-    'node-group-hover': { nodeId: string } | null;
 };
 
 const listeners: { [key in keyof BusEvents]?: Array<(arg: BusEvents[key]) => void> } = {};

--- a/ui/pages/graph/[id].vue
+++ b/ui/pages/graph/[id].vue
@@ -36,11 +36,9 @@ const mousePosition = ref({ x: 0, y: 0 });
 let lastSavedData: { graph: Graph; nodes: NodeRequest[]; edges: EdgeRequest[] } | null = null;
 const currentlyDraggedNodeId = ref<string | null>(null);
 const currentHoveredZone = ref<DragZoneHoverEvent | null>(null);
-const currentNodeCommentHover = ref<{ nodeId: string } | null>(null);
 
 let unsubscribeNodeCreate: (() => void) | null = null;
 let unsubscribeDragZoneHover: (() => void) | null = null;
-let unsubscribeNodeCommentHover: (() => void) | null = null;
 let unsubscribeEnterHistorySidebar: (() => void) | null = null;
 
 // --- Composables ---
@@ -318,7 +316,7 @@ onNodeDragStop(async (event) => {
     }
 
     onDragStopOnDragZone(currentHoveredZone.value, currentlyDraggedNodeId.value);
-    onDragStopOnGroupNode(currentNodeCommentHover.value, currentlyDraggedNodeId.value);
+    onDragStopOnGroupNode(currentlyDraggedNodeId.value);
 
     isDragging.value = false;
     currentlyDraggedNodeId.value = null;
@@ -355,10 +353,6 @@ onMounted(async () => {
 
     unsubscribeDragZoneHover = graphEvents.on('drag-zone-hover', (hoverData) => {
         currentHoveredZone.value = hoverData;
-    });
-
-    unsubscribeNodeCommentHover = graphEvents.on('node-group-hover', (hoverData) => {
-        currentNodeCommentHover.value = hoverData;
     });
 
     unsubscribeEnterHistorySidebar = graphEvents.on(
@@ -399,7 +393,6 @@ onMounted(async () => {
 onUnmounted(() => {
     if (unsubscribeNodeCreate) unsubscribeNodeCreate();
     if (unsubscribeDragZoneHover) unsubscribeDragZoneHover();
-    if (unsubscribeNodeCommentHover) unsubscribeNodeCommentHover();
     if (unsubscribeEnterHistorySidebar) unsubscribeEnterHistorySidebar();
 
     document.removeEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
This pull request refactors the logic for handling node grouping during drag-and-drop operations in the graph UI. The main change is the removal of the `node-group-hover` event and its associated state management, simplifying how nodes are assigned to groups when dropped. The grouping logic now relies on geometric intersection detection rather than hover state, making the code more robust and easier to maintain.

**Refactoring node grouping logic:**

* Removed the `node-group-hover` event from the `BusEvents` type and all related event emission and subscription code, eliminating the need for tracking hover state for group nodes. [[1]](diffhunk://#diff-4f571127e862288f0e413224f03a74efc6ce8a6ab186b6dd09aa2e9c11346ae1L30-L31) [[2]](diffhunk://#diff-666fcf4f3a24cc2bcb8c5b81e115a81202b940d6cc77c81a61d6cb1e7b0b4f97L49-L58) [ui/pages/graph/[id].vueL360-L363](diffhunk://#diff-4ee79ba4cbf472ea09b338c811c2347006ee2440fb23f4250c715dac3bbf914fL360-L363), [ui/pages/graph/[id].vueL402](diffhunk://#diff-4ee79ba4cbf472ea09b338c811c2347006ee2440fb23f4250c715dac3bbf914fL402), [ui/pages/graph/[id].vueL39-L43](diffhunk://#diff-4ee79ba4cbf472ea09b338c811c2347006ee2440fb23f4250c715dac3bbf914fL39-L43))
* Refactored the `onDragStopOnGroupNode` function in `useGraphDragAndDrop.ts` to use geometric intersection (`getIntersectingNodes`) for determining group assignment, instead of relying on the hovered zone. Added a warning if a node intersects with multiple group nodes.
* Updated the drag stop handler in `[id].vue` to call the new `onDragStopOnGroupNode` signature, passing only the dragged node ID. ([ui/pages/graph/[id].vueL321-R319](diffhunk://#diff-4ee79ba4cbf472ea09b338c811c2347006ee2440fb23f4250c715dac3bbf914fL321-R319))

These changes streamline the drag-and-drop grouping feature, reduce complexity, and improve reliability by basing group assignment on actual node positions rather than transient hover states.