### PR TITLE
feat: implement canvas search in home page

### DIFF
--- a/ui/pages/index.vue
+++ b/ui/pages/index.vue
@@ -30,13 +30,21 @@ const animWords = ref(Array(10).fill(false));
 const pageRef = ref<HTMLElement | null>(null);
 const recentCanvasSectionRef = ref<HTMLElement | null>(null);
 const selectedNodeType = ref<BlockDefinition | null>(null);
+const searchQuery = ref('');
+const searchInputRef = ref<HTMLInputElement | null>(null);
+const isMac = ref(false);
 
 // --- Computed Properties ---
 const filteredGraphs = computed(() => {
-    return [
-        ...graphs.value.filter((graph) => graph.pinned),
-        ...graphs.value.filter((graph) => !graph.pinned),
-    ];
+    if (!searchQuery.value) {
+        return [
+            ...graphs.value.filter((graph) => graph.pinned),
+            ...graphs.value.filter((graph) => !graph.pinned),
+        ];
+    }
+    return graphs.value
+        .filter((graph) => graph.name.toLowerCase().includes(searchQuery.value.toLowerCase()))
+        .sort((a, b) => Number(b.pinned) - Number(a.pinned));
 });
 
 // Motion state for scroll animation
@@ -158,6 +166,17 @@ const openNewFromButton = async (wanted: 'canvas' | 'chat' | 'temporary') => {
     navigateTo(`graph/${newGraph.id}?fromHome=true&temporary=${wanted === 'temporary'}`);
 };
 
+const handleShiftSpace = () => {
+    document.execCommand('insertText', false, ' ');
+};
+
+const handleKeyDown = (event: KeyboardEvent) => {
+    if ((event.key === 'k' || event.key === 'K') && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        searchInputRef.value?.focus();
+    }
+};
+
 // --- Lifecycle Hooks ---
 let animationTimeouts: Array<ReturnType<typeof setTimeout>> = [];
 
@@ -185,6 +204,10 @@ onMounted(() => {
             el.addEventListener('wheel', handleWheel, { passive: true });
         }
     });
+
+    isMac.value = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+    document.addEventListener('keydown', handleKeyDown);
 });
 
 onBeforeUnmount(() => {
@@ -195,6 +218,8 @@ onBeforeUnmount(() => {
     if (el) {
         el.removeEventListener('wheel', handleWheel);
     }
+
+    document.removeEventListener('keydown', handleKeyDown);
 });
 </script>
 
@@ -310,6 +335,32 @@ onBeforeUnmount(() => {
                 flex-col items-center rounded-t-3xl border-t-2 p-8 pb-0 backdrop-blur-lg"
         >
             <h2 class="font-outfit text-stone-gray mb-8 text-xl font-bold">Recent Canvas</h2>
+
+            <!-- Search input -->
+            <div v-if="!isLoading && graphs.length > 0" class="absolute top-7 right-8 w-72">
+                <UiIcon
+                    name="MdiMagnify"
+                    class="text-stone-gray/50 pointer-events-none absolute top-1/2 left-3 h-5 w-5 -translate-y-1/2"
+                />
+                <input
+                    ref="searchInputRef"
+                    v-model="searchQuery"
+                    type="text"
+                    placeholder="Search canvas..."
+                    class="dark:bg-stone-gray/25 bg-obsidian/50 placeholder:text-stone-gray/50 text-stone-gray block h-9 w-full
+                        rounded-xl border-transparent px-3 py-2 pr-16 pl-10 text-sm font-semibold focus:border-transparent
+                        focus:ring-0 focus:outline-none"
+                    @keydown.space.shift.exact.prevent="handleShiftSpace"
+                />
+                <div
+                    class="text-stone-gray/30 absolute top-1/2 right-3 ml-auto -translate-y-1/2 rounded-md border px-1 py-0.5
+                        text-[10px] font-bold"
+                >
+                    {{ isMac ? '⌘ + K' : 'CTRL + K' }}
+                </div>
+            </div>
+
+            <!-- Canvas grid -->
             <div
                 v-if="!isLoading && graphs.length > 0"
                 class="custom_scroll grid h-full w-full auto-rows-[9rem] grid-cols-4 gap-5 overflow-y-auto pb-8"


### PR DESCRIPTION
This pull request introduces a search feature to the canvas list on the home page, improving user experience by allowing quick filtering and keyboard navigation. The main changes include adding a search input UI, implementing search logic, and handling keyboard shortcuts for accessibility.

**Search Feature Implementation:**

* Added a search input field to the canvas section UI, including a magnifying glass icon and shortcut hint, with conditional rendering when canvases are available (`index.vue`).
* Implemented computed filtering logic for canvases based on the search query, sorting results by pinned status (`filteredGraphs` in `index.vue`).

**Keyboard Accessibility:**

* Added keyboard shortcut handling (`⌘ + K` for Mac, `CTRL + K` for others) to focus the search input, and a handler for inserting spaces with `Shift+Space` (`handleKeyDown` and `handleShiftSpace` in `index.vue`).
* Registered and cleaned up global keyboard event listeners for shortcut handling during component mount and unmount (`onMounted` and `onBeforeUnmount` in `index.vue`). [[1]](diffhunk://#diff-f7376202070254fde4e89ddad980e4fa38d0c24a4a423bb73a08543cca092024R207-R210) [[2]](diffhunk://#diff-f7376202070254fde4e89ddad980e4fa38d0c24a4a423bb73a08543cca092024R221-R222)

**Platform Detection:**

* Added logic to detect if the user is on a Mac to display the appropriate shortcut hint (`isMac` in `index.vue`).