### PR TITLE
fix: Passlib 1.7.4 + bcrypt 5.0.0 incompatibility

### DIFF
--- a/api/app/services/crypto.py
+++ b/api/app/services/crypto.py
@@ -3,7 +3,6 @@ import os
 
 import bcrypt
 from Crypto.Cipher import AES
-from passlib.context import CryptContext
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -83,14 +82,16 @@ def decrypt_api_key(db_payload: str) -> str | None:
         return None
 
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verifies a plain password against a hashed one."""
-    return bool(pwd_context.verify(plain_password, hashed_password))
+    return bool(
+        bcrypt.checkpw(
+            plain_password.encode("utf-8"),
+            hashed_password.encode("utf-8"),
+        )
+    )
 
 
 def get_password_hash(password: str) -> str:
     """Hashes a plain password."""
-    return str(pwd_context.hash(password))
+    return str(bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8"))

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,7 +6,7 @@ neo4j
 pybase64
 pycryptodome
 python-jose[cryptography]
-passlib[bcrypt]
+bcrypt
 alembic
 sentry-sdk[fastapi]
 redis


### PR DESCRIPTION
This pull request refactors password hashing and verification in the `crypto.py` service to remove the dependency on `passlib` and use the `bcrypt` library directly. This change streamlines password management and updates the requirements accordingly.

Password management refactor:

* Replaced usage of `passlib` for password hashing and verification with direct calls to the `bcrypt` library in `verify_password` and `get_password_hash` functions in `crypto.py`.
* Removed the initialization of `CryptContext` and the import of `passlib.context` from `crypto.py`.

Dependency updates:

* Removed `passlib[bcrypt]` and added `bcrypt` to `requirements.txt` to reflect the new dependency.