### PR TITLE
Feat: Conditional rendering of temporary chat save button

### DIFF
--- a/ui/components/ui/chat/chatBox.vue
+++ b/ui/components/ui/chat/chatBox.vue
@@ -237,6 +237,7 @@ onUnmounted(() => {
             <UiChatHeader
                 :model-select-disabled="selectedNodeType?.nodeType !== NodeTypeEnum.TEXT_TO_TEXT"
                 :is-temporary="isTemporaryGraph"
+                :is-empty="session.messages.length === 0"
                 @close="closeChatHandler"
                 @save="handleSaveTemporaryGraph"
             />

--- a/ui/components/ui/chat/header.vue
+++ b/ui/components/ui/chat/header.vue
@@ -4,6 +4,7 @@ const emit = defineEmits(['close', 'save']);
 defineProps<{
     modelSelectDisabled: boolean;
     isTemporary: boolean;
+    isEmpty: boolean;
 }>();
 
 // --- Stores ---
@@ -37,7 +38,7 @@ const { currentModel } = storeToRefs(chatStore);
         <div class="flex items-center justify-center justify-self-end">
             <!-- Save Button -->
             <button
-                v-if="isTemporary"
+                v-if="isTemporary && !isEmpty"
                 class="hover:bg-obsidian/30 bg-obsidian/20 text-soft-silk/80 flex h-10 w-fit items-center justify-center
                     gap-2 rounded-full p-1 px-4 transition-colors duration-200 ease-in-out hover:cursor-pointer"
                 title="Save Conversation"


### PR DESCRIPTION
This pull request updates the chat header component to improve the user experience when saving conversations. The main change ensures that the "Save" button is only visible when there are messages in a temporary chat session, preventing users from attempting to save empty conversations.

UI behavior improvements:

* The `UiChatHeader` component now receives an `is-empty` prop, which is set to `true` when the chat session has no messages.
* The `header.vue` component adds a new `isEmpty` prop to control UI logic.
* The "Save" button is now only displayed when the chat is temporary and not empty, hiding it for empty conversations.