### PR TITLE
Update 1.5.2-beta

### DIFF
--- a/api/app/services/openai_codex.py
+++ b/api/app/services/openai_codex.py
@@ -47,6 +47,8 @@ from services.providers.common import (
 from services.providers.openai_codex_catalog import (
     OPENAI_CODEX_MODEL_PREFIX,
     OPENAI_CODEX_PROVIDER_KEY,
+    build_openai_codex_image_generation_model,
+    get_openai_codex_base_model_id,
     normalize_openai_codex_model,
 )
 from services.providers.tool_continuation import persist_pending_tool_continuation
@@ -67,6 +69,7 @@ OPENAI_CODEX_RPC_TIMEOUT_SECONDS = 30.0
 OPENAI_CODEX_TURN_TIMEOUT_SECONDS = 300.0
 OPENAI_CODEX_FALLBACK_USER_CONTENT = "Please respond to the available context."
 OPENAI_CODEX_STDERR_MAX_LINES = 200
+OPENAI_CODEX_STDIO_LIMIT_BYTES = 128 * 1024 * 1024
 OPENAI_CODEX_MAX_DATA_URI_BYTES = 20 * 1024 * 1024
 OPENAI_CODEX_MAX_DATA_URI_BASE64_CHARS = ((OPENAI_CODEX_MAX_DATA_URI_BYTES + 2) // 3) * 4
 OPENAI_CODEX_CONFIG_TOML = """cli_auth_credentials_store = \"file\"
@@ -487,8 +490,175 @@ async def _write_local_image_input(
     return file_path
 
 
-def _build_codex_config_toml(model_instructions_path: Path | None = None) -> str:
+@dataclass(frozen=True)
+class OpenAICodexGeneratedImage:
+    image_bytes: bytes
+    extension: str
+    model: str
+
+
+def _extract_generated_image_payload(item: dict[str, Any]) -> tuple[bytes, str] | None:
+    saved_path = item.get("savedPath") or item.get("saved_path")
+    if saved_path:
+        image_path = Path(str(saved_path))
+        if image_path.is_file():
+            extension = image_path.suffix.lstrip(".").lower() or "png"
+            return image_path.read_bytes(), extension
+
+    result = str(item.get("result") or "").strip()
+    if not result:
+        return None
+
+    extension = "png"
+    if result.startswith("data:"):
+        header, result = result.split(",", 1)
+        if "jpeg" in header or "jpg" in header:
+            extension = "jpg"
+        elif "webp" in header:
+            extension = "webp"
+
+    return base64.b64decode(re.sub(r"\s+", "", result), validate=True), extension
+
+
+def _extract_completed_image_generation_item(event: dict[str, Any]) -> dict[str, Any] | None:
+    if str(event.get("method") or "") != "item/completed":
+        return None
+
+    params = event.get("params")
+    if not isinstance(params, dict):
+        return None
+    item = params.get("item")
+    if not isinstance(item, dict):
+        return None
+
+    item_type = str(item.get("type") or "").strip()
+    if item_type not in {"ImageGeneration", "imageGeneration", "image_generation"}:
+        return None
+
+    return item
+
+
+def _summarize_codex_image_generation_item(item: dict[str, Any]) -> dict[str, Any]:
+    result = str(item.get("result") or "")
+    saved_path = item.get("savedPath") or item.get("saved_path")
+    summary: dict[str, Any] = {
+        "id": item.get("id"),
+        "type": item.get("type"),
+        "status": item.get("status"),
+        "has_result": bool(result),
+        "result_length": len(result),
+        "has_saved_path": bool(saved_path),
+        "saved_path_exists": Path(str(saved_path)).is_file() if saved_path else False,
+        "keys": sorted(str(key) for key in item.keys()),
+    }
+    for key in ("error", "message", "failure", "revisedPrompt", "revised_prompt"):
+        value = item.get(key)
+        if value:
+            summary[key] = str(value)[:500]
+    return summary
+
+
+def _summarize_codex_turn_items(items: Any) -> list[dict[str, Any]]:
+    if not isinstance(items, list):
+        return []
+
+    summarized_items: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        summarized_items.append(
+            {
+                "id": item.get("id"),
+                "type": item.get("type"),
+                "status": item.get("status"),
+                "keys": sorted(str(key) for key in item.keys()),
+            }
+        )
+    return summarized_items
+
+
+def _find_completed_image_generation_item(items: Any) -> dict[str, Any] | None:
+    if not isinstance(items, list):
+        return None
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type") or "").strip()
+        if item_type in {"ImageGeneration", "imageGeneration", "image_generation"}:
+            return item
+    return None
+
+
+async def _build_image_generation_turn_input(
+    message_content: str | list[dict[str, Any]],
+    *,
+    runtime_context: OpenAICodexRuntimeContext,
+    aspect_ratio: str,
+    resolution: str,
+    http_client: Optional[httpx.AsyncClient],
+) -> list[dict[str, Any]]:
+    content_items = (
+        [{"type": "text", "text": message_content}]
+        if isinstance(message_content, str)
+        else message_content
+    )
+    input_items: list[dict[str, Any]] = []
+    image_index = 0
+
+    for item in content_items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text":
+            input_items.append({"type": "text", "text": str(item.get("text") or "")})
+            continue
+        if item.get("type") != "image_url":
+            continue
+        image_payload = item.get("image_url")
+        if not isinstance(image_payload, dict):
+            continue
+        image_url = str(image_payload.get("url") or "").strip()
+        if not image_url:
+            continue
+        image_index += 1
+        local_image_path = await _write_local_image_input(
+            image_url,
+            input_dir=runtime_context.input_dir,
+            image_index=image_index,
+            http_client=http_client,
+        )
+        input_items.append({"type": "localImage", "path": str(local_image_path)})
+
+    prompt_suffix = (
+        "\n\nUse the built-in image_generation tool exactly once. "
+        "Generate one PNG image only. "
+        f"Aspect ratio: {aspect_ratio}. Target resolution: {resolution}. "
+        "Do not create SVG, HTML, code, or text-only output."
+    )
+    if input_items and input_items[0].get("type") == "text":
+        input_items[0]["text"] = f"{input_items[0].get('text')}{prompt_suffix}"
+    else:
+        input_items.insert(0, {"type": "text", "text": prompt_suffix.strip()})
+
+    return input_items
+
+
+def _build_codex_config_toml(
+    model_instructions_path: Path | None = None,
+    *,
+    enable_image_generation: bool = False,
+) -> str:
     config_toml = OPENAI_CODEX_CONFIG_TOML
+    if enable_image_generation:
+        config_toml = config_toml.replace(
+            "[features]\n",
+            "[features]\nimage_generation = true\n",
+            1,
+        ).replace(
+            "[tools.image_generation]\nenabled = false",
+            "[tools.image_generation]\nenabled = true",
+            1,
+        )
     if model_instructions_path is not None:
         config_toml = (
             f"model_instructions_file = {json.dumps(str(model_instructions_path))}\n\n"
@@ -519,6 +689,7 @@ def _build_runtime_context(
     auth_json: str,
     *,
     model_instructions: str | None = None,
+    enable_image_generation: bool = False,
 ) -> OpenAICodexRuntimeContext:
     layout = build_runtime_directory_layout(
         OPENAI_CODEX_RUNTIME_ROOT,
@@ -538,10 +709,16 @@ def _build_runtime_context(
         write_private_file(model_instructions_path, normalized_model_instructions + "\n")
         write_private_file(
             config_toml_path,
-            _build_codex_config_toml(model_instructions_path),
+            _build_codex_config_toml(
+                model_instructions_path,
+                enable_image_generation=enable_image_generation,
+            ),
         )
     else:
-        write_private_file(config_toml_path, _build_codex_config_toml())
+        write_private_file(
+            config_toml_path,
+            _build_codex_config_toml(enable_image_generation=enable_image_generation),
+        )
 
     return OpenAICodexRuntimeContext(
         root_dir=layout.root_dir,
@@ -612,6 +789,7 @@ async def _start_codex_client(
             stderr=asyncio.subprocess.PIPE,
             cwd=str(runtime_context.cwd),
             env=build_subprocess_env(runtime_context.env),
+            limit=OPENAI_CODEX_STDIO_LIMIT_BYTES,
         )
     except FileNotFoundError as exc:
         raise ValueError(
@@ -745,6 +923,11 @@ async def list_openai_codex_models(
             normalized_models.append(normalized_model)
 
         normalized_models.sort(key=lambda m: m.id, reverse=True)
+        if normalized_models:
+            normalized_models.insert(
+                0,
+                build_openai_codex_image_generation_model(normalized_models[0]),
+            )
 
         return normalized_models
     finally:
@@ -1513,6 +1696,145 @@ async def _run_openai_codex_turn(
         usage_data_sink=usage_data_sink,
         pending_tool_call_id_sink=pending_tool_call_id_sink,
     ).run()
+
+
+async def generate_image_with_openai_codex(
+    *,
+    auth_json: str,
+    model: str,
+    message_content: str | list[dict[str, Any]],
+    aspect_ratio: str,
+    resolution: str,
+    http_client: Optional[httpx.AsyncClient],
+) -> OpenAICodexGeneratedImage:
+    normalized_auth_json = _normalize_auth_json(auth_json)
+    runtime_context = _build_runtime_context(
+        normalized_auth_json,
+        enable_image_generation=True,
+    )
+    heartbeat_task = start_runtime_heartbeat(runtime_context.root_dir)
+    client: _CodexAppServerClient | None = None
+
+    try:
+        client = await _start_codex_client(runtime_context)
+        await _ensure_openai_auth(client, refresh_token=True)
+        thread_result = await client.request(
+            "thread/start",
+            {
+                "model": strip_model_prefix(
+                    get_openai_codex_base_model_id(model),
+                    OPENAI_CODEX_MODEL_PREFIX,
+                ),
+                "cwd": str(runtime_context.cwd),
+                "approvalPolicy": "never",
+                "sandboxPolicy": {"type": "readOnly"},
+                "serviceName": "meridian",
+                "dynamicTools": [],
+            },
+        )
+        thread_payload = thread_result.get("thread")
+        if not isinstance(thread_payload, dict) or not thread_payload.get("id"):
+            raise ValueError("OpenAI Codex failed to start an image generation thread.")
+
+        turn_input = await _build_image_generation_turn_input(
+            message_content,
+            runtime_context=runtime_context,
+            aspect_ratio=aspect_ratio,
+            resolution=resolution,
+            http_client=http_client,
+        )
+        turn_result = await client.request(
+            "turn/start",
+            {"threadId": str(thread_payload["id"]), "input": turn_input},
+        )
+        turn_payload = turn_result.get("turn")
+        if not isinstance(turn_payload, dict) or not turn_payload.get("id"):
+            raise ValueError("OpenAI Codex failed to start an image generation turn.")
+        turn_id = str(turn_payload["id"])
+
+        while True:
+            event = await client.next_event(timeout=OPENAI_CODEX_TURN_TIMEOUT_SECONDS)
+            image_item = _extract_completed_image_generation_item(event)
+            if image_item is not None:
+                logger.info(
+                    "OpenAI Codex image generation item completed: %s",
+                    _summarize_codex_image_generation_item(image_item),
+                )
+                status = str(image_item.get("status") or "").strip().lower()
+                generated_payload = _extract_generated_image_payload(image_item)
+                if generated_payload is not None:
+                    image_bytes, extension = generated_payload
+                    logger.info(
+                        "OpenAI Codex image generation returned %s bytes as %s with status %s.",
+                        len(image_bytes),
+                        extension,
+                        status or "unknown",
+                    )
+                    return OpenAICodexGeneratedImage(
+                        image_bytes=image_bytes,
+                        extension=extension,
+                        model=model,
+                    )
+                if status not in {"completed", "succeeded", "success"}:
+                    logger.warning(
+                        "OpenAI Codex image generation failed with status %s; stderr=%s",
+                        status or "unknown",
+                        client.stderr_text,
+                    )
+                    raise ValueError(
+                        f"OpenAI Codex image generation failed with status {status or 'unknown'}."
+                    )
+                else:
+                    logger.warning(
+                        "OpenAI Codex image generation returned no image payload; "
+                        "item=%s; stderr=%s",
+                        _summarize_codex_image_generation_item(image_item),
+                        client.stderr_text,
+                    )
+                    raise ValueError("OpenAI Codex returned no image data.")
+
+            if str(event.get("method") or "") != "turn/completed":
+                continue
+            params = event.get("params")
+            params_dict = params if isinstance(params, dict) else {}
+            completed_turn = params_dict.get("turn")
+            if (
+                not isinstance(completed_turn, dict)
+                or str(completed_turn.get("id") or "") != turn_id
+            ):
+                continue
+            image_item = _find_completed_image_generation_item(completed_turn.get("items"))
+            if image_item is not None:
+                logger.info(
+                    "OpenAI Codex turn completed with image item: %s",
+                    _summarize_codex_image_generation_item(image_item),
+                )
+                generated_payload = _extract_generated_image_payload(image_item)
+                if generated_payload is not None:
+                    image_bytes, extension = generated_payload
+                    logger.info(
+                        "OpenAI Codex image generation returned %s bytes as %s from turn payload.",
+                        len(image_bytes),
+                        extension,
+                    )
+                    return OpenAICodexGeneratedImage(
+                        image_bytes=image_bytes,
+                        extension=extension,
+                        model=model,
+                    )
+            logger.warning(
+                "OpenAI Codex image generation turn completed without image payload; "
+                "turn_status=%s; items=%s; stderr=%s",
+                completed_turn.get("status") if isinstance(completed_turn, dict) else None,
+                _summarize_codex_turn_items(completed_turn.get("items")),
+                client.stderr_text,
+            )
+            raise ValueError("OpenAI Codex completed without returning an image.")
+    finally:
+        if client is not None:
+            await client.close()
+        await stop_runtime_heartbeat(heartbeat_task)
+        _cleanup_runtime_context(runtime_context)
 
 
 async def make_openai_codex_request_non_streaming(

--- a/api/app/services/opencode_go.py
+++ b/api/app/services/opencode_go.py
@@ -55,6 +55,10 @@ OPENCODE_GO_VALIDATION_MODEL = f"{OPENCODE_GO_MODEL_PREFIX}qwen3.5-plus"
 OPENCODE_GO_NON_STREAMING_TIMEOUT = httpx.Timeout(300.0, connect=10.0, read=300.0)
 OPENCODE_GO_ANTHROPIC_VERSION = "2023-06-01"
 OPENCODE_GO_FALLBACK_USER_CONTENT = "Please respond to the available context."
+OPENCODE_GO_REASONING_CONTENT_MODEL_IDS = {
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+}
 
 
 def _normalize_selected_tool_names(selected_tools: list[Any]) -> list[str]:
@@ -96,6 +100,13 @@ def _build_opencode_go_authoritative_system_prompt(
 
 def _uses_anthropic_protocol(model_id: str) -> bool:
     return strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX) in OPENCODE_GO_ANTHROPIC_MODEL_IDS
+
+
+def _requires_reasoning_content_round_trip(model_id: str) -> bool:
+    return (
+        strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX)
+        in OPENCODE_GO_REASONING_CONTENT_MODEL_IDS
+    )
 
 
 def _build_anthropic_tools(tool_definitions: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -243,6 +254,7 @@ class OpenCodeGoReqChat(BaseProviderReq, OpenCodeGoReq):
         raw_messages = [
             normalize_openai_request_message(
                 message,
+                include_reasoning_content=_requires_reasoning_content_round_trip(self.model),
                 include_tool_name=True,
                 strip_text=False,
             )
@@ -254,6 +266,7 @@ class OpenCodeGoReqChat(BaseProviderReq, OpenCodeGoReq):
             raw_messages,
             fallback_user_content=OPENCODE_GO_FALLBACK_USER_CONTENT,
             provider_label="OpenCode Go",
+            preserve_empty_reasoning_content=_requires_reasoning_content_round_trip(self.model),
         )
         authoritative_system_prompt = _build_opencode_go_authoritative_system_prompt(
             (
@@ -539,6 +552,7 @@ async def _stream_opencode_go_openai_response(
         error_parser=_parse_openrouter_error,
         final_data_container=final_data_container,
         span_description="Stream OpenCode Go response",
+        preserve_reasoning_content=_requires_reasoning_content_round_trip(req.model),
     ):
         yield chunk
 

--- a/api/app/services/opencode_go.py
+++ b/api/app/services/opencode_go.py
@@ -58,6 +58,8 @@ OPENCODE_GO_FALLBACK_USER_CONTENT = "Please respond to the available context."
 OPENCODE_GO_REASONING_CONTENT_MODEL_IDS = {
     "deepseek-v4-pro",
     "deepseek-v4-flash",
+    "kimi-k2.5",
+    "kimi-k2.6",
 }
 
 

--- a/api/app/services/opencode_go.py
+++ b/api/app/services/opencode_go.py
@@ -36,6 +36,7 @@ from services.providers.openai_protocol import (
 )
 from services.providers.opencode_go_catalog import (
     OPENCODE_GO_ANTHROPIC_MODEL_IDS,
+    OPENCODE_GO_IMAGE_INPUT_MODEL_IDS,
     OPENCODE_GO_MODEL_PREFIX,
 )
 from services.tools import get_openrouter_tools
@@ -102,6 +103,12 @@ def _build_opencode_go_authoritative_system_prompt(
 
 def _uses_anthropic_protocol(model_id: str) -> bool:
     return strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX) in OPENCODE_GO_ANTHROPIC_MODEL_IDS
+
+
+def _supports_image_inputs(model_id: str) -> bool:
+    return (
+        strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX) in OPENCODE_GO_IMAGE_INPUT_MODEL_IDS
+    )
 
 
 def _requires_reasoning_content_round_trip(model_id: str) -> bool:
@@ -239,8 +246,8 @@ class OpenCodeGoReqChat(BaseProviderReq, OpenCodeGoReq):
                 "OpenCode Go models do not support file or PDF attachments in Meridian yet."
             )
 
-        if has_image_inputs(self.messages):
-            raise ValueError("OpenCode Go models do not support image inputs in Meridian yet.")
+        if has_image_inputs(self.messages) and not _supports_image_inputs(self.model):
+            raise ValueError("This OpenCode Go model does not support image inputs.")
 
         if not self.stream and self.selected_tools:
             raise ValueError("OpenCode Go tool execution requires streaming mode.")
@@ -258,6 +265,7 @@ class OpenCodeGoReqChat(BaseProviderReq, OpenCodeGoReq):
                 message,
                 include_reasoning_content=_requires_reasoning_content_round_trip(self.model),
                 include_tool_name=True,
+                preserve_content_parts=_supports_image_inputs(self.model),
                 strip_text=False,
             )
             for message in self.messages
@@ -269,6 +277,7 @@ class OpenCodeGoReqChat(BaseProviderReq, OpenCodeGoReq):
             fallback_user_content=OPENCODE_GO_FALLBACK_USER_CONTENT,
             provider_label="OpenCode Go",
             preserve_empty_reasoning_content=_requires_reasoning_content_round_trip(self.model),
+            preserve_content_parts=_supports_image_inputs(self.model),
         )
         authoritative_system_prompt = _build_opencode_go_authoritative_system_prompt(
             (

--- a/api/app/services/opencode_go.py
+++ b/api/app/services/opencode_go.py
@@ -718,7 +718,7 @@ class _OpenCodeGoAnthropicEventDispatcher:
 
 
 def _parse_anthropic_sse_event(raw_event: str) -> tuple[str, str, dict[str, Any] | None]:
-    event_type = "message"
+    event_type: str | None = None
     data_lines: list[str] = []
     for raw_line in raw_event.splitlines():
         line = raw_line.strip()
@@ -727,15 +727,18 @@ def _parse_anthropic_sse_event(raw_event: str) -> tuple[str, str, dict[str, Any]
         elif line.startswith("data:"):
             data_lines.append(line[len("data:") :].strip())
 
-    data_str = "\n".join(data_lines).strip()
+    data_str = "\n".join(data_lines).strip() if data_lines else raw_event.strip()
     if not data_str:
-        return event_type, data_str, None
+        return event_type or "message", data_str, None
 
     try:
         event_payload = json.loads(data_str)
     except json.JSONDecodeError:
-        return event_type, data_str, None
-    return event_type, data_str, event_payload if isinstance(event_payload, dict) else None
+        return event_type or "message", data_str, None
+    if not isinstance(event_payload, dict):
+        return event_type or "message", data_str, None
+
+    return event_type or str(event_payload.get("type") or "message"), data_str, event_payload
 
 
 async def _stream_opencode_go_anthropic_response(

--- a/api/app/services/openrouter.py
+++ b/api/app/services/openrouter.py
@@ -376,6 +376,8 @@ async def _process_tool_calls_and_continue(
     redis_manager: RedisManager,
     reasoning_details=None,
     assistant_content=None,
+    reasoning_content: str | None = None,
+    require_reasoning_content: bool = False,
 ):
     """
     Process tool calls, generate feedback strings, and prepare for the next iteration of
@@ -406,6 +408,8 @@ async def _process_tool_calls_and_continue(
     # If we captured reasoning details (containing signatures), pass them back
     if merged_reasoning_details:
         assistant_message["reasoning_details"] = merged_reasoning_details
+    if reasoning_content is not None or require_reasoning_content:
+        assistant_message["reasoning_content"] = reasoning_content or ""
 
     messages.append(assistant_message)
 

--- a/api/app/services/provider_image_generation.py
+++ b/api/app/services/provider_image_generation.py
@@ -153,8 +153,27 @@ async def generate_image_with_provider(
             "Gemini CLI models do not support direct image generation."
         )
     if provider == InferenceProviderEnum.OPENAI_CODEX:
-        raise ImageGenerationProviderError(
-            "OpenAI Codex models do not support direct image generation."
+        if not credentials.openai_codex_auth_json:
+            raise ImageGenerationProviderError(
+                "OpenAI Codex is not connected for image generation."
+            )
+        from services.openai_codex import generate_image_with_openai_codex
+
+        try:
+            generated_image = await generate_image_with_openai_codex(
+                auth_json=credentials.openai_codex_auth_json,
+                model=model,
+                message_content=message_content,
+                aspect_ratio=aspect_ratio,
+                resolution=resolution,
+                http_client=http_client,
+            )
+        except Exception as exc:
+            raise ImageGenerationProviderError(str(exc)) from exc
+        return GeneratedImageResult(
+            image_bytes=generated_image.image_bytes,
+            extension=generated_image.extension,
+            model=generated_image.model,
         )
     return await _generate_image_with_openrouter(
         credentials=credentials,

--- a/api/app/services/providers/openai_codex_catalog.py
+++ b/api/app/services/providers/openai_codex_catalog.py
@@ -11,9 +11,20 @@ from services.providers.common import MERIDIAN_SUPPORTED_TOOL_NAMES
 
 OPENAI_CODEX_PROVIDER_KEY = "openai_codex.auth_json"
 OPENAI_CODEX_MODEL_PREFIX = "openai-codex/"
+OPENAI_CODEX_IMAGE_GENERATION_MODEL_SUFFIX = ":image-generation"
 OPENAI_CODEX_LABEL = "OpenAI Codex"
 OPENAI_CODEX_SUPPORTED_TOOL_NAMES = list(MERIDIAN_SUPPORTED_TOOL_NAMES)
 OPENAI_CODEX_DEFAULT_INPUT_MODALITIES = ["text", "image"]
+
+
+def is_openai_codex_image_generation_model(model_id: str) -> bool:
+    return model_id.endswith(OPENAI_CODEX_IMAGE_GENERATION_MODEL_SUFFIX)
+
+
+def get_openai_codex_base_model_id(model_id: str) -> str:
+    if is_openai_codex_image_generation_model(model_id):
+        return model_id[: -len(OPENAI_CODEX_IMAGE_GENERATION_MODEL_SUFFIX)]
+    return model_id
 
 
 def _normalize_input_modalities(input_modalities: Any) -> list[str]:
@@ -82,4 +93,25 @@ def normalize_openai_codex_model(payload: Any) -> ModelInfo | None:
         supportsMeridianTools=True,
         supportedMeridianToolNames=list(OPENAI_CODEX_SUPPORTED_TOOL_NAMES),
         toolsSupport=True,
+    )
+
+
+def build_openai_codex_image_generation_model(base_model: ModelInfo) -> ModelInfo:
+    return base_model.model_copy(
+        deep=True,
+        update={
+            "id": f"{base_model.id}{OPENAI_CODEX_IMAGE_GENERATION_MODEL_SUFFIX}",
+            "name": "Codex Image Generation",
+            "architecture": Architecture(
+                input_modalities=list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
+                modality="text + image->image",
+                output_modalities=["image"],
+                tokenizer=base_model.architecture.tokenizer,
+            ),
+            "pricing": Pricing(prompt="0", completion="0", image="0"),
+            "supportsStructuredOutputs": False,
+            "supportsMeridianTools": False,
+            "supportedMeridianToolNames": [],
+            "toolsSupport": False,
+        },
     )

--- a/api/app/services/providers/openai_protocol.py
+++ b/api/app/services/providers/openai_protocol.py
@@ -49,7 +49,7 @@ def normalize_openai_request_message(
             normalized["tool_calls"] = tool_calls
         if include_reasoning_content:
             reasoning_content = message.get("reasoning_content")
-            if isinstance(reasoning_content, str) and reasoning_content:
+            if isinstance(reasoning_content, str):
                 normalized["reasoning_content"] = reasoning_content
 
     if role == "tool":
@@ -70,6 +70,7 @@ def sanitize_openai_messages(
     fallback_user_content: str,
     provider_label: str,
     tool_call_placeholder_content: str | None = None,
+    preserve_empty_reasoning_content: bool = False,
 ) -> list[dict[str, Any]]:
     sanitized: list[dict[str, Any]] = []
     leading_system_message: dict[str, Any] | None = None
@@ -110,7 +111,9 @@ def sanitize_openai_messages(
                 "role": "assistant",
                 "content": content,
             }
-            if isinstance(reasoning_content, str) and reasoning_content:
+            if isinstance(reasoning_content, str) and (
+                reasoning_content or preserve_empty_reasoning_content
+            ):
                 normalized_assistant["reasoning_content"] = reasoning_content
 
             next_pending_tool_call_ids: set[str] = set()
@@ -202,6 +205,7 @@ async def stream_openai_compatible_response(
     final_data_container: Optional[dict[str, Any]] = None,
     span_description: str,
     on_rejected_request: Callable[[Any], None] | None = None,
+    preserve_reasoning_content: bool = False,
 ) -> AsyncIterator[str]:
     client = req.http_client
     if client is None:
@@ -219,6 +223,7 @@ async def stream_openai_compatible_response(
             round_usage_data: dict[str, Any] | None = None
             round_request_id: str | None = None
             native_finish_reason: str | None = None
+            round_reasoning_content = ""
             payload = req.get_payload()
 
             async with client.stream(
@@ -273,6 +278,10 @@ async def stream_openai_compatible_response(
                         if isinstance(tool_calls, list):
                             tool_call_chunks.extend(tool_calls)
 
+                        reasoning_delta = delta.get("reasoning_content") or delta.get("reasoning")
+                        if preserve_reasoning_content and reasoning_delta:
+                            round_reasoning_content += str(reasoning_delta)
+
                         if choice.get("finish_reason") == "tool_calls":
                             if thinking_started:
                                 yield "\n[!THINK]\n"
@@ -319,6 +328,10 @@ async def stream_openai_compatible_response(
                     req,
                     redis_manager,
                     assistant_content=clean_content if clean_content else None,
+                    reasoning_content=(
+                        round_reasoning_content if preserve_reasoning_content else None
+                    ),
+                    require_reasoning_content=preserve_reasoning_content,
                 )
                 messages = continuation.messages
                 req = continuation.req

--- a/api/app/services/providers/openai_protocol.py
+++ b/api/app/services/providers/openai_protocol.py
@@ -3,6 +3,7 @@ import json
 import logging
 from asyncio import TimeoutError as AsyncTimeoutError
 from collections.abc import AsyncIterator, Callable
+from enum import Enum
 from typing import Any, Optional
 
 import httpx
@@ -32,6 +33,7 @@ def normalize_openai_request_message(
     *,
     include_reasoning_content: bool = False,
     include_tool_name: bool = False,
+    preserve_content_parts: bool = False,
     strip_text: bool = False,
 ) -> dict[str, Any]:
     role = normalize_role_value(message.get("role"))
@@ -40,7 +42,9 @@ def normalize_openai_request_message(
     if "content" in message:
         content = message.get("content")
         normalized["content"] = (
-            content if isinstance(content, str) else extract_text_content(content, strip=strip_text)
+            content
+            if isinstance(content, str) or (preserve_content_parts and isinstance(content, list))
+            else extract_text_content(content, strip=strip_text)
         )
 
     if role == "assistant":
@@ -71,6 +75,7 @@ def sanitize_openai_messages(
     provider_label: str,
     tool_call_placeholder_content: str | None = None,
     preserve_empty_reasoning_content: bool = False,
+    preserve_content_parts: bool = False,
 ) -> list[dict[str, Any]]:
     sanitized: list[dict[str, Any]] = []
     leading_system_message: dict[str, Any] | None = None
@@ -91,12 +96,15 @@ def sanitize_openai_messages(
             continue
 
         if role == "user":
-            content = str(message.get("content") or "").strip()
-            if not content:
+            user_content = _sanitize_openai_user_content(
+                message.get("content"),
+                preserve_content_parts=preserve_content_parts,
+            )
+            if user_content is None:
                 continue
             seen_user_message = True
             pending_tool_call_ids.clear()
-            sanitized.append({"role": "user", "content": content})
+            sanitized.append({"role": "user", "content": user_content})
             continue
 
         if not seen_user_message:
@@ -161,6 +169,39 @@ def sanitize_openai_messages(
         sanitized.append({"role": "user", "content": fallback_user_content})
 
     return sanitized
+
+
+def _sanitize_openai_user_content(
+    content: Any,
+    *,
+    preserve_content_parts: bool,
+) -> str | list[dict[str, Any]] | None:
+    if preserve_content_parts and isinstance(content, list):
+        parts: list[dict[str, Any]] = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = _normalize_content_part_type(item.get("type"))
+            if item_type == "text":
+                text = str(item.get("text") or "")
+                if text.strip():
+                    parts.append({"type": "text", "text": text})
+                continue
+            if item_type == "image_url":
+                image_url = item.get("image_url")
+                if isinstance(image_url, dict) and str(image_url.get("url") or "").strip():
+                    parts.append({"type": "image_url", "image_url": image_url})
+
+        return parts or None
+
+    text_content = str(content or "").strip()
+    return text_content or None
+
+
+def _normalize_content_part_type(value: Any) -> str:
+    if isinstance(value, Enum):
+        return str(value.value or "").strip()
+    return str(value or "").strip()
 
 
 async def iter_openai_sse_payloads(

--- a/api/app/services/providers/opencode_go_catalog.py
+++ b/api/app/services/providers/opencode_go_catalog.py
@@ -22,13 +22,33 @@ class OpenCodeGoModelDefinition(TypedDict):
     context_length: int
 
 
+# https://opencode.ai/docs/en/go/#endpoints
 OPENCODE_GO_MODEL_DEFINITIONS: list[OpenCodeGoModelDefinition] = [
     {"id": "glm-5", "name": "GLM-5", "protocol": "openai", "context_length": 203000},
     {"id": "glm-5.1", "name": "GLM-5.1", "protocol": "openai", "context_length": 203000},
     {"id": "kimi-k2.5", "name": "Kimi K2.5", "protocol": "openai", "context_length": 256000},
     {"id": "kimi-k2.6", "name": "Kimi K2.6", "protocol": "openai", "context_length": 256000},
-    {"id": "mimo-v2-pro", "name": "MiMo-V2-Pro", "protocol": "openai", "context_length": 1000000},
+    {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "protocol": "anthropic",
+        "context_length": 1048576,
+    },
+    {
+        "id": "deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "protocol": "anthropic",
+        "context_length": 1048576,
+    },
+    {"id": "mimo-v2-pro", "name": "MiMo-V2-Pro", "protocol": "openai", "context_length": 1048576},
     {"id": "mimo-v2-omni", "name": "MiMo-V2-Omni", "protocol": "openai", "context_length": 256000},
+    {
+        "id": "mimo-v2.5-pro",
+        "name": "MiMo-V2.5-Pro",
+        "protocol": "openai",
+        "context_length": 1048576,
+    },
+    {"id": "mimo-v2.5", "name": "MiMo-V2.5", "protocol": "openai", "context_length": 1048576},
     {
         "id": "minimax-m2.5",
         "name": "MiniMax M2.5",

--- a/api/app/services/providers/opencode_go_catalog.py
+++ b/api/app/services/providers/opencode_go_catalog.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 from models.inference import (
     Architecture,
@@ -20,14 +20,27 @@ class OpenCodeGoModelDefinition(TypedDict):
     name: str
     protocol: Literal["anthropic", "openai"]
     context_length: int
+    input_modalities: NotRequired[list[str]]
 
 
 # https://opencode.ai/docs/en/go/#endpoints
 OPENCODE_GO_MODEL_DEFINITIONS: list[OpenCodeGoModelDefinition] = [
     {"id": "glm-5", "name": "GLM-5", "protocol": "openai", "context_length": 203000},
     {"id": "glm-5.1", "name": "GLM-5.1", "protocol": "openai", "context_length": 203000},
-    {"id": "kimi-k2.5", "name": "Kimi K2.5", "protocol": "openai", "context_length": 256000},
-    {"id": "kimi-k2.6", "name": "Kimi K2.6", "protocol": "openai", "context_length": 256000},
+    {
+        "id": "kimi-k2.5",
+        "name": "Kimi K2.5",
+        "protocol": "openai",
+        "context_length": 256000,
+        "input_modalities": ["text", "image"],
+    },
+    {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "protocol": "openai",
+        "context_length": 256000,
+        "input_modalities": ["text", "image"],
+    },
     {
         "id": "deepseek-v4-pro",
         "name": "DeepSeek V4 Pro",
@@ -41,14 +54,26 @@ OPENCODE_GO_MODEL_DEFINITIONS: list[OpenCodeGoModelDefinition] = [
         "context_length": 1048576,
     },
     {"id": "mimo-v2-pro", "name": "MiMo-V2-Pro", "protocol": "openai", "context_length": 1048576},
-    {"id": "mimo-v2-omni", "name": "MiMo-V2-Omni", "protocol": "openai", "context_length": 256000},
+    {
+        "id": "mimo-v2-omni",
+        "name": "MiMo-V2-Omni",
+        "protocol": "openai",
+        "context_length": 256000,
+        "input_modalities": ["text", "image"],
+    },
     {
         "id": "mimo-v2.5-pro",
         "name": "MiMo-V2.5-Pro",
         "protocol": "openai",
         "context_length": 1048576,
     },
-    {"id": "mimo-v2.5", "name": "MiMo-V2.5", "protocol": "openai", "context_length": 1048576},
+    {
+        "id": "mimo-v2.5",
+        "name": "MiMo-V2.5",
+        "protocol": "openai",
+        "context_length": 1048576,
+        "input_modalities": ["text", "image"],
+    },
     {
         "id": "minimax-m2.5",
         "name": "MiniMax M2.5",
@@ -62,7 +87,13 @@ OPENCODE_GO_MODEL_DEFINITIONS: list[OpenCodeGoModelDefinition] = [
         "context_length": 204800,
     },
     {"id": "qwen3.5-plus", "name": "Qwen3.5 Plus", "protocol": "openai", "context_length": 1000000},
-    {"id": "qwen3.6-plus", "name": "Qwen3.6 Plus", "protocol": "openai", "context_length": 1000000},
+    {
+        "id": "qwen3.6-plus",
+        "name": "Qwen3.6 Plus",
+        "protocol": "openai",
+        "context_length": 1000000,
+        "input_modalities": ["text", "image"],
+    },
 ]
 
 OPENCODE_GO_ANTHROPIC_MODEL_IDS = {
@@ -71,15 +102,22 @@ OPENCODE_GO_ANTHROPIC_MODEL_IDS = {
     if definition["protocol"] == "anthropic"
 }
 
+OPENCODE_GO_IMAGE_INPUT_MODEL_IDS = {
+    definition["id"]
+    for definition in OPENCODE_GO_MODEL_DEFINITIONS
+    if "image" in definition.get("input_modalities", [])
+}
+
 
 def _build_opencode_go_model(model_definition: OpenCodeGoModelDefinition) -> ModelInfo:
+    input_modalities = model_definition.get("input_modalities", ["text"])
     return ModelInfo(
         id=f"{OPENCODE_GO_MODEL_PREFIX}{model_definition['id']}",
         name=model_definition["name"],
         icon="opencode",
         architecture=Architecture(
-            input_modalities=["text"],
-            modality="text->text",
+            input_modalities=input_modalities,
+            modality=f"{'+'.join(input_modalities)}->text",
             output_modalities=["text"],
             tokenizer="opencode",
         ),

--- a/api/app/services/providers/opencode_go_catalog.py
+++ b/api/app/services/providers/opencode_go_catalog.py
@@ -31,13 +31,13 @@ OPENCODE_GO_MODEL_DEFINITIONS: list[OpenCodeGoModelDefinition] = [
     {
         "id": "deepseek-v4-pro",
         "name": "DeepSeek V4 Pro",
-        "protocol": "anthropic",
+        "protocol": "openai",
         "context_length": 1048576,
     },
     {
         "id": "deepseek-v4-flash",
         "name": "DeepSeek V4 Flash",
-        "protocol": "anthropic",
+        "protocol": "openai",
         "context_length": 1048576,
     },
     {"id": "mimo-v2-pro", "name": "MiMo-V2-Pro", "protocol": "openai", "context_length": 1048576},

--- a/ui/app/components/ui/graph/node/filePrompt.vue
+++ b/ui/app/components/ui/graph/node/filePrompt.vue
@@ -52,6 +52,8 @@ const handleDrop = async (event: DragEvent) => {
 const addFiles = async (newFiles: FileList) => {
     if (!newFiles) return;
 
+    const fileList = Array.from(newFiles);
+
     const root = await getRootFolder();
     let targetId = root.id;
 
@@ -73,7 +75,7 @@ const addFiles = async (newFiles: FileList) => {
         }
     }
 
-    const uploadPromises = Array.from(newFiles).map(async (file) => {
+    const uploadPromises = fileList.map(async (file) => {
         try {
             const newFile = await uploadFile(file, targetId);
             props.data.files.push(newFile);


### PR DESCRIPTION
# Meridian 1.5.2-beta

Meridian `1.5.2-beta` is a focused pre-release update that expands subscription-provider capabilities, adds OpenAI Codex image generation, refreshes OpenCode Go model support, and fixes provider tool and upload edge cases.

## Highlights

### OpenAI Codex Image Generation

OpenAI Codex can now be used as a provider-backed image generation runtime.

- Added a dedicated **Codex Image Generation** model entry derived from the connected OpenAI Codex catalog.
- Enabled Codex's native image generation tool for image requests, including prompt suffixing for aspect ratio and target resolution.
- Added support for text and image inputs in Codex image generation prompts.
- Added generated-image extraction from saved file paths, data URLs, and base64 payloads.
- Routed provider image generation through connected OpenAI Codex credentials instead of rejecting Codex models.

### OpenCode Go Model Updates

The OpenCode Go catalog has been updated for newer model coverage and multimodal metadata.

- Added **DeepSeek V4 Pro** and **DeepSeek V4 Flash**.
- Added **MiMo-V2.5-Pro** and **MiMo-V2.5**.
- Updated MiMo context lengths and model definitions.
- Marked image-capable OpenCode Go models so Meridian can accept image inputs only where supported.
- Added image input support for **Kimi K2.5**, **Kimi K2.6**, **MiMo-V2-Omni**, **MiMo-V2.5**, and **Qwen3.6 Plus**.

### Tool Use and Reasoning Stability

Provider tool execution is more reliable for newer OpenCode Go models.

- Preserved `reasoning_content` across OpenAI-compatible tool-call round trips for models that require it.
- Fixed tool usage with the new DeepSeek V4 models in OpenCode Go.
- Fixed tool usage with Kimi K2.x models in OpenCode Go.
- Improved Anthropic SSE event parsing so events without explicit `event:` lines can still be handled from their JSON payload type.
- Increased OpenAI Codex stdio buffering to handle larger runtime output.

### File Upload Fix

- Fixed device file upload in file prompt nodes by stabilizing the dropped file list before async folder and upload work begins.

## Self-Hosting and Upgrade Notes

- Run normal deployment updates for the backend and frontend.
- No database migration is required for `1.5.2-beta`.
- OpenAI Codex image generation requires connected OpenAI Codex credentials and the existing Codex runtime dependencies from the `1.5.0-beta` line.
