### PR TITLE
Update 1.6.1-beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ AGENTS.old.md
 __pycache__/
 venv/
 .memory
+
+# Local tooling binaries
+.bin/

--- a/api/app/database/pg/graph_ops/graph_config_crud.py
+++ b/api/app/database/pg/graph_ops/graph_config_crud.py
@@ -111,7 +111,7 @@ class GraphConfigUpdate(BaseModel):
     tools_web_search_custom_api_key: Optional[str] = None
     tools_web_search_force_custom_api_key: bool = True
     tools_link_extraction_max_length: int = 100000
-    block_context_merger_summarizer_model: str = "x-ai/grok-4-fast"
+    block_context_merger_summarizer_model: str = "xiaomi/mimo-v2.5"
 
 
 async def update_graph_config(

--- a/api/app/database/pg/models.py
+++ b/api/app/database/pg/models.py
@@ -1227,8 +1227,10 @@ async def create_initial_users(
                         id=uuid.uuid4(),
                         username=user.username,
                         password=user.password,
+                        email=f"{user.username}@localhost",
                         oauth_provider="userpass",
-                        is_verified=False,
+                        plan_type="premium",
+                        is_verified=True,
                     )
                     session.add(new_user)
                     users.append(new_user)

--- a/api/app/database/pg/models.py
+++ b/api/app/database/pg/models.py
@@ -1211,32 +1211,38 @@ async def create_initial_users(
 ) -> list[User]:
     """
     Create initial users from USERPASS environment variable if they don't exist.
+    Automatically creates a default workspace for each new user.
     """
     users = []
     if userpass:
         async with AsyncSession(engine) as session:
-            for user in userpass:
-                stmt = select(User).where(
-                    and_(User.username == user.username, User.oauth_provider == "userpass")
-                )
-
-                result = await session.execute(stmt)
-                existing_user = result.scalar_one_or_none()
-                if existing_user is None:
-                    new_user = User(
-                        id=uuid.uuid4(),
-                        username=user.username,
-                        password=user.password,
-                        email=f"{user.username}@localhost",
-                        oauth_provider="userpass",
-                        plan_type="premium",
-                        is_verified=True,
+            async with session.begin():
+                for user in userpass:
+                    stmt = select(User).where(
+                        and_(User.username == user.username, User.oauth_provider == "userpass")
                     )
-                    session.add(new_user)
-                    users.append(new_user)
-                else:
-                    logging.info(f"User '{user.username}' already exists, skipping.")
-            await session.commit()
+
+                    result = await session.execute(stmt)
+                    existing_user = result.scalar_one_or_none()
+                    if existing_user is None:
+                        new_user = User(
+                            id=uuid.uuid4(),
+                            username=user.username,
+                            password=user.password,
+                            email=f"{user.username}@localhost",
+                            oauth_provider="userpass",
+                            plan_type="premium",
+                            is_verified=True,
+                        )
+                        session.add(new_user)
+                        await session.flush()
+
+                        workspace = Workspace(user_id=new_user.id, name="Default")
+                        session.add(workspace)
+
+                        users.append(new_user)
+                    else:
+                        logging.info(f"User '{user.username}' already exists, skipping.")
 
             for created_user in users:
                 await session.refresh(created_user)

--- a/api/app/database/pg/user_ops/usage_limits.py
+++ b/api/app/database/pg/user_ops/usage_limits.py
@@ -16,10 +16,9 @@ async def check_free_tier_canvas_limit(pg_engine: SQLAlchemyAsyncEngine, user_id
                 .select_from(Graph)
                 .where(and_(Graph.user_id == user_id, Graph.temporary == False))  # noqa: E712
             )
-            count_result = await session.exec(count_stmt)  # type: ignore
-            count = count_result.one()[0]
+            count = await session.scalar(count_stmt)
 
-            if count >= 5:
+            if (count or 0) >= 5:
                 raise HTTPException(status_code=403, detail="FREE_TIER_CANVAS_LIMIT_REACHED")
 
 

--- a/api/app/models/usersDTO.py
+++ b/api/app/models/usersDTO.py
@@ -158,7 +158,7 @@ class BlockGithubSettings(BaseModel):
 class BlockContextMergerSettings(BaseModel):
     merger_mode: ContextMergerMode = ContextMergerMode.FULL
     last_n: int = 1
-    summarizer_model: str = "x-ai/grok-4-fast"
+    summarizer_model: str = "xiaomi/mimo-v2.5"
     include_user_messages: bool = True
 
 

--- a/api/app/schemas/images.py
+++ b/api/app/schemas/images.py
@@ -11,7 +11,7 @@ from services.image_playground.constants import (
 
 
 class ImageGenerationTaskPayload(BaseModel):
-    prompt: str = Field(min_length=1, max_length=8000)
+    prompt: str = Field(min_length=1)
     effective_prompt: Optional[str] = Field(default=None, max_length=10000)
     model: str = Field(min_length=1, max_length=255)
     aspect_ratio: str = "1:1"
@@ -36,7 +36,7 @@ class ImageEditSelectionPayload(BaseModel):
 
 class ImageEditPayload(BaseModel):
     source_image_id: uuid.UUID
-    prompt: str = Field(default="", max_length=8000)
+    prompt: str = Field(default="")
     model: str = Field(min_length=1, max_length=255)
     selection: ImageEditSelectionPayload
     resolution: str = "1K"
@@ -44,7 +44,7 @@ class ImageEditPayload(BaseModel):
 
 
 class VideoGenerationPayload(BaseModel):
-    prompt: str = Field(min_length=1, max_length=8000)
+    prompt: str = Field(min_length=1)
     model: str = Field(min_length=1, max_length=255)
     aspect_ratio: str = "16:9"
     resolution: str = "720p"

--- a/api/app/services/image_playground/gallery.py
+++ b/api/app/services/image_playground/gallery.py
@@ -114,7 +114,7 @@ async def list_generated_image_gallery(
     gallery_filter = and_(*gallery_conditions)
 
     async with AsyncSession(pg_engine) as session:
-        total_result = await session.exec(
+        total = await session.scalar(
             select(func.count())
             .select_from(Files)
             .join(
@@ -122,7 +122,7 @@ async def list_generated_image_gallery(
             )
             .where(gallery_filter)
         )
-        total = int(total_result.one())
+        total = int(total or 0)
 
         result = await session.exec(
             select(Files, ImageGenerationJob)
@@ -156,10 +156,10 @@ async def list_generated_video_gallery(
     )
 
     async with AsyncSession(pg_engine) as session:
-        total_result = await session.exec(
+        total = await session.scalar(
             select(func.count()).select_from(Files).where(gallery_filter)
         )
-        total = int(total_result.one())
+        total = int(total or 0)
 
         result = await session.exec(
             select(Files, ImageGenerationJob)

--- a/api/app/services/image_playground/gallery.py
+++ b/api/app/services/image_playground/gallery.py
@@ -156,9 +156,7 @@ async def list_generated_video_gallery(
     )
 
     async with AsyncSession(pg_engine) as session:
-        total = await session.scalar(
-            select(func.count()).select_from(Files).where(gallery_filter)
-        )
+        total = await session.scalar(select(func.count()).select_from(Files).where(gallery_filter))
         total = int(total or 0)
 
         result = await session.exec(

--- a/api/app/services/image_playground/jobs.py
+++ b/api/app/services/image_playground/jobs.py
@@ -189,7 +189,7 @@ async def is_job_cancelled(pg_engine: SQLAlchemyAsyncEngine, job_id: uuid.UUID) 
 
 
 async def count_active_generation_jobs(session: AsyncSession, *, user_id: uuid.UUID) -> int:
-    result = await session.exec(
+    count = await session.scalar(
         select(func.count())
         .select_from(ImageGenerationJob)
         .where(
@@ -199,7 +199,7 @@ async def count_active_generation_jobs(session: AsyncSession, *, user_id: uuid.U
             )
         )
     )
-    return int(result.one())
+    return int(count or 0)
 
 
 async def ensure_active_generation_job_capacity(

--- a/api/app/services/image_playground/tone_presets.py
+++ b/api/app/services/image_playground/tone_presets.py
@@ -11,12 +11,12 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 async def count_custom_image_tone_presets(session: AsyncSession, user_id: uuid.UUID) -> int:
-    result = await session.exec(  # type: ignore
+    count = await session.scalar(
         select(func.count())
         .select_from(CustomImageTonePreset)
         .where(col(CustomImageTonePreset.user_id) == user_id)
     )
-    return int(result.one())
+    return int(count or 0)
 
 
 async def list_custom_image_tone_presets(

--- a/api/app/services/stream.py
+++ b/api/app/services/stream.py
@@ -79,9 +79,9 @@ Tool: ask_user
 - For text inputs, keep the request simple and optionally provide a placeholder.
 """
 
-ROUTING_MODEL = "x-ai/grok-4.1-fast"
-TITLE_GENERATION_MODEL = "x-ai/grok-4.1-fast"
-AUTO_TOOL_SELECTION_MODEL = "x-ai/grok-4.1-fast"
+ROUTING_MODEL = "xiaomi/mimo-v2.5"
+TITLE_GENERATION_MODEL = "xiaomi/mimo-v2.5"
+AUTO_TOOL_SELECTION_MODEL = "xiaomi/mimo-v2.5"
 AUTO_TOOL_CANDIDATES_BY_NODE_TYPE: dict[NodeTypeEnum, list[ToolEnum]] = {
     NodeTypeEnum.TEXT_TO_TEXT: [
         ToolEnum.WEB_SEARCH,

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -26,4 +26,4 @@ numpy
 opencv-python-headless
 httpx[http2]
 claude-agent-sdk==0.1.58
-github-copilot-sdk==0.2.2
+github-copilot-sdk==0.2.3

--- a/api/run-dev.sh
+++ b/api/run-dev.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_DIR="${SCRIPT_DIR}/app"
-USER_FILES_DIR="${APP_DIR}/data/user_files"
-CLONED_REPOS_DIR="${APP_DIR}/data/cloned_repos"
+USER_FILES_DIR="data/user_files"
+CLONED_REPOS_DIR="data/cloned_repos"
 
 cd "${APP_DIR}"
 

--- a/docker/config.local.example.toml
+++ b/docker/config.local.example.toml
@@ -1,5 +1,5 @@
 [general]
-ENV = "prod"
+ENV = "dev"
 NAME = "meridian"
 USERPASS = "admin:admin,admin2:admin2"
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOCAL_YQ="$PROJECT_ROOT/.bin/yq"
+
 MODE="$1"
 
 if [[ ! "$MODE" =~ ^(dev|prod|build)$ ]]; then
@@ -169,15 +173,81 @@ if has_arg "down" "$@"; then
     exit 0
 fi
 
-if ! command -v yq &>/dev/null || ! yq --version | grep -q "mikefarah"; then
-    echo "❌ Error: The required version of 'yq' (from Mike Farah) is not installed."
-    echo "Please visit https://github.com/mikefarah/yq/#install to install it."
-    echo ""
-    echo "Common installation commands:"
-    echo "  macOS (Homebrew): brew install yq"
-    echo "  Linux (Snap): snap install yq"
-    echo "  (Note: You may need to 'pip uninstall yq' first)"
-    exit 1
+yq_works() {
+    local cmd="$1"
+    local tmp_toml
+    tmp_toml="$(mktemp --suffix=.toml)"
+    cat > "$tmp_toml" <<'EOF'
+[section]
+key = "value"
+EOF
+    if "$cmd" eval '.[]' "$tmp_toml" -o=props &>/dev/null; then
+        rm -f "$tmp_toml"
+        return 0
+    fi
+    rm -f "$tmp_toml"
+    return 1
+}
+
+install_local_yq() {
+    local yq_version="v4.49.2"
+    local os arch yq_os yq_arch
+    local download_url
+
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    case "$os" in
+        linux)  yq_os="linux" ;;
+        darwin) yq_os="darwin" ;;
+        *)      echo "❌ Error: Automatic yq download is not supported for OS '$os'."; exit 1 ;;
+    esac
+
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64)  yq_arch="amd64" ;;
+        aarch64) yq_arch="arm64" ;;
+        arm64)   yq_arch="arm64" ;;
+        armv7l)  yq_arch="arm" ;;
+        *)       echo "❌ Error: Automatic yq download is not supported for architecture '$arch'."; exit 1 ;;
+    esac
+
+    download_url="https://github.com/mikefarah/yq/releases/download/${yq_version}/yq_${yq_os}_${yq_arch}"
+
+    echo "⚙️ yq not found or not working. Downloading Mike Farah yq ${yq_version} to '$LOCAL_YQ'..."
+    mkdir -p "$(dirname "$LOCAL_YQ")"
+
+    if command -v curl &>/dev/null; then
+        if ! curl -fsSL -o "$LOCAL_YQ" "$download_url"; then
+            echo "❌ Error: Failed to download yq from $download_url"
+            exit 1
+        fi
+    elif command -v wget &>/dev/null; then
+        if ! wget -q -O "$LOCAL_YQ" "$download_url"; then
+            echo "❌ Error: Failed to download yq from $download_url"
+            exit 1
+        fi
+    else
+        echo "❌ Error: 'curl' or 'wget' is required to download yq automatically."
+        exit 1
+    fi
+
+    chmod +x "$LOCAL_YQ"
+
+    if ! yq_works "$LOCAL_YQ"; then
+        echo "❌ Error: Downloaded yq from $download_url is not working."
+        exit 1
+    fi
+
+    echo "✅ yq installed successfully."
+}
+
+YQ_CMD=""
+if [[ -x "$LOCAL_YQ" ]] && yq_works "$LOCAL_YQ"; then
+    YQ_CMD="$LOCAL_YQ"
+elif command -v yq &>/dev/null && yq_works "yq"; then
+    YQ_CMD="yq"
+else
+    install_local_yq
+    YQ_CMD="$LOCAL_YQ"
 fi
 
 echo "⚙️ Generating '$ENV_OUTPUT_FILE' from '$TOML_CONFIG_FILE'..."
@@ -194,7 +264,7 @@ if [[ ! -f "$TOML_CONFIG_FILE" ]]; then
     exit 1
 fi
 
-yq eval '.[]' "$TOML_CONFIG_FILE" -o=props > "$ENV_OUTPUT_FILE"
+$YQ_CMD eval '.[]' "$TOML_CONFIG_FILE" -o=props > "$ENV_OUTPUT_FILE"
 
 echo "✅ Environment file generated."
 echo ""


### PR DESCRIPTION
# Meridian 1.6.1-beta

Meridian `1.6.1-beta` is a polish and reliability update that smooths out rough edges from the `1.6.0-beta` Media Playground release. It improves default model handling, removes overly restrictive prompt limits, fixes count-query edge cases, and makes local development and self-hosted setup more reliable.

## Highlights

### Improved Default Models

Meridian now uses current model identifiers and exposes them consistently across graph configuration, user defaults, and streaming services.

- Updated deprecated default model references across the backend.
- Synchronized model defaults in graph config, user DTO, and streaming service logic.

### User Onboarding and Workspaces

New users created from self-hosted `USERPASS` credentials now receive a ready-to-use workspace and correct default account status.

- Added automatic creation of a default workspace during initial user creation.
- Set new users as verified with a premium plan type by default.
- Populated the email field for new users created from environment credentials.

### Media Playground Reliability

Several small but important fixes make gallery counts and prompt input more robust.

- Removed the `max_length` constraint from image, image-edit, and video generation prompt fields so longer prompts are accepted.
- Fixed gallery and job count queries to return `0` instead of raising errors when no results exist.
- Fixed a linter issue in the image gallery service.

### Development and Self-Hosting Experience

Local development scripts and the self-hosted run script are now more portable and self-contained.

- Simplified `USER_FILES_DIR` and `CLONED_REPOS_DIR` paths in `run-dev.sh` to use relative directories.
- Improved `yq` handling in the self-hosted `docker/run.sh` script:
  - Verifies that `yq` works before relying on it.
  - Falls back to a local `yq` installation when the system binary is missing or broken.

### Dependency Updates

- Updated `github-copilot-sdk` to version `0.2.3`.

## Self-Hosting and Upgrade Notes

Self-hosted deployments can upgrade to `1.6.1-beta` without a database migration.

- Pull the latest code and rebuild/restart the application.
- New `USERPASS` users will now automatically receive a default workspace and be created as verified premium users.
- The `docker/run.sh` script can now bootstrap a local `yq` binary if one is not installed.
