### PR TITLE
Update 1.6.3-beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ venv/
 
 # Local tooling binaries
 .bin/
+
+# Local agent files
+.agents/
+skills-lock.json

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -37,6 +37,7 @@ from services.connection_manager import manager as connection_manager
 from services.files import create_user_root_folder
 from services.image_playground.jobs import recover_stale_image_generation_jobs
 from services.openrouter import OpenRouterReq, list_available_models
+from services.providers.models_dev import fetch_models_dev_catalog
 from services.rate_limit import limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.extension import _rate_limit_exceeded_handler
@@ -45,6 +46,7 @@ from utils.helpers import load_environment_variables
 
 logging.getLogger("urllib3").setLevel(logging.ERROR)
 logger = logging.getLogger("uvicorn.error")
+MODELS_DEV_REFRESH_INTERVAL_SECONDS = 60 * 60 * 6
 
 if not os.path.exists("data/user_files"):
     os.makedirs("data/user_files")
@@ -88,6 +90,22 @@ async def cron_refresh_openrouter_models(app: FastAPI):
         await asyncio.sleep(3600)  # Refresh every hour
 
 
+async def refresh_models_dev_catalog(app: FastAPI):
+    app.state.models_dev_catalog = await fetch_models_dev_catalog(app.state.http_client)
+
+
+async def cron_refresh_models_dev_catalog(app: FastAPI):
+    while True:
+        try:
+            logger.info("Cron job: Refreshing models.dev catalog.")
+            await refresh_models_dev_catalog(app)
+        except Exception as e:
+            logger.error(f"Cron job: Error refreshing models.dev catalog: {e}", exc_info=True)
+            sentry_sdk.capture_exception(e)
+
+        await asyncio.sleep(MODELS_DEV_REFRESH_INTERVAL_SECONDS)
+
+
 async def shutdown_background_tasks(tasks: list[asyncio.Task[None]]):
     for task in tasks:
         task.cancel()
@@ -108,6 +126,7 @@ async def shutdown_background_tasks(tasks: list[asyncio.Task[None]]):
 async def lifespan(app: FastAPI):
     load_environment_variables()
     app.state.available_models = None
+    app.state.models_dev_catalog = None
     app.state.background_tasks = []
     app.state.http_client = None
     app.state.git_http_client = None
@@ -184,6 +203,12 @@ async def lifespan(app: FastAPI):
         app.state.connection_manager = connection_manager
 
         try:
+            await refresh_models_dev_catalog(app)
+        except Exception as e:
+            logger.error(f"Startup: Error refreshing models.dev catalog: {e}", exc_info=True)
+            sentry_sdk.capture_exception(e)
+
+        try:
             await refresh_openrouter_models(app)
         except Exception as e:
             logger.error(f"Startup: Error refreshing OpenRouter models: {e}", exc_info=True)
@@ -194,6 +219,10 @@ async def lifespan(app: FastAPI):
             asyncio.create_task(
                 cron_refresh_openrouter_models(app),
                 name="cron_refresh_openrouter_models",
+            ),
+            asyncio.create_task(
+                cron_refresh_models_dev_catalog(app),
+                name="cron_refresh_models_dev_catalog",
             ),
         ]
 

--- a/api/app/models/inference.py
+++ b/api/app/models/inference.py
@@ -110,8 +110,22 @@ class GeminiCliOAuthCredsPayload(BaseModel):
     oauth_creds_json: str
 
 
-class OpenAICodexAuthJsonPayload(BaseModel):
-    auth_json: str
+class OpenAICodexOAuthSessionPayload(BaseModel):
+    session_id: str
+
+
+class OpenAICodexBrowserOAuthStartResponse(BaseModel):
+    session_id: str
+    url: str
+    instructions: str
+
+
+class OpenAICodexDeviceOAuthStartResponse(BaseModel):
+    session_id: str
+    verification_url: str
+    user_code: str
+    interval_seconds: int
+    instructions: str
 
 
 class OpenCodeGoApiKeyPayload(BaseModel):

--- a/api/app/models/tool_question.py
+++ b/api/app/models/tool_question.py
@@ -58,6 +58,25 @@ class AskUserArguments(BaseModel):
     title: str | None = None
     questions: list[AskUserQuestion]
 
+    @staticmethod
+    def _normalize_question_payload(question: Any) -> Any:
+        if not isinstance(question, dict):
+            return question
+
+        normalized_question = dict(question)
+        input_type = str(normalized_question.get("input_type") or "")
+        if input_type not in {
+            AskUserInputType.SINGLE_SELECT.value,
+            AskUserInputType.MULTI_SELECT.value,
+        }:
+            normalized_question.pop("options", None)
+            normalized_question.pop("allow_other", None)
+
+        if input_type != AskUserInputType.TEXT.value:
+            normalized_question.pop("validation", None)
+
+        return normalized_question
+
     @model_validator(mode="before")
     @classmethod
     def normalize_legacy_shape(cls, data: Any) -> Any:
@@ -65,7 +84,13 @@ class AskUserArguments(BaseModel):
             return data
 
         if data.get("questions") is not None:
-            return data
+            normalized_data = dict(data)
+            questions = normalized_data.get("questions")
+            if isinstance(questions, list):
+                normalized_data["questions"] = [
+                    cls._normalize_question_payload(question) for question in questions
+                ]
+            return normalized_data
 
         if data.get("question") is None or data.get("input_type") is None:
             return data
@@ -83,11 +108,12 @@ class AskUserArguments(BaseModel):
             }.items()
             if value is not None
         }
+        normalized_question = cls._normalize_question_payload(normalized_question)
 
-        normalized_data: dict[str, Any] = {"questions": [normalized_question]}
+        legacy_normalized_data: dict[str, Any] = {"questions": [normalized_question]}
         if data.get("title") is not None:
-            normalized_data["title"] = data.get("title")
-        return normalized_data
+            legacy_normalized_data["title"] = data.get("title")
+        return legacy_normalized_data
 
     @model_validator(mode="after")
     def validate_questions(self) -> "AskUserArguments":

--- a/api/app/routers/inference_providers.py
+++ b/api/app/routers/inference_providers.py
@@ -7,7 +7,9 @@ from models.inference import (
     GeminiCliOAuthCredsPayload,
     GitHubCopilotTokenPayload,
     InferenceProviderStatusResponse,
-    OpenAICodexAuthJsonPayload,
+    OpenAICodexBrowserOAuthStartResponse,
+    OpenAICodexDeviceOAuthStartResponse,
+    OpenAICodexOAuthSessionPayload,
     OpenCodeGoApiKeyPayload,
     ZAiCodingPlanApiKeyPayload,
 )
@@ -20,7 +22,14 @@ from services.inference import (
     get_inference_provider_statuses,
     invalidate_user_available_models_cache,
 )
-from services.openai_codex import validate_openai_codex_auth_json
+from services.openai_codex import (
+    complete_openai_codex_browser_oauth,
+    complete_openai_codex_device_oauth,
+    is_openai_codex_browser_oauth_local_origin,
+    start_openai_codex_browser_oauth,
+    start_openai_codex_device_oauth,
+    validate_openai_codex_oauth_auth_json,
+)
 from services.opencode_go import validate_opencode_go_api_key
 from services.providers.claude_agent_catalog import CLAUDE_AGENT_PROVIDER_KEY
 from services.providers.gemini_cli_catalog import GEMINI_CLI_PROVIDER_KEY
@@ -237,45 +246,165 @@ async def disconnect_gemini_cli(
     return {"message": "Gemini CLI disconnected successfully."}
 
 
-@router.post("/openai-codex/auth-json")
-async def connect_openai_codex(
+async def _store_openai_codex_auth_json(
     request: Request,
-    payload: OpenAICodexAuthJsonPayload,
+    user_id: str,
+    auth_json: str,
+) -> None:
+    normalized_auth_json = await validate_openai_codex_oauth_auth_json(auth_json)
+    encrypted_auth_json = await encrypt_api_key(normalized_auth_json)
+    if not encrypted_auth_json:
+        raise ValueError("Failed to encrypt OpenAI Codex auth.json.")
+
+    await store_provider_token(
+        request.app.state.pg_engine,
+        user_id,
+        OPENAI_CODEX_PROVIDER_KEY,
+        encrypted_auth_json,
+    )
+    invalidate_user_available_models_cache(request.app, user_id)
+
+
+def _is_local_openai_codex_browser_oauth_request(request: Request) -> bool:
+    for header_name in ("origin", "referer"):
+        header_value = request.headers.get(header_name)
+        if header_value:
+            return is_openai_codex_browser_oauth_local_origin(header_value)
+
+    forwarded_host = request.headers.get("x-forwarded-host")
+    if forwarded_host:
+        forwarded_proto = request.headers.get("x-forwarded-proto") or request.url.scheme
+        browser_host = forwarded_host.split(",", 1)[0].strip()
+        return is_openai_codex_browser_oauth_local_origin(f"{forwarded_proto}://{browser_host}")
+
+    host = request.headers.get("host")
+    if host:
+        return is_openai_codex_browser_oauth_local_origin(f"{request.url.scheme}://{host}")
+    return is_openai_codex_browser_oauth_local_origin(str(request.url))
+
+
+@router.post(
+    "/openai-codex/oauth/browser/start",
+    response_model=OpenAICodexBrowserOAuthStartResponse,
+)
+async def start_openai_codex_browser_sign_in(
+    request: Request,
     user_id: str = Depends(get_current_user_id),
 ):
-    auth_json = payload.auth_json.strip()
-    if not auth_json:
+    if not _is_local_openai_codex_browser_oauth_request(request):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="OpenAI Codex auth.json is required.",
+            detail=(
+                "OpenAI Codex browser sign-in requires Meridian to be opened from localhost. "
+                "Use device-code sign-in for remote or hosted deployments."
+            ),
         )
 
     try:
-        normalized_auth_json = await validate_openai_codex_auth_json(auth_json)
-        encrypted_auth_json = await encrypt_api_key(normalized_auth_json)
-        if not encrypted_auth_json:
-            raise ValueError("Failed to encrypt OpenAI Codex auth.json.")
-
-        await store_provider_token(
-            request.app.state.pg_engine,
+        result = await start_openai_codex_browser_oauth()
+        return OpenAICodexBrowserOAuthStartResponse(**result)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Could not start local OpenAI Codex OAuth callback server on port 1455.",
+        ) from exc
+    except Exception as exc:
+        logger.error(
+            "Failed to start OpenAI Codex browser OAuth for user %s",
             user_id,
-            OPENAI_CODEX_PROVIDER_KEY,
-            encrypted_auth_json,
+            exc_info=True,
         )
-        invalidate_user_available_models_cache(request.app, user_id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not start OpenAI Codex browser sign-in.",
+        ) from exc
+
+
+@router.post("/openai-codex/oauth/browser/complete")
+async def complete_openai_codex_browser_sign_in(
+    request: Request,
+    payload: OpenAICodexOAuthSessionPayload,
+    user_id: str = Depends(get_current_user_id),
+):
+    try:
+        auth_json = await complete_openai_codex_browser_oauth(payload.session_id.strip())
+        await _store_openai_codex_auth_json(
+            request,
+            user_id,
+            auth_json,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
-        logger.error("Failed to connect OpenAI Codex for user %s", user_id, exc_info=True)
+        logger.error(
+            "Failed to complete OpenAI Codex browser OAuth for user %s",
+            user_id,
+            exc_info=True,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Could not validate or store the OpenAI Codex auth.json file.",
+            detail="Could not complete OpenAI Codex browser sign-in.",
         ) from exc
 
     return {"message": "OpenAI Codex connected successfully."}
 
 
-@router.delete("/openai-codex/auth-json")
+@router.post(
+    "/openai-codex/oauth/device/start",
+    response_model=OpenAICodexDeviceOAuthStartResponse,
+)
+async def start_openai_codex_device_sign_in(
+    user_id: str = Depends(get_current_user_id),
+):
+    try:
+        result = await start_openai_codex_device_oauth()
+        return OpenAICodexDeviceOAuthStartResponse(**result)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(
+            "Failed to start OpenAI Codex device OAuth for user %s",
+            user_id,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not start OpenAI Codex device sign-in.",
+        ) from exc
+
+
+@router.post("/openai-codex/oauth/device/complete")
+async def complete_openai_codex_device_sign_in(
+    request: Request,
+    payload: OpenAICodexOAuthSessionPayload,
+    user_id: str = Depends(get_current_user_id),
+):
+    try:
+        auth_json = await complete_openai_codex_device_oauth(payload.session_id.strip())
+        await _store_openai_codex_auth_json(
+            request,
+            user_id,
+            auth_json,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(
+            "Failed to complete OpenAI Codex device OAuth for user %s",
+            user_id,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not complete OpenAI Codex device sign-in.",
+        ) from exc
+
+    return {"message": "OpenAI Codex connected successfully."}
+
+
+@router.delete("/openai-codex/oauth")
 async def disconnect_openai_codex(
     request: Request,
     user_id: str = Depends(get_current_user_id),

--- a/api/app/services/inference.py
+++ b/api/app/services/inference.py
@@ -472,7 +472,9 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
                     OPENCODE_GO_PROVIDER_KEY,
                     credentials.opencode_go_api_key,
                 ),
-                loader=get_opencode_go_models,
+                loader=lambda: get_opencode_go_models(
+                    getattr(app.state, "models_dev_catalog", None)
+                ),
             )
         )
 

--- a/api/app/services/inference.py
+++ b/api/app/services/inference.py
@@ -429,7 +429,9 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
                     Z_AI_CODING_PLAN_PROVIDER_KEY,
                     credentials.z_ai_coding_plan_api_key,
                 ),
-                loader=get_z_ai_coding_plan_models,
+                loader=lambda: get_z_ai_coding_plan_models(
+                    getattr(app.state, "models_dev_catalog", None)
+                ),
             )
         )
     if credentials.gemini_cli_oauth_creds_json:
@@ -456,6 +458,7 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
                     openai_codex_auth_json,
                     user_id=user_id,
                     pg_engine=app.state.pg_engine,
+                    models_dev_catalog=getattr(app.state, "models_dev_catalog", None),
                     warnings=warnings,
                 ),
                 cache_empty=False,
@@ -498,12 +501,18 @@ async def get_openai_codex_models_safe(
     *,
     user_id: str,
     pg_engine: SQLAlchemyAsyncEngine,
+    models_dev_catalog: Any | None = None,
     warnings: list[ModelDiscoveryWarning] | None = None,
 ) -> list[ModelInfo]:
     from services.openai_codex import list_openai_codex_models
 
     try:
-        return await list_openai_codex_models(auth_json, user_id=user_id, pg_engine=pg_engine)
+        return await list_openai_codex_models(
+            auth_json,
+            user_id=user_id,
+            pg_engine=pg_engine,
+            models_dev_catalog=models_dev_catalog,
+        )
     except Exception as exc:
         logger.warning(
             "OpenAI Codex model discovery failed; omitting Codex models for this request.",

--- a/api/app/services/openai_codex.py
+++ b/api/app/services/openai_codex.py
@@ -1,17 +1,23 @@
 import asyncio
 import base64
 import contextlib
+import hashlib
+import http.server
 import json
 import logging
 import mimetypes
 import re
+import secrets
 import tempfile
+import threading
 import time
 import uuid
 from collections import deque
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Optional
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 from database.pg.chat_ops import create_tool_call
@@ -26,8 +32,6 @@ from services.provider_runtime import (
     build_subprocess_env,
     cleanup_runtime_dir,
     ensure_private_directory,
-    start_runtime_heartbeat,
-    stop_runtime_heartbeat,
 )
 from services.providers.common import (
     GENERIC_STREAM_ERROR_MESSAGE,
@@ -46,9 +50,10 @@ from services.providers.common import (
 from services.providers.openai_codex_catalog import (
     OPENAI_CODEX_MODEL_PREFIX,
     OPENAI_CODEX_PROVIDER_KEY,
-    build_openai_codex_image_generation_model,
+    get_default_openai_codex_models,
+    get_models_dev_openai_codex_models,
     get_openai_codex_base_model_id,
-    normalize_openai_codex_model,
+    get_openai_codex_image_generation_base_model_id,
 )
 from services.providers.tool_continuation import persist_pending_tool_continuation
 from services.tools import (
@@ -71,6 +76,25 @@ OPENAI_CODEX_RUNTIME_ROOT = Path(tempfile.gettempdir())
 OPENAI_CODEX_RUNTIME_TTL_SECONDS = 60 * 60
 OPENAI_CODEX_RPC_TIMEOUT_SECONDS = 30.0
 OPENAI_CODEX_TURN_TIMEOUT_SECONDS = 300.0
+OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+OPENAI_CODEX_ISSUER = "https://auth.openai.com"
+OPENAI_CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
+OPENAI_RESPONSES_API_ENDPOINT = "https://api.openai.com/v1/responses"
+OPENAI_MODELS_API_ENDPOINT = "https://api.openai.com/v1/models"
+OPENAI_CODEX_OAUTH_PORT = 1455
+OPENAI_CODEX_DEVICE_VERIFICATION_URL = f"{OPENAI_CODEX_ISSUER}/codex/device"
+OPENAI_CODEX_DEVICE_REDIRECT_URI = f"{OPENAI_CODEX_ISSUER}/deviceauth/callback"
+OPENAI_CODEX_OAUTH_SCOPE = "openid profile email offline_access"
+OPENAI_CODEX_OAUTH_TIMEOUT_SECONDS = 5 * 60
+OPENAI_CODEX_REFRESH_MARGIN_SECONDS = 60
+OPENAI_CODEX_DEVICE_POLL_SAFETY_SECONDS = 3
+OPENAI_CODEX_LOCAL_BROWSER_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+OPENAI_CODEX_AUTH_PROBE_INPUT = "Reply with OK."
+OPENAI_CODEX_AUTH_PROBE_INSTRUCTIONS = "Validate this OpenAI Codex session. Reply with OK."
+OPENAI_CODEX_IMAGE_GENERATION_INSTRUCTIONS = (
+    "You are an image generation assistant. Follow the user's prompt and reference images. "
+    "Use the image_generation tool exactly once and return the generated image."
+)
 OPENAI_CODEX_FALLBACK_USER_CONTENT = "Please respond to the available context."
 OPENAI_CODEX_STDERR_MAX_LINES = 200
 OPENAI_CODEX_STDIO_LIMIT_BYTES = 128 * 1024 * 1024
@@ -134,6 +158,59 @@ JSON_WHITESPACE_TRANSLATION = str.maketrans(
         "\u2060": "",
     }
 )
+OPENAI_CODEX_OAUTH_SUCCESS_HTML = """<!doctype html>
+<html><head><title>Meridian - Codex Authorization Successful</title></head>
+<body style="font-family: system-ui, sans-serif; background: #131010; color: #f1ecec;">
+  <main style="text-align: center; padding: 2rem;">
+    <h1>Authorization Successful</h1>
+    <p style="color: #b7b1b1;">You can close this window and return to Meridian.</p>
+  </main>
+  <script>setTimeout(() => window.close(), 2000)</script>
+</body></html>"""
+
+
+def _openai_codex_oauth_error_html(error: str) -> str:
+    safe_error = error.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return (
+        """<!doctype html>
+<html><head><title>Meridian - Codex Authorization Failed</title></head>
+<body style="font-family: system-ui, sans-serif; background: #131010; color: #f1ecec;">
+  <main style="text-align: center; padding: 2rem; max-width: 40rem;">
+    <h1 style="color: #fc533a;">Authorization Failed</h1>
+    <p style="color: #b7b1b1;">Return to Meridian and try again.</p>
+    <pre style="white-space: pre-wrap; color: #ff917b;">"""
+        f"{safe_error}</pre>\n"
+        """  </main>
+</body></html>"""
+    )
+
+
+@dataclass
+class OpenAICodexDeviceAuthSession:
+    session_id: str
+    device_auth_id: str
+    user_code: str
+    interval_seconds: int
+    expires_at: float
+
+
+@dataclass
+class OpenAICodexBrowserAuthSession:
+    session_id: str
+    verifier: str
+    state: str
+    redirect_uri: str
+    created_at: float
+    code: str | None = None
+    error: str | None = None
+    event: threading.Event = field(default_factory=threading.Event)
+
+
+_openai_codex_device_sessions: dict[str, OpenAICodexDeviceAuthSession] = {}
+_openai_codex_browser_sessions: dict[str, OpenAICodexBrowserAuthSession] = {}
+_openai_codex_refresh_tasks: dict[str, asyncio.Task[str]] = {}
+_openai_codex_oauth_server: http.server.ThreadingHTTPServer | None = None
+_openai_codex_oauth_server_lock = threading.Lock()
 
 
 @dataclass
@@ -342,6 +419,515 @@ def _normalize_auth_json(raw_value: str) -> str:
         raise ValueError("OpenAI Codex auth.json must be a JSON object.")
 
     return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def is_openai_codex_browser_oauth_local_origin(origin_or_url: str | None) -> bool:
+    raw_value = str(origin_or_url or "").strip()
+    if not raw_value:
+        return False
+    parsed_url = urlparse(raw_value if "://" in raw_value else f"//{raw_value}")
+    hostname = (parsed_url.hostname or "").strip().lower()
+    return hostname in OPENAI_CODEX_LOCAL_BROWSER_HOSTS
+
+
+def _base64_url_encode(raw_bytes: bytes) -> str:
+    return base64.urlsafe_b64encode(raw_bytes).decode("ascii").rstrip("=")
+
+
+def _generate_pkce_codes() -> tuple[str, str]:
+    chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    verifier = "".join(chars[byte % len(chars)] for byte in secrets.token_bytes(43))
+    challenge = _base64_url_encode(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+def _parse_jwt_claims(token: str) -> dict[str, Any] | None:
+    parts = token.split(".")
+    if len(parts) != 3 or not parts[1]:
+        return None
+
+    try:
+        padded_payload = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = base64.urlsafe_b64decode(padded_payload.encode("ascii"))
+        claims = json.loads(payload.decode("utf-8"))
+    except Exception:
+        return None
+    return claims if isinstance(claims, dict) else None
+
+
+def _extract_account_id_from_claims(claims: dict[str, Any] | None) -> str | None:
+    if not isinstance(claims, dict):
+        return None
+
+    root_account_id = str(claims.get("chatgpt_account_id") or "").strip()
+    if root_account_id:
+        return root_account_id
+
+    auth_claims = claims.get("https://api.openai.com/auth")
+    if isinstance(auth_claims, dict):
+        nested_account_id = str(auth_claims.get("chatgpt_account_id") or "").strip()
+        if nested_account_id:
+            return nested_account_id
+
+    organizations = claims.get("organizations")
+    if isinstance(organizations, list) and organizations:
+        first_org = organizations[0]
+        if isinstance(first_org, dict):
+            organization_id = str(first_org.get("id") or "").strip()
+            if organization_id:
+                return organization_id
+    return None
+
+
+def _extract_account_id_from_tokens(tokens: dict[str, Any]) -> str | None:
+    for key in ("id_token", "access_token"):
+        token = str(tokens.get(key) or "").strip()
+        if not token:
+            continue
+        account_id = _extract_account_id_from_claims(_parse_jwt_claims(token))
+        if account_id:
+            return account_id
+    return None
+
+
+def _extract_jwt_expiration_ms(token: str) -> int | None:
+    claims = _parse_jwt_claims(token)
+    if not claims:
+        return None
+    exp = claims.get("exp")
+    if isinstance(exp, (int, float)):
+        return int(exp * 1000)
+    return None
+
+
+def _build_codex_auth_json_from_tokens(
+    tokens: dict[str, Any],
+    *,
+    account_id: str | None = None,
+) -> str:
+    access_token = str(tokens.get("access_token") or "").strip()
+    id_token = str(tokens.get("id_token") or access_token).strip()
+    refresh_token = str(tokens.get("refresh_token") or "").strip()
+    if not access_token or not refresh_token:
+        raise ValueError("OpenAI Codex OAuth response did not include usable tokens.")
+
+    resolved_account_id = account_id or _extract_account_id_from_tokens(tokens)
+    auth_payload: dict[str, Any] = {
+        "auth_mode": "chatgpt",
+        "OPENAI_API_KEY": None,
+        "tokens": {
+            "id_token": id_token,
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        },
+        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    if resolved_account_id:
+        auth_payload["tokens"]["account_id"] = resolved_account_id
+    return _normalize_auth_json(json.dumps(auth_payload))
+
+
+def _build_codex_auth_json_from_api_key(api_key: str) -> str:
+    normalized_api_key = api_key.strip()
+    if not normalized_api_key:
+        raise ValueError("OpenAI Codex API key is required.")
+    return _normalize_auth_json(
+        json.dumps(
+            {
+                "auth_mode": "apikey",
+                "OPENAI_API_KEY": normalized_api_key,
+            }
+        )
+    )
+
+
+def _coerce_openai_codex_auth_json(normalized_auth_json: str) -> str:
+    try:
+        payload = json.loads(normalized_auth_json)
+    except json.JSONDecodeError:
+        return normalized_auth_json
+
+    if not isinstance(payload, dict):
+        return normalized_auth_json
+    if payload.get("type") == "api":
+        return _build_codex_auth_json_from_api_key(str(payload.get("key") or ""))
+    if payload.get("type") == "oauth":
+        tokens = _extract_codex_auth_tokens(normalized_auth_json)
+        if tokens:
+            return _build_codex_auth_json_from_tokens(tokens)
+    return normalized_auth_json
+
+
+def _extract_codex_auth_tokens(normalized_auth_json: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(normalized_auth_json)
+    except json.JSONDecodeError:
+        return None
+
+    tokens = payload.get("tokens")
+    if isinstance(tokens, dict):
+        return tokens
+
+    if payload.get("type") == "oauth":
+        refresh = str(payload.get("refresh") or "").strip()
+        access = str(payload.get("access") or "").strip()
+        if refresh and access:
+            return {
+                "id_token": str(payload.get("id_token") or ""),
+                "access_token": access,
+                "refresh_token": refresh,
+                "account_id": str(payload.get("accountId") or payload.get("account_id") or ""),
+            }
+    return None
+
+
+def _codex_auth_needs_refresh(normalized_auth_json: str, *, force: bool = False) -> bool:
+    if force:
+        return True
+    tokens = _extract_codex_auth_tokens(normalized_auth_json)
+    if not tokens:
+        return False
+    access_token = str(tokens.get("access_token") or "").strip()
+    if not access_token:
+        return True
+    expires_ms = _extract_jwt_expiration_ms(access_token)
+    if expires_ms is None:
+        return False
+    return expires_ms <= int((time.time() + OPENAI_CODEX_REFRESH_MARGIN_SECONDS) * 1000)
+
+
+async def _exchange_openai_codex_code(
+    *,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{OPENAI_CODEX_ISSUER}/oauth/token",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": OPENAI_CODEX_CLIENT_ID,
+                "code_verifier": code_verifier,
+            },
+        )
+    if response.status_code >= 400:
+        raise ValueError(f"OpenAI Codex token exchange failed: {response.status_code}")
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError("OpenAI Codex token exchange returned an invalid response.")
+    return payload
+
+
+async def _refresh_openai_codex_auth(normalized_auth_json: str) -> str:
+    tokens = _extract_codex_auth_tokens(normalized_auth_json)
+    refresh_token = str(tokens.get("refresh_token") or "").strip() if tokens else ""
+    if not refresh_token:
+        return normalized_auth_json
+
+    account_id = str(tokens.get("account_id") or "").strip() if tokens else None
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{OPENAI_CODEX_ISSUER}/oauth/token",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": OPENAI_CODEX_CLIENT_ID,
+            },
+        )
+    if response.status_code >= 400:
+        raise ValueError(f"OpenAI Codex token refresh failed: {response.status_code}")
+
+    refreshed_tokens = response.json()
+    if not isinstance(refreshed_tokens, dict):
+        raise ValueError("OpenAI Codex token refresh returned an invalid response.")
+    if not refreshed_tokens.get("refresh_token"):
+        refreshed_tokens["refresh_token"] = refresh_token
+    if not refreshed_tokens.get("id_token") and tokens and tokens.get("id_token"):
+        refreshed_tokens["id_token"] = tokens.get("id_token")
+    return _build_codex_auth_json_from_tokens(refreshed_tokens, account_id=account_id or None)
+
+
+async def _refresh_openai_codex_auth_if_needed(
+    normalized_auth_json: str,
+    *,
+    force: bool = False,
+) -> str:
+    normalized_auth_json = _coerce_openai_codex_auth_json(normalized_auth_json)
+    if not _codex_auth_needs_refresh(normalized_auth_json, force=force):
+        return normalized_auth_json
+
+    tokens = _extract_codex_auth_tokens(normalized_auth_json)
+    refresh_token = str(tokens.get("refresh_token") or "").strip() if tokens else ""
+    if not refresh_token:
+        return normalized_auth_json
+
+    task = _openai_codex_refresh_tasks.get(refresh_token)
+    if task is None:
+        task = asyncio.create_task(_refresh_openai_codex_auth(normalized_auth_json))
+        _openai_codex_refresh_tasks[refresh_token] = task
+        task.add_done_callback(lambda _: _openai_codex_refresh_tasks.pop(refresh_token, None))
+    return await task
+
+
+async def _validate_openai_codex_auth_tokens(normalized_auth_json: str) -> str:
+    normalized_auth_json = _coerce_openai_codex_auth_json(normalized_auth_json)
+    try:
+        payload = json.loads(normalized_auth_json)
+    except json.JSONDecodeError:
+        payload = {}
+    if isinstance(payload, dict) and str(payload.get("OPENAI_API_KEY") or "").strip():
+        await _probe_openai_codex_auth(normalized_auth_json)
+        return normalized_auth_json
+
+    refreshed_auth_json = await _refresh_openai_codex_auth_if_needed(
+        normalized_auth_json,
+        force=True,
+    )
+    tokens = _extract_codex_auth_tokens(refreshed_auth_json)
+    if not tokens or not str(tokens.get("access_token") or "").strip():
+        raise ValueError("OpenAI Codex credentials do not contain OAuth access tokens.")
+    await _probe_openai_codex_auth(refreshed_auth_json)
+    return refreshed_auth_json
+
+
+async def validate_openai_codex_oauth_auth_json(auth_json: str) -> str:
+    return await _validate_openai_codex_auth_tokens(_normalize_auth_json(auth_json))
+
+
+def _cleanup_openai_codex_oauth_sessions() -> None:
+    now = time.time()
+    expired_device_sessions = [
+        session_id
+        for session_id, session in _openai_codex_device_sessions.items()
+        if session.expires_at <= now
+    ]
+    for session_id in expired_device_sessions:
+        _openai_codex_device_sessions.pop(session_id, None)
+
+    expired_browser_sessions = [
+        session_id
+        for session_id, session in _openai_codex_browser_sessions.items()
+        if session.created_at + OPENAI_CODEX_OAUTH_TIMEOUT_SECONDS <= now
+    ]
+    for session_id in expired_browser_sessions:
+        _openai_codex_browser_sessions.pop(session_id, None)
+
+
+class _OpenAICodexOAuthCallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - stdlib callback name
+        parsed_url = urlparse(self.path)
+        if parsed_url.path != "/auth/callback":
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"Not found")
+            return
+
+        query = parse_qs(parsed_url.query)
+        state = (query.get("state") or [""])[0]
+        code = (query.get("code") or [""])[0]
+        error = (query.get("error_description") or query.get("error") or [""])[0]
+
+        session = next(
+            (item for item in _openai_codex_browser_sessions.values() if item.state == state),
+            None,
+        )
+        if session is None:
+            self._write_html(400, _openai_codex_oauth_error_html("Invalid OAuth state."))
+            return
+
+        if error:
+            session.error = error
+        elif code:
+            session.code = code
+        else:
+            session.error = "Missing OAuth authorization code."
+        session.event.set()
+
+        if session.error:
+            self._write_html(400, _openai_codex_oauth_error_html(session.error))
+        else:
+            self._write_html(200, OPENAI_CODEX_OAUTH_SUCCESS_HTML)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+    def _write_html(self, status_code: int, body: str) -> None:
+        encoded_body = body.encode("utf-8")
+        self.send_response(status_code)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded_body)))
+        self.end_headers()
+        self.wfile.write(encoded_body)
+
+
+def _ensure_openai_codex_oauth_server() -> None:
+    global _openai_codex_oauth_server
+    with _openai_codex_oauth_server_lock:
+        if _openai_codex_oauth_server is not None:
+            return
+        server = http.server.ThreadingHTTPServer(
+            ("127.0.0.1", OPENAI_CODEX_OAUTH_PORT),
+            _OpenAICodexOAuthCallbackHandler,
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        _openai_codex_oauth_server = server
+
+
+async def start_openai_codex_browser_oauth() -> dict[str, str]:
+    _cleanup_openai_codex_oauth_sessions()
+    _ensure_openai_codex_oauth_server()
+
+    verifier, challenge = _generate_pkce_codes()
+    state = _base64_url_encode(secrets.token_bytes(32))
+    session_id = uuid.uuid4().hex
+    redirect_uri = f"http://localhost:{OPENAI_CODEX_OAUTH_PORT}/auth/callback"
+    params = {
+        "response_type": "code",
+        "client_id": OPENAI_CODEX_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "scope": OPENAI_CODEX_OAUTH_SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "state": state,
+        "originator": "meridian",
+    }
+    auth_url = f"{OPENAI_CODEX_ISSUER}/oauth/authorize?{httpx.QueryParams(params)}"
+    _openai_codex_browser_sessions[session_id] = OpenAICodexBrowserAuthSession(
+        session_id=session_id,
+        verifier=verifier,
+        state=state,
+        redirect_uri=redirect_uri,
+        created_at=time.time(),
+    )
+    return {
+        "session_id": session_id,
+        "url": auth_url,
+        "instructions": "Complete authorization in your browser, then return to Meridian.",
+    }
+
+
+async def complete_openai_codex_browser_oauth(session_id: str) -> str:
+    _cleanup_openai_codex_oauth_sessions()
+    session = _openai_codex_browser_sessions.get(session_id)
+    if session is None:
+        raise ValueError("OpenAI Codex browser sign-in session expired. Start sign-in again.")
+
+    completed = await asyncio.to_thread(
+        session.event.wait,
+        max(0.0, session.created_at + OPENAI_CODEX_OAUTH_TIMEOUT_SECONDS - time.time()),
+    )
+    if not completed:
+        _openai_codex_browser_sessions.pop(session_id, None)
+        raise ValueError("OpenAI Codex browser sign-in timed out. Start sign-in again.")
+    _openai_codex_browser_sessions.pop(session_id, None)
+
+    if session.error:
+        raise ValueError(session.error)
+    if not session.code:
+        raise ValueError("OpenAI Codex browser sign-in did not return an authorization code.")
+
+    tokens = await _exchange_openai_codex_code(
+        code=session.code,
+        redirect_uri=session.redirect_uri,
+        code_verifier=session.verifier,
+    )
+    return _build_codex_auth_json_from_tokens(tokens)
+
+
+async def start_openai_codex_device_oauth() -> dict[str, Any]:
+    _cleanup_openai_codex_oauth_sessions()
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{OPENAI_CODEX_ISSUER}/api/accounts/deviceauth/usercode",
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "meridian/1.0.0",
+            },
+            json={"client_id": OPENAI_CODEX_CLIENT_ID},
+        )
+    if response.status_code >= 400:
+        raise ValueError("Failed to start OpenAI Codex device authorization.")
+
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError("OpenAI Codex device authorization returned an invalid response.")
+    device_auth_id = str(payload.get("device_auth_id") or "").strip()
+    user_code = str(payload.get("user_code") or "").strip()
+    if not device_auth_id or not user_code:
+        raise ValueError("OpenAI Codex device authorization did not return a user code.")
+
+    interval_seconds = max(int(str(payload.get("interval") or "5")), 1)
+    session_id = uuid.uuid4().hex
+    _openai_codex_device_sessions[session_id] = OpenAICodexDeviceAuthSession(
+        session_id=session_id,
+        device_auth_id=device_auth_id,
+        user_code=user_code,
+        interval_seconds=interval_seconds,
+        expires_at=time.time() + OPENAI_CODEX_OAUTH_TIMEOUT_SECONDS,
+    )
+    return {
+        "session_id": session_id,
+        "verification_url": OPENAI_CODEX_DEVICE_VERIFICATION_URL,
+        "user_code": user_code,
+        "interval_seconds": interval_seconds,
+        "instructions": f"Open {OPENAI_CODEX_DEVICE_VERIFICATION_URL} and enter code {user_code}.",
+    }
+
+
+async def complete_openai_codex_device_oauth(session_id: str) -> str:
+    _cleanup_openai_codex_oauth_sessions()
+    session = _openai_codex_device_sessions.get(session_id)
+    if session is None:
+        raise ValueError("OpenAI Codex device sign-in session expired. Start sign-in again.")
+
+    while time.time() < session.expires_at:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{OPENAI_CODEX_ISSUER}/api/accounts/deviceauth/token",
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "meridian/1.0.0",
+                },
+                json={
+                    "device_auth_id": session.device_auth_id,
+                    "user_code": session.user_code,
+                },
+            )
+
+        if response.status_code < 400:
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise ValueError("OpenAI Codex device token response was invalid.")
+            authorization_code = str(payload.get("authorization_code") or "").strip()
+            code_verifier = str(payload.get("code_verifier") or "").strip()
+            if not authorization_code or not code_verifier:
+                raise ValueError(
+                    "OpenAI Codex device sign-in did not return an authorization code."
+                )
+            _openai_codex_device_sessions.pop(session_id, None)
+            tokens = await _exchange_openai_codex_code(
+                code=authorization_code,
+                redirect_uri=OPENAI_CODEX_DEVICE_REDIRECT_URI,
+                code_verifier=code_verifier,
+            )
+            return _build_codex_auth_json_from_tokens(tokens)
+
+        if response.status_code not in {403, 404}:
+            _openai_codex_device_sessions.pop(session_id, None)
+            raise ValueError(f"OpenAI Codex device sign-in failed: {response.status_code}")
+
+        await asyncio.sleep(session.interval_seconds + OPENAI_CODEX_DEVICE_POLL_SAFETY_SECONDS)
+
+    _openai_codex_device_sessions.pop(session_id, None)
+    raise ValueError("OpenAI Codex device sign-in timed out. Start sign-in again.")
 
 
 def _build_output_schema(schema: type[BaseModel]) -> dict[str, Any]:
@@ -749,16 +1335,6 @@ def _cleanup_runtime_context(runtime_context: OpenAICodexRuntimeContext) -> None
     cleanup_runtime_dir(runtime_context.root_dir, provider_label="OpenAI Codex")
 
 
-def _read_runtime_auth_json(runtime_context: OpenAICodexRuntimeContext) -> str | None:
-    if not runtime_context.auth_json_path.is_file():
-        return None
-
-    raw_auth_json = runtime_context.auth_json_path.read_text(encoding="utf-8").strip()
-    if not raw_auth_json:
-        return None
-    return _normalize_auth_json(raw_auth_json)
-
-
 async def _persist_refreshed_auth_json(
     *,
     user_id: str,
@@ -821,21 +1397,6 @@ async def _start_codex_client(
     return client
 
 
-def _extract_account_label(account_payload: Any) -> str | None:
-    if not isinstance(account_payload, dict):
-        return None
-
-    account_type = str(account_payload.get("type") or "").strip()
-    if account_type == "chatgpt":
-        plan_type = str(account_payload.get("planType") or "").strip()
-        if plan_type:
-            return f"ChatGPT ({plan_type})"
-        return "ChatGPT"
-    if account_type == "apiKey":
-        return "API key"
-    return None
-
-
 async def _ensure_openai_auth(
     client: _CodexAppServerClient,
     *,
@@ -868,55 +1429,6 @@ def _codex_auth_error_message() -> str:
     )
 
 
-async def _list_available_models(
-    client: _CodexAppServerClient,
-) -> list[dict[str, Any]]:
-    models: list[dict[str, Any]] = []
-    cursor: str | None = None
-
-    while True:
-        params: dict[str, Any] = {"limit": 100, "includeHidden": False}
-        if cursor:
-            params["cursor"] = cursor
-
-        result = await client.request("model/list", params)
-        page_models = result.get("data")
-        if isinstance(page_models, list):
-            for model_payload in page_models:
-                if isinstance(model_payload, dict):
-                    models.append(model_payload)
-
-        next_cursor = result.get("nextCursor")
-        cursor = str(next_cursor).strip() if next_cursor is not None else None
-        if not cursor:
-            break
-
-    return models
-
-
-async def validate_openai_codex_auth_json(auth_json: str) -> str:
-    normalized_auth_json = _normalize_auth_json(auth_json)
-    runtime_context = _build_runtime_context(normalized_auth_json)
-    heartbeat_task = start_runtime_heartbeat(runtime_context.root_dir)
-    client: _CodexAppServerClient | None = None
-
-    try:
-        client = await _start_codex_client(runtime_context)
-        account_result = await _ensure_openai_auth(client, refresh_token=True)
-        available_models = await _list_available_models(client)
-        if not available_models:
-            account_label = _extract_account_label(account_result.get("account"))
-            if account_label:
-                raise ValueError(f"OpenAI Codex returned no models for {account_label}.")
-            raise ValueError("OpenAI Codex returned no models for this account.")
-        return _read_runtime_auth_json(runtime_context) or normalized_auth_json
-    finally:
-        if client is not None:
-            await client.close()
-        await stop_runtime_heartbeat(heartbeat_task)
-        _cleanup_runtime_context(runtime_context)
-
-
 async def list_openai_codex_models(
     auth_json: str,
     *,
@@ -924,47 +1436,26 @@ async def list_openai_codex_models(
     pg_engine: SQLAlchemyAsyncEngine | None = None,
 ) -> list[Any]:
     normalized_auth_json = _normalize_auth_json(auth_json)
-    runtime_context = _build_runtime_context(normalized_auth_json)
-    heartbeat_task = start_runtime_heartbeat(runtime_context.root_dir)
-    client: _CodexAppServerClient | None = None
-
+    original_auth_json = normalized_auth_json
+    normalized_auth_json = await _validate_openai_codex_auth_tokens(normalized_auth_json)
     try:
-        client = await _start_codex_client(runtime_context)
-        await _ensure_openai_auth(client, refresh_token=True)
-        raw_models = await _list_available_models(client)
-
-        normalized_models = []
-        seen_model_ids: set[str] = set()
-        for raw_model in raw_models:
-            normalized_model = normalize_openai_codex_model(raw_model)
-            if normalized_model is None or normalized_model.id in seen_model_ids:
-                continue
-            seen_model_ids.add(normalized_model.id)
-            normalized_models.append(normalized_model)
-
-        normalized_models.sort(key=lambda m: m.id, reverse=True)
-        if normalized_models:
-            normalized_models.insert(
-                0,
-                build_openai_codex_image_generation_model(normalized_models[0]),
-            )
-
-        return normalized_models
-    finally:
         try:
-            refreshed_auth_json = _read_runtime_auth_json(runtime_context)
-            if user_id and pg_engine is not None:
-                await _persist_refreshed_auth_json(
-                    user_id=user_id,
-                    pg_engine=pg_engine,
-                    current_auth_json=normalized_auth_json,
-                    refreshed_auth_json=refreshed_auth_json,
-                )
-        finally:
-            if client is not None:
-                await client.close()
-            await stop_runtime_heartbeat(heartbeat_task)
-            _cleanup_runtime_context(runtime_context)
+            return await get_models_dev_openai_codex_models()
+        except Exception:
+            logger.warning(
+                "OpenAI Codex models.dev catalog fetch failed; using default Codex model catalog.",
+                exc_info=True,
+            )
+            return get_default_openai_codex_models()
+    finally:
+        if user_id and pg_engine is not None:
+            refreshed_auth_json = normalized_auth_json
+            await _persist_refreshed_auth_json(
+                user_id=user_id,
+                pg_engine=pg_engine,
+                current_auth_json=original_auth_json,
+                refreshed_auth_json=refreshed_auth_json,
+            )
 
 
 def _normalize_reasoning_effort(config: Any, is_title_generation: bool) -> str | None:
@@ -977,81 +1468,6 @@ def _normalize_reasoning_effort(config: Any, is_title_generation: bool) -> str |
     if raw_effort in {"max", "xhigh"}:
         return "high"
     return None
-
-
-async def _build_turn_input(
-    req: OpenAICodexReqChat,
-    runtime_context: OpenAICodexRuntimeContext,
-) -> list[dict[str, Any]]:
-    input_items: list[dict[str, Any]] = []
-    image_index = 0
-
-    for message in req.messages:
-        role = normalize_role_value(message.get("role"))
-        if role not in {"system", "user", "assistant", "tool"}:
-            continue
-
-        if role == "system":
-            continue
-
-        content = message.get("content")
-        image_urls = _extract_image_urls(content)
-        text_blocks: list[str] = []
-
-        if role == "tool":
-            tool_name = str(message.get("name") or "tool").strip() or "tool"
-            tool_text = extract_text_content(content)
-            if not tool_text and content is not None and not isinstance(content, list):
-                tool_text = str(content).strip()
-            if tool_text:
-                input_items.append({"type": "text", "text": f"Tool ({tool_name}):\n{tool_text}"})
-            continue
-
-        text_content = extract_text_content(content)
-        if text_content:
-            text_blocks.append(text_content)
-
-        tool_calls_text = _summarize_tool_calls(message.get("tool_calls"))
-        if tool_calls_text:
-            text_blocks.append(f"Tool calls:\n{tool_calls_text}")
-
-        for placeholder_index in range(len(image_urls)):
-            text_blocks.append(f"Attached image {placeholder_index + 1} follows.")
-
-        if text_blocks:
-            input_items.append(
-                {
-                    "type": "text",
-                    "text": f"{role.capitalize()}:\n" + "\n\n".join(text_blocks),
-                }
-            )
-
-        for image_url in image_urls:
-            image_index += 1
-            local_image_path = await _write_local_image_input(
-                image_url,
-                input_dir=runtime_context.input_dir,
-                image_index=image_index,
-                http_client=req.http_client,
-            )
-            input_items.append({"type": "localImage", "path": str(local_image_path)})
-
-    if input_items:
-        return input_items
-
-    return [{"type": "text", "text": f"User:\n{OPENAI_CODEX_FALLBACK_USER_CONTENT}"}]
-
-
-def _format_turn_error(turn_payload: Any) -> str:
-    if not isinstance(turn_payload, dict):
-        return "OpenAI Codex turn failed."
-
-    error_payload = turn_payload.get("error")
-    if isinstance(error_payload, dict):
-        message = str(error_payload.get("message") or "").strip()
-        if message:
-            return message
-    return "OpenAI Codex turn failed."
 
 
 def _build_dynamic_tools(selected_tools: list[ToolEnum]) -> list[dict[str, Any]]:
@@ -1475,151 +1891,480 @@ class _OpenAICodexToolCallBridge:
         self.state.awaiting_user_input = True
 
 
-class _OpenAICodexEventDispatcher:
-    def __init__(
-        self,
-        state: _OpenAICodexTurnState,
-        output: _OpenAICodexOutputAssembler,
-        tool_call_bridge: _OpenAICodexToolCallBridge,
-        *,
-        usage_data_sink: dict[str, Any] | None,
-    ) -> None:
-        self.state = state
-        self.output = output
-        self.tool_call_bridge = tool_call_bridge
-        self.usage_data_sink = usage_data_sink
-        self._event_handlers: dict[str, Callable[[dict[str, Any]], Awaitable[bool]]] = {
-            "thread/tokenUsage/updated": self._handle_usage_updated,
-            "item/started": self._handle_item_started,
-            "item/reasoning/summaryPartAdded": self._handle_reasoning_summary_part_added,
-            "item/reasoning/summaryTextDelta": self._handle_reasoning_delta,
-            "item/reasoning/textDelta": self._handle_reasoning_delta,
-            "item/agentMessage/delta": self._handle_agent_message_delta,
-            "item/completed": self._handle_item_completed,
-            "turn/completed": self._handle_turn_completed,
+def _build_openai_codex_direct_content_items(
+    content: Any,
+    *,
+    assistant: bool = False,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    text_content = extract_text_content(content)
+    if text_content:
+        items.append({"type": "output_text" if assistant else "input_text", "text": text_content})
+
+    if assistant:
+        return items
+
+    for image_url in _extract_image_urls(content):
+        items.append({"type": "input_image", "image_url": image_url})
+    return items
+
+
+def _build_openai_codex_direct_input(req: OpenAICodexReqChat) -> list[dict[str, Any]]:
+    input_items: list[dict[str, Any]] = []
+
+    for message in req.messages:
+        role = normalize_role_value(message.get("role"))
+        if role not in {"system", "user", "assistant", "tool"}:
+            continue
+        if role == "system":
+            continue
+
+        if role == "tool":
+            tool_name = str(message.get("name") or "tool").strip() or "tool"
+            tool_text = extract_text_content(message.get("content"))
+            if not tool_text and message.get("content") is not None:
+                tool_text = str(message.get("content") or "").strip()
+            if tool_text:
+                input_items.append(
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": f"Tool ({tool_name}):\n{tool_text}"}
+                        ],
+                    }
+                )
+            continue
+
+        content_items = _build_openai_codex_direct_content_items(
+            message.get("content"),
+            assistant=role == "assistant",
+        )
+        tool_calls_text = _summarize_tool_calls(message.get("tool_calls"))
+        if tool_calls_text:
+            content_items.append(
+                {
+                    "type": "output_text" if role == "assistant" else "input_text",
+                    "text": f"Tool calls:\n{tool_calls_text}",
+                }
+            )
+        if not content_items:
+            continue
+        input_items.append({"type": "message", "role": role, "content": content_items})
+
+    if input_items:
+        return input_items
+    return [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": OPENAI_CODEX_FALLBACK_USER_CONTENT}],
         }
+    ]
 
-    async def dispatch(self, client: _CodexAppServerClient, event: dict[str, Any]) -> bool:
-        method = str(event.get("method") or "")
-        raw_params: Any = event.get("params")
-        params_dict: dict[str, Any] = raw_params if isinstance(raw_params, dict) else {}
-        request_id = event.get("id")
-        if request_id is not None:
-            return await self._handle_server_request(client, method, params_dict, request_id)
-        handler = self._event_handlers.get(method)
-        if handler is None:
-            return False
-        return await handler(params_dict)
 
-    async def _handle_server_request(
-        self,
-        client: _CodexAppServerClient,
-        method: str,
-        params_dict: dict[str, Any],
-        request_id: Any,
-    ) -> bool:
-        if method == "item/tool/call":
-            await self.tool_call_bridge.handle(client, params_dict, request_id)
-            return False
-        await client.respond_error(
-            request_id,
-            code=-32601,
-            message=f"Unsupported OpenAI Codex server request: {method or 'unknown'}",
+def _build_openai_codex_direct_tools(selected_tools: list[ToolEnum]) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for dynamic_tool in _build_dynamic_tools(selected_tools):
+        tools.append(
+            {
+                "type": "function",
+                "name": dynamic_tool["name"],
+                "description": dynamic_tool.get("description") or "",
+                "parameters": dynamic_tool.get("inputSchema") or {"type": "object"},
+            }
         )
-        return False
+    return tools
 
-    async def _handle_usage_updated(self, params_dict: dict[str, Any]) -> bool:
-        usage_data = _normalize_codex_usage_data(params_dict.get("tokenUsage"))
-        if usage_data is not None and self.usage_data_sink is not None:
-            self.usage_data_sink.clear()
-            self.usage_data_sink.update(usage_data)
-        return False
 
-    async def _handle_item_started(self, params_dict: dict[str, Any]) -> bool:
-        item = params_dict.get("item")
-        if not isinstance(item, dict):
-            return False
-        item_id = str(item.get("id") or "")
-        item_type = str(item.get("type") or "").strip()
-        if item_type == "reasoning":
-            self.state.reasoning_item_ids.add(item_id)
-            return False
-        if (
-            item_type == "agentMessage"
-            and str(item.get("phase") or "").strip().lower() == "commentary"
-        ):
-            self.state.commentary_item_ids.add(item_id)
-        return False
+def _build_openai_codex_text_controls(schema: type[BaseModel] | None) -> dict[str, Any] | None:
+    if schema is None:
+        return None
+    return {
+        "format": {
+            "type": "json_schema",
+            "name": schema.__name__ or "response_schema",
+            "schema": _build_output_schema(schema),
+            "strict": True,
+        }
+    }
 
-    async def _handle_reasoning_summary_part_added(self, params_dict: dict[str, Any]) -> bool:
-        item_id = str(params_dict.get("itemId") or "")
-        summary_index = params_dict.get("summaryIndex")
-        if not item_id or not isinstance(summary_index, int) or summary_index <= 0:
-            return False
-        seen_indices = self.state.reasoning_summary_indices.setdefault(item_id, set())
-        if summary_index in seen_indices:
-            return False
-        seen_indices.add(summary_index)
-        await self.output.emit_reasoning_summary_break(item_id)
-        return False
 
-    async def _handle_reasoning_delta(self, params_dict: dict[str, Any]) -> bool:
-        item_id = str(params_dict.get("itemId") or "")
-        delta = str(params_dict.get("delta") or "")
-        if item_id and delta:
-            await self.output.emit_commentary(item_id, delta)
-        return False
+def _build_openai_codex_reasoning(
+    req: OpenAICodexReqChat,
+) -> dict[str, Any] | None:
+    reasoning: dict[str, Any] = {}
+    effort = _normalize_reasoning_effort(req.config, req.is_title_generation)
+    if effort:
+        reasoning["effort"] = effort
+    if (
+        req.schema is None
+        and not req.is_title_generation
+        and not bool(getattr(req.config, "exclude_reasoning", False))
+    ):
+        reasoning["summary"] = "auto"
+    return reasoning or None
 
-    async def _handle_agent_message_delta(self, params_dict: dict[str, Any]) -> bool:
-        item_id = str(params_dict.get("itemId") or "")
-        delta = str(params_dict.get("delta") or "")
-        if not delta:
-            return False
-        if item_id in self.state.commentary_item_ids:
-            await self.output.emit_commentary(item_id, delta)
+
+def _build_openai_codex_direct_payload(
+    req: OpenAICodexReqChat,
+    input_items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    instructions = _extract_system_instructions(req.messages)
+    payload: dict[str, Any] = {
+        "model": strip_model_prefix(req.model, OPENAI_CODEX_MODEL_PREFIX),
+        "input": input_items,
+        "tools": _build_openai_codex_direct_tools(req.selected_tools),
+        "tool_choice": "auto",
+        "parallel_tool_calls": False,
+        "store": False,
+        "stream": True,
+        "include": [],
+    }
+    if instructions:
+        payload["instructions"] = instructions
+    reasoning = _build_openai_codex_reasoning(req)
+    if reasoning is not None:
+        payload["reasoning"] = reasoning
+        payload["include"] = ["reasoning.encrypted_content"]
+    text_controls = _build_openai_codex_text_controls(req.schema)
+    if text_controls is not None:
+        payload["text"] = text_controls
+    return payload
+
+
+def _build_openai_codex_direct_headers(
+    normalized_auth_json: str,
+    *,
+    req: OpenAICodexReqChat,
+) -> tuple[str, dict[str, str]]:
+    return _build_openai_codex_response_headers(
+        normalized_auth_json,
+        session_id=req.graph_id or req.node_id or req.user_id,
+    )
+
+
+def _build_openai_codex_response_headers(
+    normalized_auth_json: str,
+    *,
+    session_id: str,
+) -> tuple[str, dict[str, str]]:
+    try:
+        payload = json.loads(normalized_auth_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError("OpenAI Codex auth JSON is invalid.") from exc
+
+    headers = {
+        "Accept": "text/event-stream",
+        "Content-Type": "application/json",
+        "User-Agent": "meridian/1.0.0",
+        "originator": "meridian",
+        "session-id": session_id or f"meridian-{uuid.uuid4().hex}",
+    }
+
+    tokens = _extract_codex_auth_tokens(normalized_auth_json)
+    access_token = str(tokens.get("access_token") or "").strip() if tokens else ""
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+        account_id = str(tokens.get("account_id") or "").strip() if tokens else ""
+        if not account_id:
+            account_id = _extract_account_id_from_tokens(tokens or {}) or ""
+        if account_id:
+            headers["ChatGPT-Account-Id"] = account_id
+        return OPENAI_CODEX_API_ENDPOINT, headers
+
+    api_key = str(payload.get("OPENAI_API_KEY") or payload.get("key") or "").strip()
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+        return OPENAI_RESPONSES_API_ENDPOINT, headers
+
+    raise ValueError("OpenAI Codex OAuth tokens or API key are required.")
+
+
+def _select_openai_codex_probe_model_id() -> str:
+    for model in get_default_openai_codex_models():
+        base_model_id = get_openai_codex_base_model_id(model.id).removeprefix(
+            OPENAI_CODEX_MODEL_PREFIX
+        )
+        if base_model_id:
+            return base_model_id
+    return "gpt-5.5"
+
+
+def _format_openai_codex_auth_probe_error(status_code: int, body: str) -> str:
+    detail = body[:500].strip()
+    suffix = f" ({status_code} {detail})" if detail else f" ({status_code})"
+    return "OpenAI Codex authentication is invalid or unavailable. Sign in again." + suffix
+
+
+async def _probe_openai_api_key_auth(api_key: str) -> None:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(
+            OPENAI_MODELS_API_ENDPOINT,
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+    if response.status_code >= 400:
+        raise ValueError(
+            _format_openai_codex_auth_probe_error(
+                response.status_code,
+                response.text,
+            )
+        )
+
+
+async def _probe_openai_codex_auth(normalized_auth_json: str) -> None:
+    payload = json.loads(normalized_auth_json)
+    api_key = str(payload.get("OPENAI_API_KEY") or payload.get("key") or "").strip()
+    if api_key:
+        await _probe_openai_api_key_auth(api_key)
+        return
+
+    endpoint, headers = _build_openai_codex_response_headers(
+        normalized_auth_json,
+        session_id=f"auth-probe-{uuid.uuid4().hex}",
+    )
+    probe_payload = {
+        "model": _select_openai_codex_probe_model_id(),
+        "instructions": OPENAI_CODEX_AUTH_PROBE_INSTRUCTIONS,
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": OPENAI_CODEX_AUTH_PROBE_INPUT}],
+            }
+        ],
+        "store": False,
+        "stream": True,
+        "include": [],
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
+        async with client.stream("POST", endpoint, headers=headers, json=probe_payload) as response:
+            if response.status_code >= 400:
+                body = (await response.aread()).decode("utf-8", errors="replace")
+                raise ValueError(_format_openai_codex_auth_probe_error(response.status_code, body))
+            async for event_type, event_data in _iter_openai_codex_sse_events(response):
+                error_payload = event_data.get("error")
+                if event_type in {"error", "response.failed"} or error_payload:
+                    error_text = json.dumps(error_payload or event_data, separators=(",", ":"))
+                    raise ValueError(_format_openai_codex_auth_probe_error(200, error_text))
+                return
+
+
+async def _iter_openai_codex_sse_events(
+    response: httpx.Response,
+) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+    event_type = ""
+    data_lines: list[str] = []
+    buffer = ""
+
+    async def emit_event() -> tuple[str, dict[str, Any]] | None:
+        nonlocal event_type, data_lines
+        if not data_lines:
+            event_type = ""
+            return None
+        data = "\n".join(data_lines).strip()
+        data_lines = []
+        current_event_type = event_type
+        event_type = ""
+        if not data or data == "[DONE]":
+            return None
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        return current_event_type or str(parsed.get("type") or ""), parsed
+
+    async for byte_chunk in response.aiter_bytes():
+        buffer += byte_chunk.decode("utf-8", errors="ignore")
+        lines = buffer.splitlines(keepends=True)
+        if lines and not lines[-1].endswith(("\n", "\r")):
+            buffer = lines.pop()
         else:
-            await self.output.emit_text(item_id, delta)
-        return False
+            buffer = ""
 
-    async def _handle_item_completed(self, params_dict: dict[str, Any]) -> bool:
-        item = params_dict.get("item")
-        if not isinstance(item, dict):
-            return False
-        item_id = str(item.get("id") or "")
-        item_type = str(item.get("type") or "").strip()
-        if item_type == "reasoning" or item_id in self.state.reasoning_item_ids:
-            await self.output.sync_completed_reasoning(item_id, _extract_reasoning_item_text(item))
-            return False
-        if item_type != "agentMessage":
-            return False
-        await self.output.sync_completed_agent_message(
-            item_id,
-            str(item.get("text") or ""),
-            is_commentary=(
-                str(item.get("phase") or "").strip().lower() == "commentary"
-                or item_id in self.state.commentary_item_ids
-            ),
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                emitted = await emit_event()
+                if emitted is not None:
+                    yield emitted
+                continue
+            if line.startswith("event:"):
+                event_type = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[len("data:") :].strip())
+
+    if buffer:
+        line = buffer.strip()
+        if line.startswith("event:"):
+            event_type = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[len("data:") :].strip())
+
+    if data_lines:
+        emitted = await emit_event()
+        if emitted is not None:
+            yield emitted
+
+
+def _extract_openai_codex_message_text(item: Any) -> str:
+    if not isinstance(item, dict):
+        return ""
+    content = item.get("content")
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for content_item in content:
+        if not isinstance(content_item, dict):
+            continue
+        if content_item.get("type") not in {"output_text", "input_text"}:
+            continue
+        text = str(content_item.get("text") or "")
+        if text:
+            parts.append(text)
+    return "".join(parts)
+
+
+def _normalize_openai_responses_usage_data(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        usage = payload
+
+    prompt_tokens = int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
+    completion_tokens = int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0)
+    total_tokens = int(usage.get("total_tokens", 0) or 0) or prompt_tokens + completion_tokens
+    input_details = usage.get("input_tokens_details")
+    output_details = usage.get("output_tokens_details")
+    cached_tokens = (
+        int(input_details.get("cached_tokens", 0) or 0) if isinstance(input_details, dict) else 0
+    )
+    reasoning_tokens = (
+        int(output_details.get("reasoning_tokens", 0) or 0)
+        if isinstance(output_details, dict)
+        else 0
+    )
+    if not any((prompt_tokens, completion_tokens, total_tokens, cached_tokens, reasoning_tokens)):
+        return None
+    return {
+        "cost": 0.0,
+        "is_byok": False,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "prompt_tokens_details": {"cached_tokens": cached_tokens},
+        "completion_tokens_details": {"reasoning_tokens": reasoning_tokens},
+    }
+
+
+def _extract_openai_codex_completed_usage(event_data: dict[str, Any]) -> dict[str, Any] | None:
+    response_payload = event_data.get("response")
+    if isinstance(response_payload, dict):
+        usage_data = _normalize_openai_responses_usage_data(response_payload.get("usage"))
+        if usage_data is not None:
+            return usage_data
+    return _normalize_openai_responses_usage_data(event_data.get("usage"))
+
+
+async def _run_openai_codex_direct_tool_call(
+    *,
+    req: OpenAICodexReqChat,
+    state: _OpenAICodexTurnState,
+    output: _OpenAICodexOutputAssembler,
+    redis_manager: RedisManager | None,
+    pending_tool_call_id_sink: dict[str, Any] | None,
+    item: dict[str, Any],
+    mixed_tool_round: bool = False,
+) -> dict[str, Any]:
+    tool_name = str(item.get("name") or "").strip()
+    call_id = str(item.get("call_id") or item.get("id") or "").strip()
+    if not call_id:
+        call_id = f"openai-codex-call-{uuid.uuid4().hex}"
+    arguments = _parse_dynamic_tool_arguments(item.get("arguments"))
+    runtime = get_tool_runtime(tool_name)
+    handler = TOOL_HANDLERS_BY_NAME.get(tool_name)
+    bridge = _OpenAICodexToolCallBridge(
+        req,
+        state,
+        output,
+        redis_manager=redis_manager,
+        pending_tool_call_id_sink=pending_tool_call_id_sink,
+    )
+    tool_result, duration_ms = await bridge._run_tool(handler, tool_name, arguments)
+
+    if tool_name == ASK_USER_TOOL_NAME and mixed_tool_round:
+        tool_result = {"error": ASK_USER_BATCH_ERROR}
+
+    normalized_result = normalize_tool_storage_value(tool_result)
+    status = resolve_tool_status(tool_result)
+    model_context_payload = json.dumps(normalized_result, separators=(",", ":"))
+    if (
+        tool_name == ASK_USER_TOOL_NAME
+        and status != ToolCallStatusEnum.ERROR
+        and output.on_chunk is None
+    ):
+        tool_result = {"error": "OpenAI Codex ask_user requires streaming mode."}
+        normalized_result = normalize_tool_storage_value(tool_result)
+        status = resolve_tool_status(tool_result)
+        model_context_payload = json.dumps(normalized_result, separators=(",", ":"))
+
+    persisted_arguments = arguments
+    persisted_result = normalized_result
+    persisted_status = status
+    persisted_payload = model_context_payload
+    if tool_name == ASK_USER_TOOL_NAME and status != ToolCallStatusEnum.ERROR:
+        pending_result = AskUserPendingResult().model_dump()
+        persisted_arguments = (
+            normalized_result if isinstance(normalized_result, dict) else arguments
         )
-        return False
+        persisted_result = pending_result
+        persisted_status = ToolCallStatusEnum.PENDING_USER_INPUT
+        persisted_payload = json.dumps(pending_result, separators=(",", ":"))
 
-    async def _handle_turn_completed(self, params_dict: dict[str, Any]) -> bool:
-        turn_data = params_dict.get("turn")
-        if not isinstance(turn_data, dict) or str(turn_data.get("id") or "") != self.state.turn_id:
-            return False
-        turn_status = str(turn_data.get("status") or "").strip().lower()
-        if turn_status == "completed" or (
-            turn_status == "interrupted" and self.state.awaiting_user_input
-        ):
-            await self.output.close_thinking()
-            return True
-        raise ValueError(_format_turn_error(turn_data))
+    public_tool_call_id = await _persist_tool_call(
+        req=req,
+        tool_call_id=call_id,
+        tool_name=tool_name,
+        arguments=persisted_arguments,
+        normalized_result=persisted_result,
+        model_context_payload=persisted_payload,
+        status=persisted_status,
+        duration_ms=duration_ms,
+    )
+
+    if runtime is not None:
+        await output.emit_feedback(
+            runtime.summary_renderer(
+                public_tool_call_id,
+                arguments,
+                persisted_result if tool_name == ASK_USER_TOOL_NAME else tool_result,
+                duration_ms,
+            )
+        )
+
+    if tool_name == ASK_USER_TOOL_NAME and status != ToolCallStatusEnum.ERROR:
+        await bridge._persist_pending_tool_continuation(
+            public_tool_call_id=public_tool_call_id,
+            tool_name=tool_name,
+            tool_call_id=call_id,
+            arguments=arguments,
+        )
+
+    return {
+        "type": "function_call_output",
+        "call_id": call_id,
+        "output": persisted_payload,
+    }
 
 
-class _OpenAICodexTurnRunner:
+class _OpenAICodexDirectTurnRunner:
     def __init__(
         self,
         req: OpenAICodexReqChat,
-        runtime_context: OpenAICodexRuntimeContext,
+        normalized_auth_json: str,
         *,
         on_chunk: Callable[[str], Awaitable[None]] | None = None,
         redis_manager: RedisManager | None = None,
@@ -1627,95 +2372,218 @@ class _OpenAICodexTurnRunner:
         pending_tool_call_id_sink: dict[str, Any] | None = None,
     ) -> None:
         self.req = req
-        self.runtime_context = runtime_context
-        self.client: _CodexAppServerClient | None = None
-        self.state = _OpenAICodexTurnState()
+        self.normalized_auth_json = normalized_auth_json
+        self.on_chunk = on_chunk
+        self.redis_manager = redis_manager
+        self.usage_data_sink = usage_data_sink
+        self.pending_tool_call_id_sink = pending_tool_call_id_sink
+        self.state = _OpenAICodexTurnState(turn_id=f"direct-{uuid.uuid4().hex}")
         self.output = _OpenAICodexOutputAssembler(req, self.state, on_chunk)
-        self.tool_call_bridge = _OpenAICodexToolCallBridge(
-            req,
-            self.state,
-            self.output,
-            redis_manager=redis_manager,
-            pending_tool_call_id_sink=pending_tool_call_id_sink,
-        )
-        self.dispatcher = _OpenAICodexEventDispatcher(
-            self.state,
-            self.output,
-            self.tool_call_bridge,
-            usage_data_sink=usage_data_sink,
-        )
+        self.function_call_argument_deltas: dict[str, str] = {}
 
     async def run(self) -> str:
-        self.client = await _start_codex_client(self.runtime_context)
+        endpoint, headers = _build_openai_codex_direct_headers(
+            self.normalized_auth_json,
+            req=self.req,
+        )
+        input_items = _build_openai_codex_direct_input(self.req)
+        owned_client: httpx.AsyncClient | None = None
+        client = self.req.http_client
+        if client is None:
+            timeout = httpx.Timeout(OPENAI_CODEX_TURN_TIMEOUT_SECONDS, connect=30.0)
+            owned_client = httpx.AsyncClient(timeout=timeout)
+            client = owned_client
+
         try:
-            await _ensure_openai_auth(self.client, refresh_token=True)
-            await self._start_turn()
-            while True:
-                event = await self.client.next_event()
-                if await self.dispatcher.dispatch(self.client, event):
+            for _ in range(8):
+                function_calls = await self._stream_one_request(
+                    client,
+                    endpoint=endpoint,
+                    headers=headers,
+                    input_items=input_items,
+                )
+                if self.state.awaiting_user_input:
                     return self.output.build_output()
+                if not function_calls:
+                    return self.output.build_output()
+                input_items.extend(function_calls)
+                mixed_tool_round = len(function_calls) > 1
+                for function_call in function_calls:
+                    function_output = await _run_openai_codex_direct_tool_call(
+                        req=self.req,
+                        state=self.state,
+                        output=self.output,
+                        redis_manager=self.redis_manager,
+                        pending_tool_call_id_sink=self.pending_tool_call_id_sink,
+                        item=function_call,
+                        mixed_tool_round=mixed_tool_round,
+                    )
+                    if self.state.awaiting_user_input:
+                        return self.output.build_output()
+                    input_items.append(function_output)
+                if self.state.awaiting_user_input:
+                    return self.output.build_output()
+            raise ValueError("OpenAI Codex exceeded the maximum tool continuation rounds.")
         finally:
             await self.output.finalize_stream()
-            if self.client is not None:
-                await self.client.close()
+            if owned_client is not None:
+                await owned_client.aclose()
 
-    async def _start_turn(self) -> None:
-        assert self.client is not None
-        turn_input = await _build_turn_input(self.req, self.runtime_context)
-        dynamic_tools = _build_dynamic_tools(self.req.selected_tools)
-        thread_result = await self.client.request(
-            "thread/start",
-            {
-                "model": strip_model_prefix(self.req.model, OPENAI_CODEX_MODEL_PREFIX),
-                "cwd": str(self.runtime_context.cwd),
-                "approvalPolicy": "never",
-                "sandboxPolicy": {"type": "readOnly"},
-                "serviceName": "meridian",
-                "dynamicTools": dynamic_tools,
-            },
-        )
-        thread_payload = thread_result.get("thread")
-        if not isinstance(thread_payload, dict) or not thread_payload.get("id"):
-            raise ValueError("OpenAI Codex failed to start a conversation thread.")
-        self.state.thread_id = str(thread_payload["id"])
-        turn_params: dict[str, Any] = {"threadId": self.state.thread_id, "input": turn_input}
-        if self.req.schema is not None:
-            turn_params["outputSchema"] = _build_output_schema(self.req.schema)
-        if (
-            self.req.schema is None
-            and not self.req.is_title_generation
-            and not bool(getattr(self.req.config, "exclude_reasoning", False))
-        ):
-            turn_params["summary"] = "auto"
-        reasoning_effort = _normalize_reasoning_effort(
-            self.req.config, self.req.is_title_generation
-        )
-        if reasoning_effort:
-            turn_params["effort"] = reasoning_effort
-        turn_result = await self.client.request("turn/start", turn_params)
-        turn_payload = turn_result.get("turn")
-        if not isinstance(turn_payload, dict) or not turn_payload.get("id"):
-            raise ValueError("OpenAI Codex failed to start a turn.")
-        self.state.turn_id = str(turn_payload["id"])
+    async def _stream_one_request(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        endpoint: str,
+        headers: dict[str, str],
+        input_items: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        payload = _build_openai_codex_direct_payload(self.req, input_items)
+        function_calls: list[dict[str, Any]] = []
+        async with client.stream("POST", endpoint, headers=headers, json=payload) as response:
+            if response.status_code >= 400:
+                error_content = await response.aread()
+                raise ValueError(
+                    "OpenAI Codex request failed: "
+                    f"{response.status_code} {error_content.decode('utf-8', errors='ignore')}"
+                )
+
+            async for event_type, event_data in _iter_openai_codex_sse_events(response):
+                await self._handle_response_event(event_type, event_data, function_calls)
+        return function_calls
+
+    async def _handle_response_event(
+        self,
+        event_type: str,
+        event_data: dict[str, Any],
+        function_calls: list[dict[str, Any]],
+    ) -> None:
+        event_type = event_type or str(event_data.get("type") or "")
+        if event_type == "response.output_text.delta":
+            delta = str(event_data.get("delta") or "")
+            item_id = str(event_data.get("item_id") or event_data.get("output_index") or "message")
+            await self.output.emit_text(item_id, delta)
+            return
+        if event_type in {"response.reasoning_summary_text.delta", "response.reasoning_text.delta"}:
+            delta = str(event_data.get("delta") or "")
+            await self.output.emit_commentary("reasoning", delta)
+            return
+        if event_type == "response.reasoning_summary_part.added":
+            await self.output.emit_reasoning_summary_break("reasoning")
+            return
+        if event_type == "response.function_call_arguments.delta":
+            item_id = str(event_data.get("item_id") or event_data.get("output_index") or "")
+            if item_id:
+                self.function_call_argument_deltas[item_id] = (
+                    self.function_call_argument_deltas.get(item_id, "")
+                    + str(event_data.get("delta") or "")
+                )
+            return
+        if event_type == "response.output_item.done":
+            item = event_data.get("item")
+            if not isinstance(item, dict):
+                return
+            item_type = str(item.get("type") or "")
+            item_id = str(item.get("id") or event_data.get("item_id") or "")
+            if item_type == "message":
+                await self.output.sync_completed_agent_message(
+                    item_id or "message",
+                    _extract_openai_codex_message_text(item),
+                    is_commentary=str(item.get("phase") or "").strip().lower() == "commentary",
+                )
+                return
+            if item_type == "reasoning":
+                await self.output.sync_completed_reasoning(
+                    item_id or "reasoning", _extract_reasoning_item_text(item)
+                )
+                return
+            if item_type == "function_call":
+                if item_id and not item.get("arguments"):
+                    item["arguments"] = self.function_call_argument_deltas.get(item_id, "")
+                function_calls.append(item)
+                return
+        if event_type == "response.completed":
+            usage_data = _extract_openai_codex_completed_usage(event_data)
+            if usage_data is not None and self.usage_data_sink is not None:
+                self.usage_data_sink.clear()
+                self.usage_data_sink.update(usage_data)
 
 
-async def _run_openai_codex_turn(
+async def _run_openai_codex_direct_turn(
     req: OpenAICodexReqChat,
-    runtime_context: OpenAICodexRuntimeContext,
+    normalized_auth_json: str,
     *,
     on_chunk: Callable[[str], Awaitable[None]] | None = None,
     redis_manager: RedisManager | None = None,
     usage_data_sink: dict[str, Any] | None = None,
     pending_tool_call_id_sink: dict[str, Any] | None = None,
 ) -> str:
-    return await _OpenAICodexTurnRunner(
+    return await _OpenAICodexDirectTurnRunner(
         req,
-        runtime_context,
+        normalized_auth_json,
         on_chunk=on_chunk,
         redis_manager=redis_manager,
         usage_data_sink=usage_data_sink,
         pending_tool_call_id_sink=pending_tool_call_id_sink,
     ).run()
+
+
+def _build_openai_codex_direct_image_input(
+    message_content: str | list[dict[str, Any]],
+    *,
+    aspect_ratio: str,
+    resolution: str,
+) -> list[dict[str, Any]]:
+    content_items = _build_openai_codex_direct_content_items(message_content)
+    prompt_suffix = (
+        "\n\nUse the built-in image_generation tool exactly once. "
+        "Generate one PNG image only. "
+        f"Aspect ratio: {aspect_ratio}. Target resolution: {resolution}. "
+        "Do not create SVG, HTML, code, or text-only output."
+    )
+    for content_item in content_items:
+        if content_item.get("type") == "input_text":
+            content_item["text"] = f"{content_item.get('text') or ''}{prompt_suffix}"
+            break
+    else:
+        content_items.insert(0, {"type": "input_text", "text": prompt_suffix.strip()})
+
+    return [{"type": "message", "role": "user", "content": content_items}]
+
+
+def _build_openai_codex_direct_image_payload(
+    *,
+    model: str,
+    input_items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "model": get_openai_codex_image_generation_base_model_id(model),
+        "instructions": OPENAI_CODEX_IMAGE_GENERATION_INSTRUCTIONS,
+        "input": input_items,
+        "tools": [{"type": "image_generation", "action": "generate", "partial_images": 0}],
+        "store": False,
+        "stream": True,
+    }
+
+
+def _extract_openai_codex_direct_image_result(
+    event_data: dict[str, Any],
+) -> tuple[bytes, str] | None:
+    response = event_data.get("response")
+    output_items = response.get("output") if isinstance(response, dict) else None
+    if not isinstance(output_items, list):
+        output_items = event_data.get("output")
+    if not isinstance(output_items, list):
+        return None
+
+    for item in output_items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") != "image_generation_call":
+            continue
+        image_payload = _extract_generated_image_payload(item)
+        if image_payload is not None:
+            return image_payload
+    return None
 
 
 async def generate_image_with_openai_codex(
@@ -1728,139 +2596,60 @@ async def generate_image_with_openai_codex(
     http_client: Optional[httpx.AsyncClient],
 ) -> OpenAICodexGeneratedImage:
     normalized_auth_json = _normalize_auth_json(auth_json)
-    runtime_context = _build_runtime_context(
+    normalized_auth_json = await _refresh_openai_codex_auth_if_needed(normalized_auth_json)
+    endpoint, headers = _build_openai_codex_response_headers(
         normalized_auth_json,
-        enable_image_generation=True,
+        session_id=f"image-{uuid.uuid4().hex}",
     )
-    heartbeat_task = start_runtime_heartbeat(runtime_context.root_dir)
-    client: _CodexAppServerClient | None = None
-
-    try:
-        client = await _start_codex_client(runtime_context)
-        await _ensure_openai_auth(client, refresh_token=True)
-        if _is_codex_auth_stderr(client.stderr_text):
-            raise ValueError(_codex_auth_error_message())
-        thread_result = await client.request(
-            "thread/start",
-            {
-                "model": strip_model_prefix(
-                    get_openai_codex_base_model_id(model),
-                    OPENAI_CODEX_MODEL_PREFIX,
-                ),
-                "cwd": str(runtime_context.cwd),
-                "approvalPolicy": "never",
-                "sandboxPolicy": {"type": "readOnly"},
-                "serviceName": "meridian",
-                "dynamicTools": [],
-            },
-        )
-        thread_payload = thread_result.get("thread")
-        if not isinstance(thread_payload, dict) or not thread_payload.get("id"):
-            raise ValueError("OpenAI Codex failed to start an image generation thread.")
-
-        turn_input = await _build_image_generation_turn_input(
+    payload = _build_openai_codex_direct_image_payload(
+        model=model,
+        input_items=_build_openai_codex_direct_image_input(
             message_content,
-            runtime_context=runtime_context,
             aspect_ratio=aspect_ratio,
             resolution=resolution,
-            http_client=http_client,
+        ),
+    )
+    owned_client: httpx.AsyncClient | None = None
+    client = http_client
+    if client is None:
+        owned_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(OPENAI_CODEX_TURN_TIMEOUT_SECONDS, connect=30.0)
         )
-        turn_result = await client.request(
-            "turn/start",
-            {"threadId": str(thread_payload["id"]), "input": turn_input},
-        )
-        turn_payload = turn_result.get("turn")
-        if not isinstance(turn_payload, dict) or not turn_payload.get("id"):
-            raise ValueError("OpenAI Codex failed to start an image generation turn.")
-        turn_id = str(turn_payload["id"])
+        client = owned_client
 
-        while True:
-            event = await client.next_event(timeout=OPENAI_CODEX_TURN_TIMEOUT_SECONDS)
-            image_item = _extract_completed_image_generation_item(event)
-            if image_item is not None:
-                logger.info(
-                    "OpenAI Codex image generation item completed: %s",
-                    _summarize_codex_image_generation_item(image_item),
+    try:
+        async with client.stream("POST", endpoint, headers=headers, json=payload) as response:
+            if response.status_code >= 400:
+                body = (await response.aread()).decode("utf-8", errors="replace")
+                raise ValueError(
+                    f"OpenAI Codex image generation failed: {response.status_code} {body[:500]}"
                 )
-                status = str(image_item.get("status") or "").strip().lower()
-                generated_payload = _extract_generated_image_payload(image_item)
+            async for event_type, event_data in _iter_openai_codex_sse_events(response):
+                if event_type == "response.output_item.done":
+                    item = event_data.get("item")
+                    if isinstance(item, dict) and item.get("type") == "image_generation_call":
+                        generated_payload = _extract_generated_image_payload(item)
+                        if generated_payload is not None:
+                            image_bytes, extension = generated_payload
+                            return OpenAICodexGeneratedImage(
+                                image_bytes=image_bytes,
+                                extension=extension,
+                                model=model,
+                            )
+                if event_type != "response.completed":
+                    continue
+                generated_payload = _extract_openai_codex_direct_image_result(event_data)
                 if generated_payload is not None:
                     image_bytes, extension = generated_payload
-                    logger.info(
-                        "OpenAI Codex image generation returned %s bytes as %s with status %s.",
-                        len(image_bytes),
-                        extension,
-                        status or "unknown",
-                    )
                     return OpenAICodexGeneratedImage(
                         image_bytes=image_bytes,
                         extension=extension,
                         model=model,
                     )
-                if status not in {"completed", "succeeded", "success"}:
-                    logger.warning(
-                        "OpenAI Codex image generation failed with status %s; stderr=%s",
-                        status or "unknown",
-                        client.stderr_text,
-                    )
-                    raise ValueError(
-                        f"OpenAI Codex image generation failed with status {status or 'unknown'}."
-                    )
-                else:
-                    logger.warning(
-                        "OpenAI Codex image generation returned no image payload; "
-                        "item=%s; stderr=%s",
-                        _summarize_codex_image_generation_item(image_item),
-                        client.stderr_text,
-                    )
-                    if _is_codex_auth_stderr(client.stderr_text):
-                        raise ValueError(_codex_auth_error_message())
-                    raise ValueError("OpenAI Codex returned no image data.")
-
-            if str(event.get("method") or "") != "turn/completed":
-                continue
-            params = event.get("params")
-            params_dict = params if isinstance(params, dict) else {}
-            completed_turn = params_dict.get("turn")
-            if (
-                not isinstance(completed_turn, dict)
-                or str(completed_turn.get("id") or "") != turn_id
-            ):
-                continue
-            image_item = _find_completed_image_generation_item(completed_turn.get("items"))
-            if image_item is not None:
-                logger.info(
-                    "OpenAI Codex turn completed with image item: %s",
-                    _summarize_codex_image_generation_item(image_item),
-                )
-                generated_payload = _extract_generated_image_payload(image_item)
-                if generated_payload is not None:
-                    image_bytes, extension = generated_payload
-                    logger.info(
-                        "OpenAI Codex image generation returned %s bytes as %s from turn payload.",
-                        len(image_bytes),
-                        extension,
-                    )
-                    return OpenAICodexGeneratedImage(
-                        image_bytes=image_bytes,
-                        extension=extension,
-                        model=model,
-                    )
-            logger.warning(
-                "OpenAI Codex image generation turn completed without image payload; "
-                "turn_status=%s; items=%s; stderr=%s",
-                completed_turn.get("status") if isinstance(completed_turn, dict) else None,
-                _summarize_codex_turn_items(completed_turn.get("items")),
-                client.stderr_text,
-            )
-            if _is_codex_auth_stderr(client.stderr_text):
-                raise ValueError(_codex_auth_error_message())
-            raise ValueError("OpenAI Codex completed without returning an image.")
+        raise ValueError("OpenAI Codex completed without returning an image.")
     finally:
-        if client is not None:
-            await client.close()
-        await stop_runtime_heartbeat(heartbeat_task)
-        _cleanup_runtime_context(runtime_context)
+        if owned_client is not None:
+            await owned_client.aclose()
 
 
 async def make_openai_codex_request_non_streaming(
@@ -1871,15 +2660,13 @@ async def make_openai_codex_request_non_streaming(
     if ToolEnum.ASK_USER in req.selected_tools:
         raise ValueError("OpenAI Codex ask_user requires streaming mode.")
     usage_data: dict[str, Any] = {}
-    runtime_context = _build_runtime_context(
-        _normalize_auth_json(req.auth_json),
-        model_instructions=_extract_system_instructions(req.messages),
+    normalized_auth_json = await _refresh_openai_codex_auth_if_needed(
+        _normalize_auth_json(req.auth_json)
     )
-    heartbeat_task = start_runtime_heartbeat(runtime_context.root_dir)
     try:
-        response_text = await _run_openai_codex_turn(
+        response_text = await _run_openai_codex_direct_turn(
             req,
-            runtime_context,
+            normalized_auth_json,
             usage_data_sink=usage_data,
         )
         if usage_data and req.graph_id and req.node_id and not req.is_title_generation:
@@ -1893,16 +2680,12 @@ async def make_openai_codex_request_non_streaming(
             )
         return response_text
     finally:
-        try:
-            await _persist_refreshed_auth_json(
-                user_id=req.user_id,
-                pg_engine=pg_engine,
-                current_auth_json=req.auth_json,
-                refreshed_auth_json=_read_runtime_auth_json(runtime_context),
-            )
-        finally:
-            await stop_runtime_heartbeat(heartbeat_task)
-            _cleanup_runtime_context(runtime_context)
+        await _persist_refreshed_auth_json(
+            user_id=req.user_id,
+            pg_engine=pg_engine,
+            current_auth_json=req.auth_json,
+            refreshed_auth_json=normalized_auth_json,
+        )
 
 
 async def stream_openai_codex_response(
@@ -1914,11 +2697,9 @@ async def stream_openai_codex_response(
     req.validate_request()
     usage_data: dict[str, Any] = {}
     turn_task: asyncio.Task[str] | None = None
-    runtime_context = _build_runtime_context(
-        _normalize_auth_json(req.auth_json),
-        model_instructions=_extract_system_instructions(req.messages),
+    normalized_auth_json = await _refresh_openai_codex_auth_if_needed(
+        _normalize_auth_json(req.auth_json)
     )
-    heartbeat_task = start_runtime_heartbeat(runtime_context.root_dir)
     try:
         queue: asyncio.Queue[str | None] = asyncio.Queue()
         pending_tool_call_state: dict[str, Any] = {}
@@ -1927,9 +2708,9 @@ async def stream_openai_codex_response(
             await queue.put(chunk)
 
         turn_task = asyncio.create_task(
-            _run_openai_codex_turn(
+            _run_openai_codex_direct_turn(
                 req,
-                runtime_context,
+                normalized_auth_json,
                 on_chunk=push_chunk,
                 redis_manager=redis_manager,
                 usage_data_sink=usage_data,
@@ -1967,17 +2748,13 @@ async def stream_openai_codex_response(
         logger.error("OpenAI Codex streaming error: %s", exc, exc_info=True)
         yield f"[ERROR]{GENERIC_STREAM_ERROR_MESSAGE}[!ERROR]"
     finally:
-        try:
-            if turn_task is not None and not turn_task.done():
-                turn_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await turn_task
-            await _persist_refreshed_auth_json(
-                user_id=req.user_id,
-                pg_engine=pg_engine,
-                current_auth_json=req.auth_json,
-                refreshed_auth_json=_read_runtime_auth_json(runtime_context),
-            )
-        finally:
-            await stop_runtime_heartbeat(heartbeat_task)
-            _cleanup_runtime_context(runtime_context)
+        if turn_task is not None and not turn_task.done():
+            turn_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await turn_task
+        await _persist_refreshed_auth_json(
+            user_id=req.user_id,
+            pg_engine=pg_engine,
+            current_auth_json=req.auth_json,
+            refreshed_auth_json=normalized_auth_json,
+        )

--- a/api/app/services/openai_codex.py
+++ b/api/app/services/openai_codex.py
@@ -50,9 +50,7 @@ from services.providers.common import (
 from services.providers.openai_codex_catalog import (
     OPENAI_CODEX_MODEL_PREFIX,
     OPENAI_CODEX_PROVIDER_KEY,
-    get_default_openai_codex_models,
     get_models_dev_openai_codex_models,
-    get_openai_codex_base_model_id,
     get_openai_codex_image_generation_base_model_id,
 )
 from services.providers.tool_continuation import persist_pending_tool_continuation
@@ -1434,19 +1432,20 @@ async def list_openai_codex_models(
     *,
     user_id: str | None = None,
     pg_engine: SQLAlchemyAsyncEngine | None = None,
+    models_dev_catalog: Any | None = None,
 ) -> list[Any]:
     normalized_auth_json = _normalize_auth_json(auth_json)
     original_auth_json = normalized_auth_json
     normalized_auth_json = await _validate_openai_codex_auth_tokens(normalized_auth_json)
     try:
         try:
-            return await get_models_dev_openai_codex_models()
+            return await get_models_dev_openai_codex_models(models_dev_catalog)
         except Exception:
             logger.warning(
-                "OpenAI Codex models.dev catalog fetch failed; using default Codex model catalog.",
+                "OpenAI Codex models.dev catalog unavailable; omitting Codex models.",
                 exc_info=True,
             )
-            return get_default_openai_codex_models()
+            return []
     finally:
         if user_id and pg_engine is not None:
             refreshed_auth_json = normalized_auth_json
@@ -2082,12 +2081,6 @@ def _build_openai_codex_response_headers(
 
 
 def _select_openai_codex_probe_model_id() -> str:
-    for model in get_default_openai_codex_models():
-        base_model_id = get_openai_codex_base_model_id(model.id).removeprefix(
-            OPENAI_CODEX_MODEL_PREFIX
-        )
-        if base_model_id:
-            return base_model_id
     return "gpt-5.5"
 
 

--- a/api/app/services/opencode_go.py
+++ b/api/app/services/opencode_go.py
@@ -35,8 +35,6 @@ from services.providers.openai_protocol import (
     stream_openai_compatible_response,
 )
 from services.providers.opencode_go_catalog import (
-    OPENCODE_GO_ANTHROPIC_MODEL_IDS,
-    OPENCODE_GO_IMAGE_INPUT_MODEL_IDS,
     OPENCODE_GO_MODEL_PREFIX,
     OPENCODE_GO_TEMPERATURE_OVERRIDES,
     OPENCODE_GO_TOP_P_OVERRIDES,
@@ -104,12 +102,16 @@ def _build_opencode_go_authoritative_system_prompt(
 
 
 def _uses_anthropic_protocol(model_id: str) -> bool:
-    return strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX) in OPENCODE_GO_ANTHROPIC_MODEL_IDS
+    model_key = strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX)
+    return model_key.startswith(("minimax-", "qwen"))
 
 
 def _supports_image_inputs(model_id: str) -> bool:
+    model_key = strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX)
     return (
-        strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX) in OPENCODE_GO_IMAGE_INPUT_MODEL_IDS
+        model_key.startswith("kimi-k2.")
+        or model_key in {"mimo-v2-omni", "mimo-v2.5", "minimax-m3"}
+        or (model_key.startswith("qwen") and model_key.endswith("-plus"))
     )
 
 

--- a/api/app/services/providers/models_dev.py
+++ b/api/app/services/providers/models_dev.py
@@ -3,7 +3,7 @@ from typing import Any
 import httpx
 
 MODELS_DEV_API_URL = "https://models.dev/api.json"
-MODELS_DEV_USED_PROVIDER_KEYS = ("openai", "zai-coding-plan")
+MODELS_DEV_USED_PROVIDER_KEYS = ("openai", "zai-coding-plan", "opencode-go")
 
 
 def reduce_models_dev_catalog(payload: Any) -> dict[str, dict[str, Any]]:

--- a/api/app/services/providers/models_dev.py
+++ b/api/app/services/providers/models_dev.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+import httpx
+
+MODELS_DEV_API_URL = "https://models.dev/api.json"
+MODELS_DEV_USED_PROVIDER_KEYS = ("openai", "zai-coding-plan")
+
+
+def reduce_models_dev_catalog(payload: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return {}
+
+    catalog: dict[str, dict[str, Any]] = {}
+    for provider_key in MODELS_DEV_USED_PROVIDER_KEYS:
+        provider_payload = payload.get(provider_key)
+        if not isinstance(provider_payload, dict):
+            continue
+
+        models_payload = provider_payload.get("models")
+        if not isinstance(models_payload, dict):
+            continue
+
+        catalog[provider_key] = {
+            "models": {
+                str(model_id): raw_model
+                for model_id, raw_model in models_payload.items()
+                if model_id and isinstance(raw_model, dict)
+            }
+        }
+
+    return catalog
+
+
+def get_models_dev_provider_models(
+    catalog: Any,
+    provider_key: str,
+) -> dict[str, Any]:
+    if not isinstance(catalog, dict):
+        return {}
+
+    provider_payload = catalog.get(provider_key)
+    if not isinstance(provider_payload, dict):
+        return {}
+
+    models_payload = provider_payload.get("models")
+    if not isinstance(models_payload, dict):
+        return {}
+    return models_payload
+
+
+async def fetch_models_dev_catalog(http_client: httpx.AsyncClient) -> dict[str, dict[str, Any]]:
+    response = await http_client.get(MODELS_DEV_API_URL)
+    response.raise_for_status()
+    return reduce_models_dev_catalog(response.json())

--- a/api/app/services/providers/openai_codex_catalog.py
+++ b/api/app/services/providers/openai_codex_catalog.py
@@ -1,5 +1,7 @@
+import re
 from typing import Any
 
+import httpx
 from models.inference import (
     Architecture,
     BillingTypeEnum,
@@ -15,6 +17,42 @@ OPENAI_CODEX_IMAGE_GENERATION_MODEL_SUFFIX = ":image-generation"
 OPENAI_CODEX_LABEL = "OpenAI Codex"
 OPENAI_CODEX_SUPPORTED_TOOL_NAMES = list(MERIDIAN_SUPPORTED_TOOL_NAMES)
 OPENAI_CODEX_DEFAULT_INPUT_MODALITIES = ["text", "image"]
+OPENAI_CODEX_MODELS_DEV_URL = "https://models.dev/api.json"
+OPENAI_CODEX_ALLOWED_MODEL_IDS = {
+    "gpt-5.5",
+    "gpt-5.3-codex-spark",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+}
+OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS = (
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
+)
+OPENAI_CODEX_DEFAULT_MODEL_PAYLOADS = [
+    {
+        "id": "gpt-5.5",
+        "inputModalities": list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
+        "contextLength": 400000,
+        "defaultReasoningEffort": "medium",
+    },
+    {
+        "id": "gpt-5.4",
+        "inputModalities": list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
+        "defaultReasoningEffort": "medium",
+    },
+    {
+        "id": "gpt-5.4-mini",
+        "inputModalities": list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
+        "defaultReasoningEffort": "medium",
+    },
+    {
+        "id": "gpt-5.3-codex-spark",
+        "inputModalities": list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
+        "defaultReasoningEffort": "medium",
+    },
+]
 
 
 def is_openai_codex_image_generation_model(model_id: str) -> bool:
@@ -27,12 +65,41 @@ def get_openai_codex_base_model_id(model_id: str) -> str:
     return model_id
 
 
+def get_openai_codex_image_generation_base_model_id(model_id: str) -> str:
+    base_model_id = get_openai_codex_base_model_id(model_id).removeprefix(OPENAI_CODEX_MODEL_PREFIX)
+    if base_model_id in OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS:
+        return base_model_id
+    if base_model_id.endswith("-pro"):
+        non_pro_model_id = base_model_id[: -len("-pro")]
+        if non_pro_model_id in OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS:
+            return non_pro_model_id
+    return OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS[0]
+
+
 def _normalize_input_modalities(input_modalities: Any) -> list[str]:
     if not isinstance(input_modalities, list):
         return list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES)
 
     normalized = [str(modality).strip().lower() for modality in input_modalities if modality]
     return normalized or list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES)
+
+
+def _get_models_dev_input_modalities(payload: dict[str, Any]) -> Any:
+    modalities = payload.get("modalities")
+    if isinstance(modalities, dict):
+        return modalities.get("input")
+    return None
+
+
+def _get_context_length(payload: dict[str, Any]) -> int:
+    context_length = payload.get("contextLength")
+    if isinstance(context_length, int):
+        return context_length
+
+    limit = payload.get("limit")
+    if isinstance(limit, dict) and isinstance(limit.get("context"), int):
+        return int(limit["context"])
+    return -1
 
 
 def _build_modality_description(input_modalities: list[str]) -> str:
@@ -55,11 +122,15 @@ def normalize_openai_codex_model(payload: Any) -> ModelInfo | None:
     if not model_id:
         return None
 
-    display_name = str(model_id).strip().replace("gpt", "GPT", 1) or model_id
-    input_modalities = _normalize_input_modalities(payload.get("inputModalities"))
+    display_name = str(payload.get("name") or "").strip()
+    if not display_name:
+        display_name = str(model_id).strip().replace("gpt", "GPT", 1) or model_id
+    input_modalities = _normalize_input_modalities(
+        payload.get("inputModalities") or _get_models_dev_input_modalities(payload)
+    )
     default_reasoning_effort = str(payload.get("defaultReasoningEffort") or "").strip()
     supported_reasoning_efforts = payload.get("supportedReasoningEfforts")
-    context_length = payload.get("contextLength")
+    context_length = _get_context_length(payload)
 
     internal_reasoning = None
     if default_reasoning_effort:
@@ -84,7 +155,7 @@ def normalize_openai_codex_model(payload: Any) -> ModelInfo | None:
             output_modalities=["text"],
             tokenizer="gpt",
         ),
-        context_length=(int(context_length) if isinstance(context_length, int) else -1),
+        context_length=context_length,
         pricing=Pricing(prompt="0", completion="0", internal_reasoning=internal_reasoning),
         provider=InferenceProviderEnum.OPENAI_CODEX,
         billingType=BillingTypeEnum.SUBSCRIPTION,
@@ -94,6 +165,19 @@ def normalize_openai_codex_model(payload: Any) -> ModelInfo | None:
         supportedMeridianToolNames=list(OPENAI_CODEX_SUPPORTED_TOOL_NAMES),
         toolsSupport=True,
     )
+
+
+def is_models_dev_openai_codex_model(model_id: str) -> bool:
+    if model_id in OPENAI_CODEX_ALLOWED_MODEL_IDS:
+        return True
+
+    match = re.match(r"^gpt-(\d+\.\d+)", model_id)
+    if not match:
+        return False
+    try:
+        return float(match.group(1)) > 5.4
+    except ValueError:
+        return False
 
 
 def build_openai_codex_image_generation_model(base_model: ModelInfo) -> ModelInfo:
@@ -115,3 +199,71 @@ def build_openai_codex_image_generation_model(base_model: ModelInfo) -> ModelInf
             "toolsSupport": False,
         },
     )
+
+
+def _select_openai_codex_image_generation_base_model(models: list[ModelInfo]) -> ModelInfo | None:
+    if not models:
+        return None
+    by_base_id = {
+        get_openai_codex_base_model_id(model.id).removeprefix(OPENAI_CODEX_MODEL_PREFIX): model
+        for model in models
+    }
+    for base_model_id in OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS:
+        if base_model_id in by_base_id:
+            return by_base_id[base_model_id]
+    return models[0]
+
+
+def get_default_openai_codex_models() -> list[ModelInfo]:
+    models = [
+        normalized
+        for payload in OPENAI_CODEX_DEFAULT_MODEL_PAYLOADS
+        if (normalized := normalize_openai_codex_model(payload)) is not None
+    ]
+    if models:
+        image_base_model = _select_openai_codex_image_generation_base_model(models)
+        if image_base_model is not None:
+            models.insert(0, build_openai_codex_image_generation_model(image_base_model))
+    return models
+
+
+def build_openai_codex_models_from_models_dev(payload: Any) -> list[ModelInfo]:
+    if not isinstance(payload, dict):
+        return get_default_openai_codex_models()
+
+    openai_payload = payload.get("openai")
+    if not isinstance(openai_payload, dict):
+        return get_default_openai_codex_models()
+
+    models_payload = openai_payload.get("models")
+    if not isinstance(models_payload, dict):
+        return get_default_openai_codex_models()
+
+    normalized_models: list[ModelInfo] = []
+    seen_model_ids: set[str] = set()
+    for model_id, raw_model in models_payload.items():
+        resolved_model_id = str(model_id or "").strip()
+        if not resolved_model_id or not is_models_dev_openai_codex_model(resolved_model_id):
+            continue
+        if not isinstance(raw_model, dict):
+            continue
+        normalized_model = normalize_openai_codex_model({"id": resolved_model_id, **raw_model})
+        if normalized_model is None or normalized_model.id in seen_model_ids:
+            continue
+        seen_model_ids.add(normalized_model.id)
+        normalized_models.append(normalized_model)
+
+    normalized_models.sort(key=lambda model: model.id, reverse=True)
+    if normalized_models:
+        image_base_model = _select_openai_codex_image_generation_base_model(normalized_models)
+        if image_base_model is not None:
+            normalized_models.insert(0, build_openai_codex_image_generation_model(image_base_model))
+        return normalized_models
+    return get_default_openai_codex_models()
+
+
+async def get_models_dev_openai_codex_models() -> list[ModelInfo]:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(OPENAI_CODEX_MODELS_DEV_URL)
+        response.raise_for_status()
+        return build_openai_codex_models_from_models_dev(response.json())

--- a/api/app/services/providers/openai_codex_catalog.py
+++ b/api/app/services/providers/openai_codex_catalog.py
@@ -1,7 +1,6 @@
 import re
 from typing import Any
 
-import httpx
 from models.inference import (
     Architecture,
     BillingTypeEnum,
@@ -10,6 +9,7 @@ from models.inference import (
     Pricing,
 )
 from services.providers.common import MERIDIAN_SUPPORTED_TOOL_NAMES
+from services.providers.models_dev import get_models_dev_provider_models
 
 OPENAI_CODEX_PROVIDER_KEY = "openai_codex.auth_json"
 OPENAI_CODEX_MODEL_PREFIX = "openai-codex/"
@@ -17,42 +17,6 @@ OPENAI_CODEX_IMAGE_GENERATION_MODEL_SUFFIX = ":image-generation"
 OPENAI_CODEX_LABEL = "OpenAI Codex"
 OPENAI_CODEX_SUPPORTED_TOOL_NAMES = list(MERIDIAN_SUPPORTED_TOOL_NAMES)
 OPENAI_CODEX_DEFAULT_INPUT_MODALITIES = ["text", "image"]
-OPENAI_CODEX_MODELS_DEV_URL = "https://models.dev/api.json"
-OPENAI_CODEX_ALLOWED_MODEL_IDS = {
-    "gpt-5.5",
-    "gpt-5.3-codex-spark",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-}
-OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS = (
-    "gpt-5.5",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.3-codex-spark",
-)
-OPENAI_CODEX_DEFAULT_MODEL_PAYLOADS = [
-    {
-        "id": "gpt-5.5",
-        "inputModalities": list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
-        "contextLength": 400000,
-        "defaultReasoningEffort": "medium",
-    },
-    {
-        "id": "gpt-5.4",
-        "inputModalities": list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
-        "defaultReasoningEffort": "medium",
-    },
-    {
-        "id": "gpt-5.4-mini",
-        "inputModalities": list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
-        "defaultReasoningEffort": "medium",
-    },
-    {
-        "id": "gpt-5.3-codex-spark",
-        "inputModalities": list(OPENAI_CODEX_DEFAULT_INPUT_MODALITIES),
-        "defaultReasoningEffort": "medium",
-    },
-]
 
 
 def is_openai_codex_image_generation_model(model_id: str) -> bool:
@@ -67,13 +31,9 @@ def get_openai_codex_base_model_id(model_id: str) -> str:
 
 def get_openai_codex_image_generation_base_model_id(model_id: str) -> str:
     base_model_id = get_openai_codex_base_model_id(model_id).removeprefix(OPENAI_CODEX_MODEL_PREFIX)
-    if base_model_id in OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS:
-        return base_model_id
     if base_model_id.endswith("-pro"):
-        non_pro_model_id = base_model_id[: -len("-pro")]
-        if non_pro_model_id in OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS:
-            return non_pro_model_id
-    return OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS[0]
+        return base_model_id[: -len("-pro")]
+    return base_model_id
 
 
 def _normalize_input_modalities(input_modalities: Any) -> list[str]:
@@ -168,14 +128,14 @@ def normalize_openai_codex_model(payload: Any) -> ModelInfo | None:
 
 
 def is_models_dev_openai_codex_model(model_id: str) -> bool:
-    if model_id in OPENAI_CODEX_ALLOWED_MODEL_IDS:
+    if "codex" in model_id:
         return True
 
     match = re.match(r"^gpt-(\d+\.\d+)", model_id)
     if not match:
         return False
     try:
-        return float(match.group(1)) > 5.4
+        return float(match.group(1)) >= 5.4 and not model_id.endswith("-nano")
     except ValueError:
         return False
 
@@ -204,40 +164,19 @@ def build_openai_codex_image_generation_model(base_model: ModelInfo) -> ModelInf
 def _select_openai_codex_image_generation_base_model(models: list[ModelInfo]) -> ModelInfo | None:
     if not models:
         return None
-    by_base_id = {
-        get_openai_codex_base_model_id(model.id).removeprefix(OPENAI_CODEX_MODEL_PREFIX): model
-        for model in models
-    }
-    for base_model_id in OPENAI_CODEX_IMAGE_GENERATION_BASE_MODEL_IDS:
-        if base_model_id in by_base_id:
-            return by_base_id[base_model_id]
+    for model in models:
+        base_model_id = get_openai_codex_base_model_id(model.id).removeprefix(
+            OPENAI_CODEX_MODEL_PREFIX
+        )
+        if not base_model_id.endswith("-pro"):
+            return model
     return models[0]
 
 
-def get_default_openai_codex_models() -> list[ModelInfo]:
-    models = [
-        normalized
-        for payload in OPENAI_CODEX_DEFAULT_MODEL_PAYLOADS
-        if (normalized := normalize_openai_codex_model(payload)) is not None
-    ]
-    if models:
-        image_base_model = _select_openai_codex_image_generation_base_model(models)
-        if image_base_model is not None:
-            models.insert(0, build_openai_codex_image_generation_model(image_base_model))
-    return models
-
-
 def build_openai_codex_models_from_models_dev(payload: Any) -> list[ModelInfo]:
-    if not isinstance(payload, dict):
-        return get_default_openai_codex_models()
-
-    openai_payload = payload.get("openai")
-    if not isinstance(openai_payload, dict):
-        return get_default_openai_codex_models()
-
-    models_payload = openai_payload.get("models")
-    if not isinstance(models_payload, dict):
-        return get_default_openai_codex_models()
+    models_payload = get_models_dev_provider_models(payload, "openai")
+    if not models_payload:
+        return []
 
     normalized_models: list[ModelInfo] = []
     seen_model_ids: set[str] = set()
@@ -259,11 +198,8 @@ def build_openai_codex_models_from_models_dev(payload: Any) -> list[ModelInfo]:
         if image_base_model is not None:
             normalized_models.insert(0, build_openai_codex_image_generation_model(image_base_model))
         return normalized_models
-    return get_default_openai_codex_models()
+    return []
 
 
-async def get_models_dev_openai_codex_models() -> list[ModelInfo]:
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.get(OPENAI_CODEX_MODELS_DEV_URL)
-        response.raise_for_status()
-        return build_openai_codex_models_from_models_dev(response.json())
+async def get_models_dev_openai_codex_models(models_dev_catalog: Any) -> list[ModelInfo]:
+    return build_openai_codex_models_from_models_dev(models_dev_catalog)

--- a/api/app/services/providers/opencode_go_catalog.py
+++ b/api/app/services/providers/opencode_go_catalog.py
@@ -1,4 +1,4 @@
-from typing import Literal, NotRequired, TypedDict
+from typing import Any
 
 from models.inference import (
     Architecture,
@@ -8,181 +8,89 @@ from models.inference import (
     Pricing,
 )
 from services.providers.common import MERIDIAN_SUPPORTED_TOOL_NAMES
+from services.providers.models_dev import get_models_dev_provider_models
 
 OPENCODE_GO_PROVIDER_KEY = "opencode_go.api_key"
 OPENCODE_GO_MODEL_PREFIX = "opencode-go/"
+OPENCODE_GO_MODELS_DEV_PROVIDER_KEY = "opencode-go"
 OPENCODE_GO_LABEL = "OpenCode Go"
 OPENCODE_GO_SUPPORTED_TOOL_NAMES = list(MERIDIAN_SUPPORTED_TOOL_NAMES)
 
-
-class OpenCodeGoModelDefinition(TypedDict):
-    id: str
-    name: str
-    protocol: Literal["anthropic", "openai"]
-    context_length: int
-    input_modalities: NotRequired[list[str]]
-    override_temperature: NotRequired[float]
-    override_top_p: NotRequired[float]
+# models.dev exposes `temperature: false` for this model, but the API expects
+# fixed sampling values instead of omitted sampling fields.
+OPENCODE_GO_TEMPERATURE_OVERRIDES = {"kimi-k2.7-code": 1.0}
+OPENCODE_GO_TOP_P_OVERRIDES = {"kimi-k2.7-code": 0.95}
 
 
-# https://opencode.ai/docs/en/go/#endpoints
-OPENCODE_GO_MODEL_DEFINITIONS: list[OpenCodeGoModelDefinition] = [
-    {"id": "glm-5", "name": "GLM-5", "protocol": "openai", "context_length": 202752},
-    {"id": "glm-5.1", "name": "GLM-5.1", "protocol": "openai", "context_length": 202752},
-    {
-        "id": "kimi-k2.7-code",
-        "name": "Kimi K2.7 Code",
-        "protocol": "openai",
-        "context_length": 262144,
-        "input_modalities": ["text", "image", "video"],
-        "override_temperature": 1.0,
-        "override_top_p": 0.95,
-    },
-    {
-        "id": "kimi-k2.5",
-        "name": "Kimi K2.5",
-        "protocol": "openai",
-        "context_length": 262144,
-        "input_modalities": ["text", "image", "video"],
-    },
-    {
-        "id": "kimi-k2.6",
-        "name": "Kimi K2.6",
-        "protocol": "openai",
-        "context_length": 262144,
-        "input_modalities": ["text", "image", "video"],
-    },
-    {
-        "id": "deepseek-v4-pro",
-        "name": "DeepSeek V4 Pro",
-        "protocol": "openai",
-        "context_length": 1000000,
-    },
-    {
-        "id": "deepseek-v4-flash",
-        "name": "DeepSeek V4 Flash",
-        "protocol": "openai",
-        "context_length": 1000000,
-    },
-    {
-        "id": "mimo-v2-pro",
-        "name": "MiMo-V2-Pro",
-        "protocol": "openai",
-        "context_length": 1048576,
-    },
-    {
-        "id": "mimo-v2-omni",
-        "name": "MiMo-V2-Omni",
-        "protocol": "openai",
-        "context_length": 262144,
-        "input_modalities": ["text", "image", "audio", "pdf"],
-    },
-    {
-        "id": "mimo-v2.5-pro",
-        "name": "MiMo-V2.5-Pro",
-        "protocol": "openai",
-        "context_length": 1048576,
-    },
-    {
-        "id": "mimo-v2.5",
-        "name": "MiMo-V2.5",
-        "protocol": "openai",
-        "context_length": 1000000,
-        "input_modalities": ["text", "image", "audio", "video"],
-    },
-    {
-        "id": "minimax-m3",
-        "name": "MiniMax M3",
-        "protocol": "anthropic",
-        "context_length": 512000,
-        "input_modalities": ["text", "image", "video"],
-    },
-    {
-        "id": "minimax-m2.5",
-        "name": "MiniMax M2.5",
-        "protocol": "anthropic",
-        "context_length": 204800,
-    },
-    {
-        "id": "minimax-m2.7",
-        "name": "MiniMax M2.7",
-        "protocol": "anthropic",
-        "context_length": 204800,
-    },
-    {
-        "id": "qwen3.7-max",
-        "name": "Qwen3.7 Max",
-        "protocol": "anthropic",
-        "context_length": 1000000,
-    },
-    {
-        "id": "qwen3.7-plus",
-        "name": "Qwen3.7 Plus",
-        "protocol": "anthropic",
-        "context_length": 1000000,
-        "input_modalities": ["text", "image", "video"],
-    },
-    {
-        "id": "qwen3.5-plus",
-        "name": "Qwen3.5 Plus",
-        "protocol": "anthropic",
-        "context_length": 262144,
-        "input_modalities": ["text", "image", "video"],
-    },
-    {
-        "id": "qwen3.6-plus",
-        "name": "Qwen3.6 Plus",
-        "protocol": "anthropic",
-        "context_length": 1000000,
-        "input_modalities": ["text", "image", "video"],
-    },
-    {
-        "id": "hy3-preview",
-        "name": "Hy3 Preview",
-        "protocol": "openai",
-        "context_length": 262144,
-    },
-]
-
-OPENCODE_GO_ANTHROPIC_MODEL_IDS = {
-    definition["id"]
-    for definition in OPENCODE_GO_MODEL_DEFINITIONS
-    if definition["protocol"] == "anthropic"
-}
-
-OPENCODE_GO_IMAGE_INPUT_MODEL_IDS = {
-    definition["id"]
-    for definition in OPENCODE_GO_MODEL_DEFINITIONS
-    if "image" in definition.get("input_modalities", [])
-}
-
-OPENCODE_GO_TEMPERATURE_OVERRIDES = {
-    definition["id"]: definition["override_temperature"]
-    for definition in OPENCODE_GO_MODEL_DEFINITIONS
-    if "override_temperature" in definition
-}
-
-OPENCODE_GO_TOP_P_OVERRIDES = {
-    definition["id"]: definition["override_top_p"]
-    for definition in OPENCODE_GO_MODEL_DEFINITIONS
-    if "override_top_p" in definition
-}
+def _normalize_modalities(modalities: Any) -> list[str]:
+    if not isinstance(modalities, list):
+        return ["text"]
+    normalized = [str(modality).strip().lower() for modality in modalities if modality]
+    return normalized or ["text"]
 
 
-def _build_opencode_go_model(model_definition: OpenCodeGoModelDefinition) -> ModelInfo:
-    input_modalities = model_definition.get("input_modalities", ["text"])
+def _get_models_dev_input_modalities(payload: dict[str, Any]) -> Any:
+    modalities = payload.get("modalities")
+    if isinstance(modalities, dict):
+        return modalities.get("input")
+    return None
+
+
+def _get_models_dev_output_modalities(payload: dict[str, Any]) -> list[str]:
+    modalities = payload.get("modalities")
+    if isinstance(modalities, dict):
+        return _normalize_modalities(modalities.get("output"))
+    return ["text"]
+
+
+def _get_context_length(payload: dict[str, Any]) -> int:
+    context_length = payload.get("contextLength")
+    if isinstance(context_length, int):
+        return context_length
+
+    limit = payload.get("limit")
+    if isinstance(limit, dict) and isinstance(limit.get("context"), int):
+        return int(limit["context"])
+    return -1
+
+
+def _get_pricing(payload: dict[str, Any]) -> Pricing:
+    cost = payload.get("cost")
+    if isinstance(cost, dict):
+        prompt = cost.get("input")
+        completion = cost.get("output")
+        return Pricing(prompt=str(prompt or "0"), completion=str(completion or "0"))
+    return Pricing(prompt="0", completion="0")
+
+
+def _build_modality_description(input_modalities: list[str], output_modalities: list[str]) -> str:
+    return f"{'+'.join(input_modalities)}->{'+'.join(output_modalities)}"
+
+
+def normalize_opencode_go_model(payload: Any) -> ModelInfo | None:
+    if not isinstance(payload, dict):
+        return None
+
+    model_id = str(payload.get("model") or payload.get("id") or "").strip()
+    if not model_id:
+        return None
+
+    display_name = str(payload.get("name") or model_id).strip()
+    input_modalities = _normalize_modalities(_get_models_dev_input_modalities(payload))
+    output_modalities = _get_models_dev_output_modalities(payload)
     return ModelInfo(
-        id=f"{OPENCODE_GO_MODEL_PREFIX}{model_definition['id']}",
-        name=model_definition["name"],
+        id=f"{OPENCODE_GO_MODEL_PREFIX}{model_id}",
+        name=display_name,
         icon="opencode",
         architecture=Architecture(
             input_modalities=input_modalities,
-            modality=f"{'+'.join(input_modalities)}->text",
-            output_modalities=["text"],
+            modality=_build_modality_description(input_modalities, output_modalities),
+            output_modalities=output_modalities,
             tokenizer="opencode",
         ),
-        context_length=model_definition["context_length"],
-        pricing=Pricing(prompt="0", completion="0"),
+        context_length=_get_context_length(payload),
+        created=payload.get("release_date") or payload.get("created"),
+        pricing=_get_pricing(payload),
         provider=InferenceProviderEnum.OPENCODE_GO,
         billingType=BillingTypeEnum.SUBSCRIPTION,
         requiresConnection=True,
@@ -193,10 +101,27 @@ def _build_opencode_go_model(model_definition: OpenCodeGoModelDefinition) -> Mod
     )
 
 
-OPENCODE_GO_MODELS = [
-    _build_opencode_go_model(model_definition) for model_definition in OPENCODE_GO_MODEL_DEFINITIONS
-]
+def build_opencode_go_models_from_models_dev(payload: Any) -> list[ModelInfo]:
+    models_payload = get_models_dev_provider_models(payload, OPENCODE_GO_MODELS_DEV_PROVIDER_KEY)
+    if not models_payload:
+        return []
+
+    normalized_models: list[ModelInfo] = []
+    seen_model_ids: set[str] = set()
+    for model_id, raw_model in models_payload.items():
+        if not isinstance(raw_model, dict):
+            continue
+        normalized_model = normalize_opencode_go_model({"id": model_id, **raw_model})
+        if normalized_model is None or normalized_model.id in seen_model_ids:
+            continue
+        seen_model_ids.add(normalized_model.id)
+        normalized_models.append(normalized_model)
+
+    normalized_models.sort(key=lambda model: (model.created or "", model.id), reverse=True)
+    return normalized_models
 
 
-async def get_opencode_go_models() -> list[ModelInfo]:
-    return [model.model_copy(deep=True) for model in OPENCODE_GO_MODELS]
+async def get_opencode_go_models(models_dev_catalog: Any | None = None) -> list[ModelInfo]:
+    if models_dev_catalog is None:
+        return []
+    return build_opencode_go_models_from_models_dev(models_dev_catalog)

--- a/api/app/services/providers/z_ai_coding_plan_catalog.py
+++ b/api/app/services/providers/z_ai_coding_plan_catalog.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import Any
 
 from models.inference import (
     Architecture,
@@ -8,6 +8,7 @@ from models.inference import (
     Pricing,
 )
 from services.providers.common import MERIDIAN_SUPPORTED_TOOL_NAMES
+from services.providers.models_dev import get_models_dev_provider_models
 
 Z_AI_CODING_PLAN_PROVIDER_KEY = "z_ai_coding_plan.api_key"
 Z_AI_CODING_PLAN_MODEL_PREFIX = "z-ai-plan/"
@@ -15,83 +16,118 @@ Z_AI_CODING_PLAN_LABEL = "Z.AI Coding Plan"
 Z_AI_CODING_PLAN_SUPPORTED_TOOL_NAMES = list(MERIDIAN_SUPPORTED_TOOL_NAMES)
 
 
-class ZAiCodingPlanModelDefinition(TypedDict):
-    id: str
-    name: str
-    created: str
-    context_length: int
-    pricing: Pricing
+def _normalize_input_modalities(input_modalities: Any) -> list[str]:
+    if not isinstance(input_modalities, list):
+        return ["text"]
+    normalized = [str(modality).strip().lower() for modality in input_modalities if modality]
+    return normalized or ["text"]
 
 
-# Keep this catalog aligned with the documented Coding Plan models only.
-Z_AI_CODING_PLAN_MODEL_DEFINITIONS: list[ZAiCodingPlanModelDefinition] = [
-    {
-        "id": "glm-5.2",
-        "name": "GLM-5.2",
-        "created": "2026-06-13",
-        "context_length": 203000,
-        "pricing": Pricing(prompt="1.40", completion="4.40"),
-    },
-    {
-        "id": "glm-5.1",
-        "name": "GLM-5.1",
-        "created": "2026-04-07",
-        "context_length": 203000,
-        "pricing": Pricing(prompt="1.40", completion="4.40"),
-    },
-    {
-        "id": "glm-5-turbo",
-        "name": "GLM-5 Turbo",
-        "created": "2026-03-15",
-        "context_length": 203000,
-        "pricing": Pricing(prompt="1.20", completion="4.00"),
-    },
-    {
-        "id": "glm-4.7",
-        "name": "GLM-4.7",
-        "created": "2025-12-22",
-        "context_length": 200000,
-        "pricing": Pricing(prompt="0.60", completion="2.20"),
-    },
-    {
-        "id": "glm-4.5-air",
-        "name": "GLM-4.5 Air",
-        "created": "2025-07-25",
-        "context_length": 131000,
-        "pricing": Pricing(prompt="0.20", completion="1.10"),
-    },
-]
+def _get_models_dev_input_modalities(payload: dict[str, Any]) -> Any:
+    modalities = payload.get("modalities")
+    if isinstance(modalities, dict):
+        return modalities.get("input")
+    return None
 
 
-def _build_z_ai_coding_plan_model(model_definition: ZAiCodingPlanModelDefinition) -> ModelInfo:
+def _get_models_dev_output_modalities(payload: dict[str, Any]) -> list[str]:
+    modalities = payload.get("modalities")
+    if isinstance(modalities, dict):
+        output_modalities = modalities.get("output")
+        if isinstance(output_modalities, list):
+            normalized = [
+                str(modality).strip().lower() for modality in output_modalities if modality
+            ]
+            if normalized:
+                return normalized
+    return ["text"]
+
+
+def _get_context_length(payload: dict[str, Any]) -> int:
+    context_length = payload.get("contextLength")
+    if isinstance(context_length, int):
+        return context_length
+
+    limit = payload.get("limit")
+    if isinstance(limit, dict) and isinstance(limit.get("context"), int):
+        return int(limit["context"])
+    return -1
+
+
+def _get_pricing(payload: dict[str, Any]) -> Pricing:
+    cost = payload.get("cost")
+    if isinstance(cost, dict):
+        prompt = cost.get("input")
+        completion = cost.get("output")
+        return Pricing(prompt=str(prompt or "0"), completion=str(completion or "0"))
+    return Pricing(prompt="0", completion="0")
+
+
+def _build_modality_description(input_modalities: list[str], output_modalities: list[str]) -> str:
+    input_description = "+".join(input_modalities)
+    output_description = "+".join(output_modalities)
+    return f"{input_description}->{output_description}"
+
+
+def normalize_z_ai_coding_plan_model(payload: Any) -> ModelInfo | None:
+    if not isinstance(payload, dict):
+        return None
+
+    model_id = str(payload.get("model") or payload.get("id") or "").strip()
+    if not model_id:
+        return None
+
+    display_name = str(payload.get("name") or model_id).strip()
+    input_modalities = _normalize_input_modalities(_get_models_dev_input_modalities(payload))
+    output_modalities = _get_models_dev_output_modalities(payload)
     return ModelInfo(
-        id=f"{Z_AI_CODING_PLAN_MODEL_PREFIX}{model_definition['id']}",
-        name=model_definition["name"],
+        id=f"{Z_AI_CODING_PLAN_MODEL_PREFIX}{model_id}",
+        name=display_name,
         icon="z-ai",
         architecture=Architecture(
-            input_modalities=["text"],
-            modality="text->text",
-            output_modalities=["text"],
+            input_modalities=input_modalities,
+            modality=_build_modality_description(input_modalities, output_modalities),
+            output_modalities=output_modalities,
             tokenizer="glm",
         ),
-        context_length=model_definition["context_length"],
-        created=model_definition["created"],
-        pricing=model_definition["pricing"],
+        context_length=_get_context_length(payload),
+        created=payload.get("release_date") or payload.get("created"),
+        pricing=_get_pricing(payload),
         provider=InferenceProviderEnum.Z_AI_CODING_PLAN,
         billingType=BillingTypeEnum.SUBSCRIPTION,
         requiresConnection=True,
         supportsStructuredOutputs=False,
         supportsMeridianTools=True,
-        supportedMeridianToolNames=Z_AI_CODING_PLAN_SUPPORTED_TOOL_NAMES,
+        supportedMeridianToolNames=list(Z_AI_CODING_PLAN_SUPPORTED_TOOL_NAMES),
         toolsSupport=True,
     )
 
 
-Z_AI_CODING_PLAN_MODELS = [
-    _build_z_ai_coding_plan_model(model_definition)
-    for model_definition in Z_AI_CODING_PLAN_MODEL_DEFINITIONS
-]
+def build_z_ai_coding_plan_models_from_models_dev(payload: Any) -> list[ModelInfo]:
+    models_payload = get_models_dev_provider_models(payload, "zai-coding-plan")
+    if not models_payload:
+        return []
+
+    normalized_models: list[ModelInfo] = []
+    seen_model_ids: set[str] = set()
+    for model_id, raw_model in models_payload.items():
+        if not isinstance(raw_model, dict):
+            continue
+        normalized_model = normalize_z_ai_coding_plan_model({"id": model_id, **raw_model})
+        if normalized_model is None or normalized_model.id in seen_model_ids:
+            continue
+        if normalized_model.architecture.input_modalities != ["text"]:
+            continue
+        seen_model_ids.add(normalized_model.id)
+        normalized_models.append(normalized_model)
+
+    normalized_models.sort(key=lambda model: (model.created or "", model.id), reverse=True)
+    if normalized_models:
+        return normalized_models
+    return []
 
 
-async def get_z_ai_coding_plan_models() -> list[ModelInfo]:
-    return [model.model_copy(deep=True) for model in Z_AI_CODING_PLAN_MODELS]
+async def get_z_ai_coding_plan_models(models_dev_catalog: Any | None = None) -> list[ModelInfo]:
+    if models_dev_catalog is None:
+        return []
+    return build_z_ai_coding_plan_models_from_models_dev(models_dev_catalog)

--- a/api/tests/test_inference.py
+++ b/api/tests/test_inference.py
@@ -84,6 +84,7 @@ from services.providers.gemini_cli_catalog import (
     get_gemini_cli_models,
 )
 from services.providers.github_copilot_catalog import normalize_github_copilot_model
+from services.providers.models_dev import reduce_models_dev_catalog
 from services.providers.openai_codex_catalog import normalize_openai_codex_model
 from services.providers.openai_codex_catalog import build_openai_codex_models_from_models_dev
 from services.providers.opencode_go_catalog import (
@@ -91,7 +92,7 @@ from services.providers.opencode_go_catalog import (
     OPENCODE_GO_TOP_P_OVERRIDES,
 )
 from services.providers.z_ai_coding_plan_catalog import (
-    Z_AI_CODING_PLAN_MODELS,
+    build_z_ai_coding_plan_models_from_models_dev,
     get_z_ai_coding_plan_models,
 )
 
@@ -116,13 +117,63 @@ def test_claude_agent_catalog_is_subscription_only_and_not_structured():
 
 
 def test_z_ai_coding_plan_catalog_is_subscription_only_and_not_structured():
-    assert Z_AI_CODING_PLAN_MODELS
-    for model in Z_AI_CODING_PLAN_MODELS:
+    models = build_z_ai_coding_plan_models_from_models_dev(
+        {
+            "zai-coding-plan": {
+                "models": {
+                    "glm-5.2": {
+                        "id": "glm-5.2",
+                        "name": "GLM-5.2",
+                        "release_date": "2026-06-13",
+                        "modalities": {"input": ["text"], "output": ["text"]},
+                        "limit": {"context": 1000000},
+                        "cost": {"input": 0, "output": 0},
+                    }
+                }
+            }
+        }
+    )
+
+    assert models
+    for model in models:
         assert model.provider == InferenceProviderEnum.Z_AI_CODING_PLAN
         assert model.billingType == BillingTypeEnum.SUBSCRIPTION
         assert model.supportsStructuredOutputs is False
         assert model.supportsMeridianTools is True
         assert model.supportedMeridianToolNames == Z_AI_CODING_PLAN_SUPPORTED_TOOL_NAMES
+
+
+def test_z_ai_coding_plan_models_dev_catalog_filters_to_text_models():
+    models = build_z_ai_coding_plan_models_from_models_dev(
+        {
+            "zai-coding-plan": {
+                "models": {
+                    "glm-5.2": {
+                        "id": "glm-5.2",
+                        "name": "GLM-5.2",
+                        "release_date": "2026-06-13",
+                        "modalities": {"input": ["text"], "output": ["text"]},
+                        "limit": {"context": 1000000},
+                        "cost": {"input": 0, "output": 0},
+                    },
+                    "glm-5v-turbo": {
+                        "id": "glm-5v-turbo",
+                        "name": "GLM-5V-Turbo",
+                        "release_date": "2026-04-01",
+                        "modalities": {"input": ["text", "image"], "output": ["text"]},
+                        "limit": {"context": 200000},
+                    },
+                }
+            }
+        }
+    )
+
+    assert [model.id for model in models] == ["z-ai-plan/glm-5.2"]
+    assert models[0].context_length == 1000000
+    assert models[0].created == "2026-06-13"
+    assert models[0].pricing.prompt == "0"
+    assert models[0].pricing.completion == "0"
+    assert models[0].supportsStructuredOutputs is False
 
 
 def test_gemini_cli_catalog_is_subscription_only_and_structured():
@@ -238,6 +289,23 @@ def test_normalize_openrouter_model_sets_provider_capabilities():
     assert normalized.supportsStructuredOutputs is True
     assert normalized.supportsMeridianTools is True
     assert "ask_user" in normalized.supportedMeridianToolNames
+
+
+def test_reduce_models_dev_catalog_keeps_only_used_providers_and_models():
+    reduced = reduce_models_dev_catalog(
+        {
+            "openai": {"api": "unused", "models": {"gpt-5.5": {"name": "GPT-5.5"}}},
+            "zai-coding-plan": {
+                "doc": "unused",
+                "models": {"glm-5.2": {"name": "GLM-5.2"}},
+            },
+            "anthropic": {"models": {"claude-sonnet-4-6": {"name": "Claude"}}},
+        }
+    )
+
+    assert set(reduced) == {"openai", "zai-coding-plan"}
+    assert reduced["openai"] == {"models": {"gpt-5.5": {"name": "GPT-5.5"}}}
+    assert reduced["zai-coding-plan"] == {"models": {"glm-5.2": {"name": "GLM-5.2"}}}
 
 
 def test_model_supports_structured_outputs_reads_dict_and_model_instances():
@@ -864,11 +932,33 @@ def test_claude_agent_catalog_validation_cache_filters_and_reuses_validated_alia
     assert [model.id for model in validated_twice] == ["claude-agent/default"]
 
 
-def test_z_ai_coding_plan_catalog_returns_copies():
+def test_z_ai_coding_plan_catalog_returns_models_dev_copies():
+    models_dev_catalog = {
+        "zai-coding-plan": {
+            "models": {
+                "glm-5.2": {
+                    "id": "glm-5.2",
+                    "name": "GLM-5.2",
+                    "modalities": {"input": ["text"], "output": ["text"]},
+                    "limit": {"context": 1000000},
+                    "cost": {"input": 0, "output": 0},
+                }
+            }
+        }
+    }
+
+    models = asyncio.run(get_z_ai_coding_plan_models(models_dev_catalog))
+    models[0].name = "Mutated"
+    models_again = asyncio.run(get_z_ai_coding_plan_models(models_dev_catalog))
+
+    assert [model.id for model in models_again] == ["z-ai-plan/glm-5.2"]
+    assert models_again[0].name == "GLM-5.2"
+
+
+def test_z_ai_coding_plan_catalog_returns_empty_without_models_dev_catalog():
     models = asyncio.run(get_z_ai_coding_plan_models())
-    assert [model.id for model in models] == [model.id for model in Z_AI_CODING_PLAN_MODELS]
-    assert models is not Z_AI_CODING_PLAN_MODELS
-    assert all(model_a is not model_b for model_a, model_b in zip(models, Z_AI_CODING_PLAN_MODELS))
+
+    assert models == []
 
 
 def test_gemini_cli_catalog_returns_copies():
@@ -1167,7 +1257,7 @@ def test_openai_codex_model_discovery_validates_before_catalog_fetch():
         events.append("validate")
         return auth_json_value
 
-    async def _fetch_catalog():
+    async def _fetch_catalog(_models_dev_catalog):
         events.append("catalog")
         return []
 
@@ -1175,7 +1265,7 @@ def test_openai_codex_model_discovery_validates_before_catalog_fetch():
         patch("services.openai_codex._validate_openai_codex_auth_tokens", _validate_auth),
         patch("services.openai_codex.get_models_dev_openai_codex_models", _fetch_catalog),
     ):
-        models = asyncio.run(list_openai_codex_models(auth_json))
+        models = asyncio.run(list_openai_codex_models(auth_json, models_dev_catalog={}))
 
     assert models == []
     assert events == ["validate", "catalog"]
@@ -1185,7 +1275,7 @@ def test_openai_codex_model_discovery_rejects_invalid_auth_before_catalog_fetch(
     async def _validate_auth(_auth_json_value: str) -> str:
         raise ValueError("bad codex auth")
 
-    async def _fetch_catalog():  # pragma: no cover - defensive regression guard
+    async def _fetch_catalog(_models_dev_catalog):  # pragma: no cover - defensive regression guard
         raise AssertionError("catalog should not be fetched before auth validation")
 
     with (
@@ -1193,14 +1283,14 @@ def test_openai_codex_model_discovery_rejects_invalid_auth_before_catalog_fetch(
         patch("services.openai_codex.get_models_dev_openai_codex_models", _fetch_catalog),
     ):
         try:
-            asyncio.run(list_openai_codex_models("{}"))
+            asyncio.run(list_openai_codex_models("{}", models_dev_catalog={}))
         except ValueError as exc:
             assert "bad codex auth" in str(exc)
         else:  # pragma: no cover - defensive regression guard
             raise AssertionError("Expected invalid Codex auth to fail before catalog fetch.")
 
 
-def test_openai_codex_model_discovery_falls_back_when_models_dev_fails():
+def test_openai_codex_model_discovery_returns_empty_when_models_dev_fails():
     auth_json = _build_codex_auth_json_from_tokens(
         {
             "id_token": _unsigned_jwt({}),
@@ -1219,12 +1309,9 @@ def test_openai_codex_model_discovery_falls_back_when_models_dev_fails():
             side_effect=RuntimeError("models.dev unavailable"),
         ),
     ):
-        models = asyncio.run(list_openai_codex_models(auth_json))
+        models = asyncio.run(list_openai_codex_models(auth_json, models_dev_catalog={}))
 
-    model_ids = [model.id for model in models]
-    assert "openai-codex/gpt-5.5" in model_ids
-    assert "openai-codex/gpt-5.4" in model_ids
-    assert model_ids[0] == "openai-codex/gpt-5.5:image-generation"
+    assert models == []
 
 
 def test_format_model_unavailable_error_mentions_cli_scope():

--- a/api/tests/test_inference.py
+++ b/api/tests/test_inference.py
@@ -1,8 +1,13 @@
 import asyncio
+import base64
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
+
+import httpx
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
 
@@ -14,6 +19,7 @@ from models.inference import (
     Pricing,
 )
 from models.message import ToolEnum
+from models.tool_question import AskUserArguments
 from services.github_copilot import (
     GitHubCopilotReqChat,
     _build_copilot_system_message,
@@ -41,13 +47,31 @@ from services.inference import (
 )
 from services.openai_codex import (
     OpenAICodexReqChat,
+    _build_openai_codex_direct_headers,
+    _build_openai_codex_direct_image_input,
+    _build_openai_codex_direct_image_payload,
+    _build_openai_codex_direct_input,
+    _build_openai_codex_direct_payload,
     _build_pending_assistant_message,
+    _build_codex_auth_json_from_tokens,
     _build_dynamic_tools,
+    _codex_auth_needs_refresh,
+    _extract_account_id_from_claims,
+    _extract_openai_codex_direct_image_result,
     _extract_system_instructions,
     _extract_reasoning_item_text,
+    is_openai_codex_browser_oauth_local_origin,
+    _iter_openai_codex_sse_events,
+    _normalize_openai_responses_usage_data,
+    _OpenAICodexDirectTurnRunner,
     _normalize_codex_usage_data,
     _normalize_auth_json,
+    _probe_openai_codex_auth,
     _sanitize_model_instructions,
+    generate_image_with_openai_codex,
+    list_openai_codex_models,
+    make_openai_codex_request_non_streaming,
+    validate_openai_codex_oauth_auth_json,
 )
 from services.providers.common import sanitize_external_tool_references
 from services.providers.claude_agent_catalog import (
@@ -61,6 +85,7 @@ from services.providers.gemini_cli_catalog import (
 )
 from services.providers.github_copilot_catalog import normalize_github_copilot_model
 from services.providers.openai_codex_catalog import normalize_openai_codex_model
+from services.providers.openai_codex_catalog import build_openai_codex_models_from_models_dev
 from services.providers.opencode_go_catalog import (
     OPENCODE_GO_TEMPERATURE_OVERRIDES,
     OPENCODE_GO_TOP_P_OVERRIDES,
@@ -258,6 +283,351 @@ def test_normalize_openai_codex_auth_json_sorts_keys():
 
 def test_normalize_openai_codex_auth_json_accepts_non_breaking_spaces():
     assert _normalize_auth_json('{\u00a0"b":2,\u00a0"a":1\u00a0}') == '{"a":1,"b":2}'
+
+
+def _unsigned_jwt(payload: dict) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').decode("ascii").rstrip("=")
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).decode("ascii").rstrip("=")
+    return f"{header}.{body}.sig"
+
+
+def test_openai_codex_extract_account_id_prefers_auth_namespace():
+    assert (
+        _extract_account_id_from_claims(
+            {"https://api.openai.com/auth": {"chatgpt_account_id": "acc-nested"}}
+        )
+        == "acc-nested"
+    )
+
+
+def test_build_openai_codex_auth_json_from_oauth_tokens_uses_codex_shape():
+    id_token = _unsigned_jwt({"https://api.openai.com/auth": {"chatgpt_account_id": "acc-123"}})
+    auth_json = _build_codex_auth_json_from_tokens(
+        {
+            "id_token": id_token,
+            "access_token": _unsigned_jwt({"exp": 4102444800}),
+            "refresh_token": "refresh-token",
+        }
+    )
+
+    payload = json.loads(auth_json)
+    assert payload["auth_mode"] == "chatgpt"
+    assert payload["OPENAI_API_KEY"] is None
+    assert payload["tokens"]["id_token"] == id_token
+    assert payload["tokens"]["access_token"]
+    assert payload["tokens"]["refresh_token"] == "refresh-token"
+    assert payload["tokens"]["account_id"] == "acc-123"
+
+
+def test_openai_codex_auth_refresh_check_uses_access_token_expiration():
+    expired_auth_json = _build_codex_auth_json_from_tokens(
+        {
+            "id_token": _unsigned_jwt({}),
+            "access_token": _unsigned_jwt({"exp": 1}),
+            "refresh_token": "refresh-token",
+        }
+    )
+    fresh_auth_json = _build_codex_auth_json_from_tokens(
+        {
+            "id_token": _unsigned_jwt({}),
+            "access_token": _unsigned_jwt({"exp": 4102444800}),
+            "refresh_token": "refresh-token",
+        }
+    )
+
+    assert _codex_auth_needs_refresh(expired_auth_json)
+    assert not _codex_auth_needs_refresh(fresh_auth_json)
+
+
+def _openai_codex_test_req(auth_json: str | None = None) -> OpenAICodexReqChat:
+    if auth_json is None:
+        auth_json = _build_codex_auth_json_from_tokens(
+            {
+                "id_token": _unsigned_jwt(
+                    {"https://api.openai.com/auth": {"chatgpt_account_id": "acc-123"}}
+                ),
+                "access_token": _unsigned_jwt({"exp": 4102444800}),
+                "refresh_token": "refresh-token",
+            }
+        )
+    return OpenAICodexReqChat(
+        auth_json=auth_json,
+        model="openai-codex/gpt-5.5",
+        model_id="openai-codex/gpt-5.5",
+        messages=[
+            {"role": "system", "content": "Follow the rules."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this."},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+                ],
+            },
+        ],
+        config=SimpleNamespace(exclude_reasoning=False, reasoning_effort="low"),
+        user_id="user-1",
+        graph_id="graph-1",
+        node_id="node-1",
+        pg_engine=None,
+    )
+
+
+def test_openai_codex_direct_headers_use_chatgpt_codex_endpoint_and_account_id():
+    req = _openai_codex_test_req()
+    endpoint, headers = _build_openai_codex_direct_headers(req.auth_json, req=req)
+
+    assert endpoint == "https://chatgpt.com/backend-api/codex/responses"
+    assert headers["Authorization"].startswith("Bearer ")
+    assert headers["ChatGPT-Account-Id"] == "acc-123"
+    assert headers["originator"] == "meridian"
+    assert headers["session-id"] == "graph-1"
+
+
+def test_openai_codex_direct_payload_matches_responses_shape():
+    req = _openai_codex_test_req()
+    input_items = _build_openai_codex_direct_input(req)
+    payload = _build_openai_codex_direct_payload(req, input_items)
+
+    assert payload["model"] == "gpt-5.5"
+    assert payload["instructions"] == "Follow the rules."
+    assert payload["tool_choice"] == "auto"
+    assert payload["parallel_tool_calls"] is False
+    assert payload["store"] is False
+    assert payload["stream"] is True
+    assert payload["reasoning"] == {"effort": "low", "summary": "auto"}
+    assert payload["include"] == ["reasoning.encrypted_content"]
+    assert payload["input"] == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Describe this."},
+                {"type": "input_image", "image_url": "https://example.com/image.png"},
+            ],
+        }
+    ]
+
+
+def test_openai_codex_direct_image_payload_uses_responses_image_tool():
+    input_items = _build_openai_codex_direct_image_input(
+        [
+            {"type": "text", "text": "A watercolor cabin"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/ref.png"}},
+        ],
+        aspect_ratio="16:9",
+        resolution="1024x576",
+    )
+    payload = _build_openai_codex_direct_image_payload(
+        model="openai-codex/gpt-5.5",
+        input_items=input_items,
+    )
+    pro_payload = _build_openai_codex_direct_image_payload(
+        model="openai-codex/gpt-5.5-pro:image-generation",
+        input_items=input_items,
+    )
+
+    assert payload["model"] == "gpt-5.5"
+    assert pro_payload["model"] == "gpt-5.5"
+    assert "image generation assistant" in payload["instructions"]
+    assert payload["stream"] is True
+    assert payload["store"] is False
+    assert payload["tools"] == [
+        {"type": "image_generation", "action": "generate", "partial_images": 0}
+    ]
+    assert input_items[0]["content"][0]["text"].startswith("A watercolor cabin")
+    assert "Aspect ratio: 16:9" in input_items[0]["content"][0]["text"]
+    assert input_items[0]["content"][1] == {
+        "type": "input_image",
+        "image_url": "https://example.com/ref.png",
+    }
+
+
+def test_openai_codex_direct_image_result_decodes_completed_response_output():
+    encoded = base64.b64encode(b"fake-png").decode()
+
+    assert _extract_openai_codex_direct_image_result(
+        {"response": {"output": [{"type": "image_generation_call", "result": encoded}]}}
+    ) == (b"fake-png", "png")
+
+
+def test_openai_codex_image_generation_uses_direct_responses_without_runtime():
+    req = _openai_codex_test_req()
+    encoded = base64.b64encode(b"fake-png").decode()
+    calls: dict[str, Any] = {}
+
+    class ImageStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield (
+                "event: response.completed\n"
+                f'data: {{"response":{{"output":[{{"type":"image_generation_call","result":"{encoded}"}}]}}}}\n\n'
+            ).encode()
+
+    class StreamContext:
+        async def __aenter__(self):
+            return httpx.Response(200, stream=ImageStream())
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class FakeClient:
+        def stream(self, method, endpoint, *, headers, json):
+            calls["method"] = method
+            calls["endpoint"] = endpoint
+            calls["headers"] = headers
+            calls["payload"] = json
+            return StreamContext()
+
+    with patch("services.openai_codex._build_runtime_context", side_effect=AssertionError):
+        generated = asyncio.run(
+            generate_image_with_openai_codex(
+                auth_json=req.auth_json,
+                model="openai-codex/gpt-5.5",
+                message_content="A tiny robot painting",
+                aspect_ratio="1:1",
+                resolution="1024x1024",
+                http_client=FakeClient(),
+            )
+        )
+
+    assert generated.image_bytes == b"fake-png"
+    assert generated.extension == "png"
+    assert generated.model == "openai-codex/gpt-5.5"
+    assert calls["method"] == "POST"
+    assert calls["endpoint"] == "https://chatgpt.com/backend-api/codex/responses"
+    assert calls["payload"]["tools"][0]["type"] == "image_generation"
+
+
+def test_openai_codex_responses_usage_normalizes_token_details():
+    usage = _normalize_openai_responses_usage_data(
+        {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "input_tokens_details": {"cached_tokens": 3},
+            "output_tokens_details": {"reasoning_tokens": 2},
+        }
+    )
+
+    assert usage == {
+        "cost": 0.0,
+        "is_byok": False,
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+        "prompt_tokens_details": {"cached_tokens": 3},
+        "completion_tokens_details": {"reasoning_tokens": 2},
+    }
+
+
+def test_openai_codex_sse_parser_handles_split_chunks():
+    class ChunkedStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'event: response.output_text.delta\ndata: {"delta":"Hel'
+            yield b'lo"}\n\nevent: response.completed\ndata: {"usage":{"total_tokens":1}}\n\n'
+
+    async def _collect():
+        response = httpx.Response(200, stream=ChunkedStream())
+        return [event async for event in _iter_openai_codex_sse_events(response)]
+
+    assert asyncio.run(_collect()) == [
+        ("response.output_text.delta", {"delta": "Hello"}),
+        ("response.completed", {"usage": {"total_tokens": 1}}),
+    ]
+
+
+def test_openai_codex_non_streaming_uses_direct_runner_without_runtime():
+    req = _openai_codex_test_req()
+
+    async def _direct_runner(*_args, **kwargs):
+        kwargs["usage_data_sink"].update({"prompt_tokens": 1, "completion_tokens": 1})
+        return "direct response"
+
+    async def _persist_refreshed_auth_json(**_kwargs):
+        return None
+
+    async def _update_node_usage_data(**_kwargs):
+        return None
+
+    with (
+        patch("services.openai_codex._run_openai_codex_direct_turn", _direct_runner),
+        patch("services.openai_codex._build_runtime_context", side_effect=AssertionError),
+        patch("services.openai_codex._persist_refreshed_auth_json", _persist_refreshed_auth_json),
+        patch("services.openai_codex.update_node_usage_data", _update_node_usage_data),
+    ):
+        response = asyncio.run(make_openai_codex_request_non_streaming(req, None))
+
+    assert response == "direct response"
+
+
+def test_ask_user_arguments_drop_empty_codex_optional_fields():
+    parsed = AskUserArguments.model_validate(
+        {
+            "title": "Image details",
+            "questions": [
+                {
+                    "id": "subject",
+                    "options": [],
+                    "question": "What should the image show?",
+                    "help_text": "Describe the subject, scene, style, and any important details.",
+                    "input_type": "text",
+                    "validation": {
+                        "placeholder": "Example: a cozy cabin in a snowy forest at sunset"
+                    },
+                    "allow_other": False,
+                },
+                {
+                    "id": "aspect",
+                    "options": [{"label": "Square", "value": "1:1"}],
+                    "question": "What aspect ratio do you want?",
+                    "help_text": "",
+                    "input_type": "single_select",
+                    "validation": {"placeholder": ""},
+                    "allow_other": False,
+                },
+            ],
+        }
+    )
+
+    dumped = parsed.dump_public()
+    assert "options" not in dumped["questions"][0]
+    assert dumped["questions"][0]["validation"]["placeholder"].startswith("Example:")
+    assert dumped["questions"][1]["options"] == [{"label": "Square", "value": "1:1"}]
+    assert "validation" not in dumped["questions"][1]
+
+
+def test_openai_codex_direct_runner_stops_after_ask_user_pending():
+    req = _openai_codex_test_req()
+    calls = {"stream": 0}
+
+    async def _stream_one_request(self, *_args, **_kwargs):
+        calls["stream"] += 1
+        if calls["stream"] > 1:
+            raise AssertionError("Codex should wait for user input before another request.")
+        return [
+            {
+                "type": "function_call",
+                "name": "ask_user",
+                "call_id": "call-1",
+                "arguments": '{"questions":[{"question":"Continue?","input_type":"boolean"}]}',
+            }
+        ]
+
+    async def _direct_tool_call(**kwargs):
+        assert kwargs["mixed_tool_round"] is False
+        kwargs["state"].awaiting_user_input = True
+        return {"type": "function_call_output", "call_id": "call-1", "output": "{}"}
+
+    with (
+        patch(
+            "services.openai_codex._OpenAICodexDirectTurnRunner._stream_one_request",
+            _stream_one_request,
+        ),
+        patch("services.openai_codex._run_openai_codex_direct_tool_call", _direct_tool_call),
+    ):
+        response = asyncio.run(_OpenAICodexDirectTurnRunner(req, req.auth_json).run())
+
+    assert response == ""
+    assert calls["stream"] == 1
 
 
 def test_extract_openai_codex_reasoning_item_text_prefers_summary_then_content():
@@ -666,6 +1036,195 @@ def test_get_openai_codex_models_safe_returns_warning_on_auth_failure():
     assert warnings[0].message == str(auth_error)
     assert warnings[0].actionLabel == "Open provider settings"
     assert warnings[0].actionUrl == "/settings?tab=providers"
+
+
+def test_openai_codex_models_dev_catalog_filters_codex_models():
+    models = build_openai_codex_models_from_models_dev(
+        {
+            "openai": {
+                "models": {
+                    "gpt-5.4": {
+                        "id": "gpt-5.4",
+                        "name": "GPT-5.4",
+                        "modalities": {"input": ["text", "image", "pdf"], "output": ["text"]},
+                        "limit": {"context": 1050000},
+                    },
+                    "gpt-5.5-pro": {
+                        "id": "gpt-5.5-pro",
+                        "name": "GPT-5.5 Pro",
+                        "modalities": {"input": ["text", "image"], "output": ["text"]},
+                        "limit": {"context": 1050000},
+                    },
+                    "gpt-5.4-nano": {"id": "gpt-5.4-nano"},
+                    "gpt-4.1": {"id": "gpt-4.1"},
+                }
+            }
+        }
+    )
+
+    model_ids = [model.id for model in models]
+    assert model_ids[0] == "openai-codex/gpt-5.4:image-generation"
+    assert "openai-codex/gpt-5.5-pro" in model_ids
+    assert "openai-codex/gpt-5.4" in model_ids
+    assert "openai-codex/gpt-5.4-nano" not in model_ids
+    assert "openai-codex/gpt-4.1" not in model_ids
+
+
+def test_openai_codex_browser_oauth_origin_is_local_only():
+    assert is_openai_codex_browser_oauth_local_origin("http://localhost:3000") is True
+    assert is_openai_codex_browser_oauth_local_origin("http://127.0.0.1:3000") is True
+    assert is_openai_codex_browser_oauth_local_origin("http://0.0.0.0:3000") is True
+    assert is_openai_codex_browser_oauth_local_origin("http://[::1]:3000") is True
+    assert is_openai_codex_browser_oauth_local_origin("https://meridian.example.com") is False
+    assert is_openai_codex_browser_oauth_local_origin("") is False
+
+
+def test_openai_codex_validation_forces_refresh_and_probes_auth():
+    auth_json = _build_codex_auth_json_from_tokens(
+        {
+            "id_token": _unsigned_jwt({}),
+            "access_token": _unsigned_jwt({"exp": 4102444800}),
+            "refresh_token": "refresh-token",
+        }
+    )
+    events = []
+
+    async def _refresh_if_needed(auth_json_value: str, *, force: bool = False) -> str:
+        events.append(("refresh", force))
+        return auth_json_value
+
+    async def _probe_auth(_auth_json_value: str) -> None:
+        events.append(("probe", True))
+
+    with (
+        patch("services.openai_codex._refresh_openai_codex_auth_if_needed", _refresh_if_needed),
+        patch("services.openai_codex._probe_openai_codex_auth", _probe_auth),
+    ):
+        normalized_auth_json = asyncio.run(validate_openai_codex_oauth_auth_json(auth_json))
+
+    assert normalized_auth_json == auth_json
+    assert events == [("refresh", True), ("probe", True)]
+
+
+def test_openai_codex_auth_probe_payload_includes_required_instructions():
+    auth_json = _build_codex_auth_json_from_tokens(
+        {
+            "id_token": _unsigned_jwt({}),
+            "access_token": _unsigned_jwt({"exp": 4102444800}),
+            "refresh_token": "refresh-token",
+        }
+    )
+    calls: dict[str, Any] = {}
+
+    class ProbeStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'event: response.completed\ndata: {"response":{"output":[]}}\n\n'
+
+    class StreamContext:
+        async def __aenter__(self):
+            return httpx.Response(200, stream=ProbeStream())
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class FakeAsyncClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def stream(self, method, endpoint, *, headers, json):
+            calls["method"] = method
+            calls["endpoint"] = endpoint
+            calls["headers"] = headers
+            calls["payload"] = json
+            return StreamContext()
+
+    with patch("services.openai_codex.httpx.AsyncClient", FakeAsyncClient):
+        asyncio.run(_probe_openai_codex_auth(auth_json))
+
+    assert calls["method"] == "POST"
+    assert calls["endpoint"] == "https://chatgpt.com/backend-api/codex/responses"
+    assert calls["payload"]["instructions"]
+    assert "max_output_tokens" not in calls["payload"]
+
+
+def test_openai_codex_model_discovery_validates_before_catalog_fetch():
+    auth_json = _build_codex_auth_json_from_tokens(
+        {
+            "id_token": _unsigned_jwt({}),
+            "access_token": _unsigned_jwt({"exp": 4102444800}),
+            "refresh_token": "refresh-token",
+        }
+    )
+    events = []
+
+    async def _validate_auth(auth_json_value: str) -> str:
+        events.append("validate")
+        return auth_json_value
+
+    async def _fetch_catalog():
+        events.append("catalog")
+        return []
+
+    with (
+        patch("services.openai_codex._validate_openai_codex_auth_tokens", _validate_auth),
+        patch("services.openai_codex.get_models_dev_openai_codex_models", _fetch_catalog),
+    ):
+        models = asyncio.run(list_openai_codex_models(auth_json))
+
+    assert models == []
+    assert events == ["validate", "catalog"]
+
+
+def test_openai_codex_model_discovery_rejects_invalid_auth_before_catalog_fetch():
+    async def _validate_auth(_auth_json_value: str) -> str:
+        raise ValueError("bad codex auth")
+
+    async def _fetch_catalog():  # pragma: no cover - defensive regression guard
+        raise AssertionError("catalog should not be fetched before auth validation")
+
+    with (
+        patch("services.openai_codex._validate_openai_codex_auth_tokens", _validate_auth),
+        patch("services.openai_codex.get_models_dev_openai_codex_models", _fetch_catalog),
+    ):
+        try:
+            asyncio.run(list_openai_codex_models("{}"))
+        except ValueError as exc:
+            assert "bad codex auth" in str(exc)
+        else:  # pragma: no cover - defensive regression guard
+            raise AssertionError("Expected invalid Codex auth to fail before catalog fetch.")
+
+
+def test_openai_codex_model_discovery_falls_back_when_models_dev_fails():
+    auth_json = _build_codex_auth_json_from_tokens(
+        {
+            "id_token": _unsigned_jwt({}),
+            "access_token": _unsigned_jwt({"exp": 4102444800}),
+            "refresh_token": "refresh-token",
+        }
+    )
+
+    async def _validate_auth(auth_json_value: str) -> str:
+        return auth_json_value
+
+    with (
+        patch("services.openai_codex._validate_openai_codex_auth_tokens", _validate_auth),
+        patch(
+            "services.openai_codex.get_models_dev_openai_codex_models",
+            side_effect=RuntimeError("models.dev unavailable"),
+        ),
+    ):
+        models = asyncio.run(list_openai_codex_models(auth_json))
+
+    model_ids = [model.id for model in models]
+    assert "openai-codex/gpt-5.5" in model_ids
+    assert "openai-codex/gpt-5.4" in model_ids
+    assert model_ids[0] == "openai-codex/gpt-5.5:image-generation"
 
 
 def test_format_model_unavailable_error_mentions_cli_scope():

--- a/api/tests/test_inference.py
+++ b/api/tests/test_inference.py
@@ -37,6 +37,7 @@ from services.inference import (
     GEMINI_CLI_SUPPORTED_TOOL_NAMES,
     GITHUB_COPILOT_SUPPORTED_TOOL_NAMES,
     OPENAI_CODEX_SUPPORTED_TOOL_NAMES,
+    OPENCODE_GO_SUPPORTED_TOOL_NAMES,
     Z_AI_CODING_PLAN_SUPPORTED_TOOL_NAMES,
     get_github_copilot_models_safe,
     get_openai_codex_models_safe,
@@ -90,6 +91,8 @@ from services.providers.openai_codex_catalog import build_openai_codex_models_fr
 from services.providers.opencode_go_catalog import (
     OPENCODE_GO_TEMPERATURE_OVERRIDES,
     OPENCODE_GO_TOP_P_OVERRIDES,
+    build_opencode_go_models_from_models_dev,
+    get_opencode_go_models,
 )
 from services.providers.z_ai_coding_plan_catalog import (
     build_z_ai_coding_plan_models_from_models_dev,
@@ -174,6 +177,68 @@ def test_z_ai_coding_plan_models_dev_catalog_filters_to_text_models():
     assert models[0].pricing.prompt == "0"
     assert models[0].pricing.completion == "0"
     assert models[0].supportsStructuredOutputs is False
+
+
+def test_opencode_go_catalog_is_subscription_only_and_not_structured():
+    models = build_opencode_go_models_from_models_dev(
+        {
+            "opencode-go": {
+                "models": {
+                    "kimi-k2.7-code": {
+                        "id": "kimi-k2.7-code",
+                        "name": "Kimi K2.7 Code",
+                        "release_date": "2026-06-12",
+                        "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+                        "limit": {"context": 262144},
+                        "cost": {"input": 0.95, "output": 4},
+                    }
+                }
+            }
+        }
+    )
+
+    assert models
+    for model in models:
+        assert model.provider == InferenceProviderEnum.OPENCODE_GO
+        assert model.billingType == BillingTypeEnum.SUBSCRIPTION
+        assert model.supportsStructuredOutputs is False
+        assert model.supportsMeridianTools is True
+        assert model.supportedMeridianToolNames == OPENCODE_GO_SUPPORTED_TOOL_NAMES
+
+
+def test_opencode_go_models_dev_catalog_normalizes_metadata():
+    models = build_opencode_go_models_from_models_dev(
+        {
+            "opencode-go": {
+                "models": {
+                    "glm-5": {
+                        "id": "glm-5",
+                        "name": "GLM-5",
+                        "release_date": "2026-04-01",
+                        "modalities": {"input": ["text"], "output": ["text"]},
+                        "limit": {"context": 202752},
+                        "cost": {"input": 1.4, "output": 4.4},
+                    },
+                    "qwen3.7-plus": {
+                        "id": "qwen3.7-plus",
+                        "name": "Qwen3.7 Plus",
+                        "release_date": "2026-06-02",
+                        "modalities": {"input": ["text", "image", "video"], "output": ["text"]},
+                        "limit": {"context": 1000000},
+                        "cost": {"input": 0.4, "output": 1.6},
+                    },
+                }
+            }
+        }
+    )
+
+    assert [model.id for model in models] == ["opencode-go/qwen3.7-plus", "opencode-go/glm-5"]
+    assert models[0].architecture.input_modalities == ["text", "image", "video"]
+    assert models[0].architecture.modality == "text+image+video->text"
+    assert models[0].context_length == 1000000
+    assert models[0].created == "2026-06-02"
+    assert models[0].pricing.prompt == "0.4"
+    assert models[0].pricing.completion == "1.6"
 
 
 def test_gemini_cli_catalog_is_subscription_only_and_structured():
@@ -299,13 +364,18 @@ def test_reduce_models_dev_catalog_keeps_only_used_providers_and_models():
                 "doc": "unused",
                 "models": {"glm-5.2": {"name": "GLM-5.2"}},
             },
+            "opencode-go": {
+                "api": "unused",
+                "models": {"glm-5": {"name": "GLM-5"}},
+            },
             "anthropic": {"models": {"claude-sonnet-4-6": {"name": "Claude"}}},
         }
     )
 
-    assert set(reduced) == {"openai", "zai-coding-plan"}
+    assert set(reduced) == {"openai", "zai-coding-plan", "opencode-go"}
     assert reduced["openai"] == {"models": {"gpt-5.5": {"name": "GPT-5.5"}}}
     assert reduced["zai-coding-plan"] == {"models": {"glm-5.2": {"name": "GLM-5.2"}}}
+    assert reduced["opencode-go"] == {"models": {"glm-5": {"name": "GLM-5"}}}
 
 
 def test_model_supports_structured_outputs_reads_dict_and_model_instances():
@@ -957,6 +1027,35 @@ def test_z_ai_coding_plan_catalog_returns_models_dev_copies():
 
 def test_z_ai_coding_plan_catalog_returns_empty_without_models_dev_catalog():
     models = asyncio.run(get_z_ai_coding_plan_models())
+
+    assert models == []
+
+
+def test_opencode_go_catalog_returns_models_dev_copies():
+    models_dev_catalog = {
+        "opencode-go": {
+            "models": {
+                "glm-5": {
+                    "id": "glm-5",
+                    "name": "GLM-5",
+                    "modalities": {"input": ["text"], "output": ["text"]},
+                    "limit": {"context": 202752},
+                    "cost": {"input": 1.4, "output": 4.4},
+                }
+            }
+        }
+    }
+
+    models = asyncio.run(get_opencode_go_models(models_dev_catalog))
+    models[0].name = "Mutated"
+    models_again = asyncio.run(get_opencode_go_models(models_dev_catalog))
+
+    assert [model.id for model in models_again] == ["opencode-go/glm-5"]
+    assert models_again[0].name == "GLM-5"
+
+
+def test_opencode_go_catalog_returns_empty_without_models_dev_catalog():
+    models = asyncio.run(get_opencode_go_models())
 
     assert models == []
 

--- a/ui/app/components/ui/chat/chatBox.vue
+++ b/ui/app/components/ui/chat/chatBox.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { useMediaQuery } from '@vueuse/core';
 import { NodeTypeEnum, MessageRoleEnum } from '@/types/enums';
 import { DEFAULT_NODE_ID } from '@/constants';
 import { useChatGenerator } from '@/composables/useChatGenerator';
@@ -42,7 +41,7 @@ const isAtBottom = ref(true);
 const chatContainer: Ref<HTMLElement | null> = ref(null);
 const expandedMessages = ref<Set<number>>(new Set());
 const highlightedNodeId = ref<string | null>(null);
-const isCompactCanvasWidth = useMediaQuery('(max-width: 110rem)');
+const isCompactCanvasWidth = useHydratedMediaQuery('(max-width: 110rem)');
 
 // --- Composables ---
 const { isCanvasEmpty } = useGraphChat();

--- a/ui/app/components/ui/chat/nodeTrash.vue
+++ b/ui/app/components/ui/chat/nodeTrash.vue
@@ -1,13 +1,11 @@
 <script lang="ts" setup>
-import { useMediaQuery } from '@vueuse/core';
-
 defineProps<{
     isHoverDelete: boolean;
 }>();
 
 const sidebarSelectorStore = useSidebarCanvasStore();
 const { isLeftOpen } = storeToRefs(sidebarSelectorStore);
-const isCompactCanvasWidth = useMediaQuery('(max-width: 96rem)');
+const isCompactCanvasWidth = useHydratedMediaQuery('(max-width: 96rem)');
 </script>
 
 <template>

--- a/ui/app/components/ui/graph/canvasControls.vue
+++ b/ui/app/components/ui/graph/canvasControls.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { useMediaQuery } from '@vueuse/core';
 import { useVueFlow } from '@vue-flow/core';
 import { Controls, ControlButton } from '@vue-flow/controls';
 import { DEFAULT_NODE_ID } from '@/constants';
@@ -14,7 +13,7 @@ const sidebarSelectorStore = useSidebarCanvasStore();
 
 // --- State from Stores (Reactive Refs) ---
 const { isLeftOpen } = storeToRefs(sidebarSelectorStore);
-const isCompactCanvasWidth = useMediaQuery('(max-width: 96rem)');
+const isCompactCanvasWidth = useHydratedMediaQuery('(max-width: 96rem)');
 
 // --- Composables ---
 const { getNodes, removeNodes } = useVueFlow('main-graph-' + props.graphId);

--- a/ui/app/components/ui/graph/saveCron.vue
+++ b/ui/app/components/ui/graph/saveCron.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { useMediaQuery } from '@vueuse/core';
 import { SavingStatus } from '@/types/enums';
 import { useVueFlow } from '@vue-flow/core';
 
@@ -11,7 +10,7 @@ const canvasSaveStore = useCanvasSaveStore();
 // --- State from Stores (Reactive Refs) ---
 const { isRightOpen } = storeToRefs(sidebarSelectorStore);
 const { isAnyNodeStreaming } = storeToRefs(streamStore);
-const isCompactCanvasWidth = useMediaQuery('(max-width: 96rem)');
+const isCompactCanvasWidth = useHydratedMediaQuery('(max-width: 96rem)');
 
 // --- Actions/Methods from Stores ---
 const { setUpdateGraphHandler, saveGraph, setNeedSave, getNeedSave } = canvasSaveStore;

--- a/ui/app/components/ui/settings/section/accountProviders.vue
+++ b/ui/app/components/ui/settings/section/accountProviders.vue
@@ -20,8 +20,11 @@ const {
     disconnectZAiCodingPlanApiKey,
     connectGeminiCliOAuthCreds,
     disconnectGeminiCliOAuthCreds,
-    connectOpenAICodexAuthJson,
-    disconnectOpenAICodexAuthJson,
+    startOpenAICodexBrowserOAuth,
+    completeOpenAICodexBrowserOAuth,
+    startOpenAICodexDeviceOAuth,
+    completeOpenAICodexDeviceOAuth,
+    disconnectOpenAICodexOAuth,
     connectOpenCodeGoApiKey,
     disconnectOpenCodeGoApiKey,
     getAvailableModels,
@@ -56,8 +59,17 @@ const isGeminiCliSubmitting = ref(false);
 const openAICodexStatus = computed<InferenceProviderStatus | null>(() =>
     getProviderStatus('openai_codex'),
 );
-const openAICodexAuthJson = ref('');
 const isOpenAICodexSubmitting = ref(false);
+const openAICodexBrowserSessionId = ref('');
+const openAICodexDeviceSessionId = ref('');
+const openAICodexDeviceUrl = ref('');
+const openAICodexDeviceCode = ref('');
+const isOpenAICodexBrowserSignInAvailable = computed(() => {
+    if (!import.meta.client) {
+        return false;
+    }
+    return ['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(window.location.hostname);
+});
 
 const openCodeGoStatus = computed<InferenceProviderStatus | null>(() =>
     getProviderStatus('opencode_go'),
@@ -231,20 +243,22 @@ const removeGeminiCliOAuthCreds = async () => {
     }
 };
 
-const saveOpenAICodexAuthJson = async () => {
-    if (!openAICodexAuthJson.value.trim()) {
-        warning('Paste OpenAI Codex auth.json content first.', { title: 'Missing auth.json' });
+const startOpenAICodexBrowserSignIn = async () => {
+    if (!isOpenAICodexBrowserSignInAvailable.value) {
+        warning('Use device-code sign-in when Meridian is not opened from localhost.', {
+            title: 'Browser Sign-In Unavailable',
+        });
         return;
     }
     isOpenAICodexSubmitting.value = true;
     try {
-        await connectOpenAICodexAuthJson(openAICodexAuthJson.value.trim());
-        openAICodexAuthJson.value = '';
-        await Promise.all([refreshInferenceProviderStatuses(), refreshAvailableModels()]);
-        success('OpenAI Codex connected successfully.');
+        const result = await startOpenAICodexBrowserOAuth();
+        openAICodexBrowserSessionId.value = result.session_id;
+        window.open(result.url, '_blank', 'noopener,noreferrer');
+        success('OpenAI Codex sign-in opened. Complete it in your browser, then finish here.');
     } catch (err) {
-        console.error('Failed to connect OpenAI Codex:', err);
-        error((err as Error).message || 'Failed to connect OpenAI Codex.', {
+        console.error('Failed to start OpenAI Codex browser sign-in:', err);
+        error((err as Error).message || 'Failed to start OpenAI Codex browser sign-in.', {
             title: 'OpenAI Codex Error',
         });
     } finally {
@@ -252,10 +266,73 @@ const saveOpenAICodexAuthJson = async () => {
     }
 };
 
-const removeOpenAICodexAuthJson = async () => {
+const completeOpenAICodexBrowserSignIn = async () => {
+    if (!openAICodexBrowserSessionId.value) {
+        warning('Start browser sign-in first.', { title: 'No active sign-in' });
+        return;
+    }
     isOpenAICodexSubmitting.value = true;
     try {
-        await disconnectOpenAICodexAuthJson();
+        await completeOpenAICodexBrowserOAuth(openAICodexBrowserSessionId.value);
+        openAICodexBrowserSessionId.value = '';
+        await Promise.all([refreshInferenceProviderStatuses(), refreshAvailableModels()]);
+        success('OpenAI Codex connected successfully.');
+    } catch (err) {
+        console.error('Failed to complete OpenAI Codex browser sign-in:', err);
+        error((err as Error).message || 'Failed to complete OpenAI Codex browser sign-in.', {
+            title: 'OpenAI Codex Error',
+        });
+    } finally {
+        isOpenAICodexSubmitting.value = false;
+    }
+};
+
+const startOpenAICodexDeviceSignIn = async () => {
+    isOpenAICodexSubmitting.value = true;
+    try {
+        const result = await startOpenAICodexDeviceOAuth();
+        openAICodexDeviceSessionId.value = result.session_id;
+        openAICodexDeviceUrl.value = result.verification_url;
+        openAICodexDeviceCode.value = result.user_code;
+        window.open(result.verification_url, '_blank', 'noopener,noreferrer');
+        success('OpenAI Codex device code created. Enter it in the opened page.');
+    } catch (err) {
+        console.error('Failed to start OpenAI Codex device sign-in:', err);
+        error((err as Error).message || 'Failed to start OpenAI Codex device sign-in.', {
+            title: 'OpenAI Codex Error',
+        });
+    } finally {
+        isOpenAICodexSubmitting.value = false;
+    }
+};
+
+const completeOpenAICodexDeviceSignIn = async () => {
+    if (!openAICodexDeviceSessionId.value) {
+        warning('Start device-code sign-in first.', { title: 'No active sign-in' });
+        return;
+    }
+    isOpenAICodexSubmitting.value = true;
+    try {
+        await completeOpenAICodexDeviceOAuth(openAICodexDeviceSessionId.value);
+        openAICodexDeviceSessionId.value = '';
+        openAICodexDeviceUrl.value = '';
+        openAICodexDeviceCode.value = '';
+        await Promise.all([refreshInferenceProviderStatuses(), refreshAvailableModels()]);
+        success('OpenAI Codex connected successfully.');
+    } catch (err) {
+        console.error('Failed to complete OpenAI Codex device sign-in:', err);
+        error((err as Error).message || 'Failed to complete OpenAI Codex device sign-in.', {
+            title: 'OpenAI Codex Error',
+        });
+    } finally {
+        isOpenAICodexSubmitting.value = false;
+    }
+};
+
+const removeOpenAICodexOAuth = async () => {
+    isOpenAICodexSubmitting.value = true;
+    try {
+        await disconnectOpenAICodexOAuth();
         await Promise.all([refreshInferenceProviderStatuses(), refreshAvailableModels()]);
         success('OpenAI Codex disconnected successfully.');
     } catch (err) {
@@ -1045,42 +1122,129 @@ onMounted(() => {
             <Transition
                 enter-active-class="transition-[max-height,opacity] duration-300 ease-out"
                 enter-from-class="max-h-0 opacity-0"
-                enter-to-class="max-h-[700px] opacity-100"
+                enter-to-class="max-h-[900px] opacity-100"
                 leave-active-class="transition-[max-height,opacity] duration-200 ease-in"
-                leave-from-class="max-h-[700px] opacity-100"
+                leave-from-class="max-h-[900px] opacity-100"
                 leave-to-class="max-h-0 opacity-0"
             >
                 <div v-if="expandedProvider === 'openai'" class="overflow-hidden">
                     <div class="border-stone-gray/8 mx-5 border-t" />
-                    <div class="grid grid-cols-2 gap-6 px-5 py-5">
-                        <!-- Left: textarea + actions -->
+                    <div class="grid grid-cols-1 gap-6 px-5 py-5 lg:grid-cols-2">
+                        <!-- Left: OAuth actions -->
                         <div class="flex flex-col gap-4">
-                            <div class="flex flex-col gap-1.5">
-                                <label
+                            <div class="border-stone-gray/10 bg-obsidian/35 rounded-xl border p-4">
+                                <p
                                     class="text-stone-gray/60 text-xs font-semibold tracking-wider
                                         uppercase"
-                                    >Auth JSON</label
                                 >
-                                <textarea
-                                    v-model="openAICodexAuthJson"
-                                    class="provider-input border-stone-gray/15 bg-obsidian/60
-                                        text-stone-gray focus:border-ember-glow/60 min-h-28 w-full
-                                        rounded-lg border-2 p-3 text-sm transition-colors
-                                        duration-200 outline-none"
-                                    placeholder="Paste the full auth.json content"
-                                />
+                                    Recommended
+                                </p>
+                                <h4 class="text-soft-silk mt-1 text-sm font-bold">
+                                    ChatGPT Pro/Plus OAuth
+                                </h4>
+                                <p class="text-stone-gray/60 mt-1 text-xs leading-relaxed">
+                                    Meridian signs in with OpenAI's Codex OAuth flow and stores fresh
+                                    refreshable tokens for direct Codex requests. Browser sign-in is
+                                    available only from localhost.
+                                </p>
+                                <div class="mt-4 flex flex-wrap items-center gap-2">
+                                    <button
+                                        v-if="isOpenAICodexBrowserSignInAvailable"
+                                        class="bg-ember-glow/80 hover:bg-ember-glow/60 text-soft-silk
+                                            rounded-lg px-4 py-2 text-xs font-bold transition-colors
+                                            duration-200 disabled:cursor-not-allowed
+                                            disabled:opacity-50"
+                                        :disabled="isOpenAICodexSubmitting"
+                                        @click="startOpenAICodexBrowserSignIn"
+                                    >
+                                        Open Browser Sign-In
+                                    </button>
+                                    <button
+                                        v-if="isOpenAICodexBrowserSignInAvailable"
+                                        class="border-ember-glow/30 text-ember-glow/90
+                                            hover:bg-ember-glow/10 rounded-lg border px-4 py-2 text-xs
+                                            font-bold transition-colors duration-200
+                                            disabled:cursor-not-allowed disabled:opacity-40"
+                                        :disabled="
+                                            !openAICodexBrowserSessionId || isOpenAICodexSubmitting
+                                        "
+                                        @click="completeOpenAICodexBrowserSignIn"
+                                    >
+                                        Finish Browser Sign-In
+                                    </button>
+                                </div>
+                                <p
+                                    v-if="!isOpenAICodexBrowserSignInAvailable"
+                                    class="text-stone-gray/50 mt-3 text-xs leading-relaxed"
+                                >
+                                    Browser callback sign-in is disabled because this Meridian session
+                                    is not running on localhost. Use device-code sign-in below.
+                                </p>
                             </div>
-                            <div class="flex items-center gap-2">
-                                <button
-                                    class="bg-ember-glow/80 hover:bg-ember-glow/60 text-soft-silk
-                                        rounded-lg px-4 py-2 text-xs font-bold transition-colors
-                                        duration-200 disabled:cursor-not-allowed
-                                        disabled:opacity-50"
-                                    :disabled="isOpenAICodexSubmitting"
-                                    @click="saveOpenAICodexAuthJson"
+
+                            <div class="border-stone-gray/10 bg-obsidian/35 rounded-xl border p-4">
+                                <p
+                                    class="text-stone-gray/60 text-xs font-semibold tracking-wider
+                                        uppercase"
                                 >
-                                    Connect
-                                </button>
+                                    Headless fallback
+                                </p>
+                                <h4 class="text-soft-silk mt-1 text-sm font-bold">Device Code</h4>
+                                <p class="text-stone-gray/60 mt-1 text-xs leading-relaxed">
+                                    Use this when browser callback sign-in is blocked or Meridian is
+                                    running on another machine.
+                                </p>
+                                <div
+                                    v-if="openAICodexDeviceCode"
+                                    class="border-stone-gray/10 bg-obsidian/60 mt-3 rounded-lg border p-3"
+                                >
+                                    <p class="text-stone-gray/50 text-[11px] uppercase tracking-wider">
+                                        Enter this code
+                                    </p>
+                                    <p class="text-soft-silk mt-1 font-mono text-xl font-bold">
+                                        {{ openAICodexDeviceCode }}
+                                    </p>
+                                    <NuxtLink
+                                        v-if="openAICodexDeviceUrl"
+                                        :to="openAICodexDeviceUrl"
+                                        external
+                                        target="_blank"
+                                        class="text-ember-glow/80 hover:text-ember-glow mt-2 inline-flex
+                                            items-center gap-1 text-xs font-semibold"
+                                    >
+                                        Open verification page<UiIcon
+                                            name="MdiArrowTopRightThick"
+                                            class="h-3.5 w-3.5"
+                                        />
+                                    </NuxtLink>
+                                </div>
+                                <div class="mt-4 flex flex-wrap items-center gap-2">
+                                    <button
+                                        class="border-stone-gray/15 text-stone-gray/80
+                                            hover:bg-stone-gray/8 hover:text-soft-silk rounded-lg border
+                                            px-4 py-2 text-xs font-bold transition-colors duration-200
+                                            disabled:cursor-not-allowed disabled:opacity-40"
+                                        :disabled="isOpenAICodexSubmitting"
+                                        @click="startOpenAICodexDeviceSignIn"
+                                    >
+                                        Create Device Code
+                                    </button>
+                                    <button
+                                        class="border-ember-glow/30 text-ember-glow/90
+                                            hover:bg-ember-glow/10 rounded-lg border px-4 py-2 text-xs
+                                            font-bold transition-colors duration-200
+                                            disabled:cursor-not-allowed disabled:opacity-40"
+                                        :disabled="
+                                            !openAICodexDeviceSessionId || isOpenAICodexSubmitting
+                                        "
+                                        @click="completeOpenAICodexDeviceSignIn"
+                                    >
+                                        Finish Device Sign-In
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div class="flex items-center gap-2">
                                 <button
                                     class="border-stone-gray/15 text-stone-gray/70
                                         hover:bg-stone-gray/8 hover:text-soft-silk rounded-lg border
@@ -1089,7 +1253,7 @@ onMounted(() => {
                                     :disabled="
                                         !openAICodexStatus?.isConnected || isOpenAICodexSubmitting
                                     "
-                                    @click="removeOpenAICodexAuthJson"
+                                    @click="removeOpenAICodexOAuth"
                                 >
                                     Disconnect
                                 </button>
@@ -1098,11 +1262,9 @@ onMounted(() => {
                         <!-- Right: description + help -->
                         <div class="flex flex-col gap-3">
                             <p class="text-stone-gray/70 text-sm leading-relaxed">
-                                Paste the raw content of your local
-                                <code>~/.codex/auth.json</code> file. If your Codex CLI uses the OS
-                                keychain, set <code>cli_auth_credentials_store = "file"</code> in
-                                <code>~/.codex/config.toml</code>, run Codex once, then paste the
-                                resulting file.
+                                The new connection path mirrors OpenCode's Codex integration: PKCE
+                                browser OAuth, device-code OAuth, token refresh deduplication, and
+                                direct Codex HTTP requests without a local Codex runtime.
                             </p>
                             <NuxtLink
                                 class="text-ember-glow/70 hover:text-ember-glow text-xs
@@ -1128,17 +1290,8 @@ onMounted(() => {
                                         <span class="text-stone-gray/30 mt-px">&#x2022;</span>
                                         <span>PDF and generic file attachments input</span>
                                     </li>
-                                    <li class="flex items-start gap-1.5">
-                                        <span class="text-stone-gray/30 mt-px">&#x2022;</span>
-                                        <span>Direct image generation</span>
-                                    </li>
                                 </ul>
                             </div>
-                            <p class="text-stone-gray/40 mt-1 text-[11px]">
-                                Copied sessions can become invalid after token refresh. If models
-                                stop listing, refresh <code>auth.json</code> from a machine where
-                                <code>codex</code> is signed in.
-                            </p>
                         </div>
                     </div>
                 </div>

--- a/ui/app/composables/useAPI.ts
+++ b/ui/app/composables/useAPI.ts
@@ -420,14 +420,38 @@ export const useAPI = () => {
             method: 'DELETE',
         });
 
-    const connectOpenAICodexAuthJson = (auth_json: string) =>
-        apiFetch<{ message: string }>('/api/inference/providers/openai-codex/auth-json', {
+    const startOpenAICodexBrowserOAuth = () =>
+        apiFetch<{ session_id: string; url: string; instructions: string }>(
+            '/api/inference/providers/openai-codex/oauth/browser/start',
+            { method: 'POST' },
+        );
+
+    const completeOpenAICodexBrowserOAuth = (session_id: string) =>
+        apiFetch<{ message: string }>(
+            '/api/inference/providers/openai-codex/oauth/browser/complete',
+            {
+                method: 'POST',
+                body: JSON.stringify({ session_id }),
+            },
+        );
+
+    const startOpenAICodexDeviceOAuth = () =>
+        apiFetch<{
+            session_id: string;
+            verification_url: string;
+            user_code: string;
+            interval_seconds: number;
+            instructions: string;
+        }>('/api/inference/providers/openai-codex/oauth/device/start', { method: 'POST' });
+
+    const completeOpenAICodexDeviceOAuth = (session_id: string) =>
+        apiFetch<{ message: string }>('/api/inference/providers/openai-codex/oauth/device/complete', {
             method: 'POST',
-            body: JSON.stringify({ auth_json }),
+            body: JSON.stringify({ session_id }),
         });
 
-    const disconnectOpenAICodexAuthJson = () =>
-        apiFetch<{ message: string }>('/api/inference/providers/openai-codex/auth-json', {
+    const disconnectOpenAICodexOAuth = () =>
+        apiFetch<{ message: string }>('/api/inference/providers/openai-codex/oauth', {
             method: 'DELETE',
         });
 
@@ -1037,8 +1061,11 @@ export const useAPI = () => {
         disconnectZAiCodingPlanApiKey,
         connectGeminiCliOAuthCreds,
         disconnectGeminiCliOAuthCreds,
-        connectOpenAICodexAuthJson,
-        disconnectOpenAICodexAuthJson,
+        startOpenAICodexBrowserOAuth,
+        completeOpenAICodexBrowserOAuth,
+        startOpenAICodexDeviceOAuth,
+        completeOpenAICodexDeviceOAuth,
+        disconnectOpenAICodexOAuth,
         connectOpenCodeGoApiKey,
         disconnectOpenCodeGoApiKey,
         getPromptImproverTaxonomy,

--- a/ui/app/composables/useHydratedMediaQuery.ts
+++ b/ui/app/composables/useHydratedMediaQuery.ts
@@ -1,0 +1,12 @@
+import { useMediaQuery } from '@vueuse/core';
+
+export function useHydratedMediaQuery(query: string) {
+    const isMounted = ref(false);
+    const matches = useMediaQuery(query);
+
+    onMounted(() => {
+        isMounted.value = true;
+    });
+
+    return computed(() => isMounted.value && matches.value);
+}


### PR DESCRIPTION
# Meridian 1.6.3-beta

Meridian `1.6.3-beta` improves subscription-backed model access with a new OpenAI Codex sign-in flow, dynamic models.dev catalog discovery, better OpenCode Go and Z.AI Coding Plan model metadata, and a small set of frontend reliability fixes.

## Highlights

### OpenAI Codex OAuth Sign-In

OpenAI Codex connections no longer depend on manually pasting a local `auth.json` file.

- Added browser-based OpenAI Codex OAuth sign-in for local Meridian sessions.
- Added device-code OpenAI Codex sign-in for remote, hosted, or headless deployments.
- Added backend endpoints for starting and completing browser and device-code OAuth sessions.
- Added automatic OpenAI Codex token normalization, validation, refresh, and refresh de-duplication.
- Added local-origin checks so browser callback sign-in is only offered from localhost-compatible sessions.
- Added OpenAI Codex disconnect support through the provider settings flow.
- Updated OpenAI Codex provider settings with dedicated **Browser Sign-In**, **Device Code**, completion, and disconnect actions.

### Dynamic Subscription Model Discovery

Subscription-backed providers can now use the live `models.dev` catalog instead of relying only on fixed local model lists.

- Added startup and background refresh for the reduced `models.dev` catalog.
- Added catalog reduction so Meridian keeps only provider data it currently needs.
- Added models.dev-backed discovery for **OpenAI Codex**, **OpenCode Go**, and **Z.AI Coding Plan**.
- Added metadata normalization for model names, input/output modalities, context windows, release dates, and pricing.
- Added safer empty-catalog behavior so providers return no dynamic models when models.dev data is unavailable.
- Kept subscription model discovery isolated from OpenRouter's existing model refresh path.

### OpenAI Codex Model and Runtime Updates

OpenAI Codex model handling now better matches the direct Codex HTTP flow.

- Added models.dev filtering for Codex-capable OpenAI models, including GPT 5.4+ and Codex-named models.
- Added dynamic Codex model IDs under the `openai-codex/` prefix.
- Added a synthetic Codex image-generation model entry backed by a compatible base Codex model.
- Added Codex model validation before dynamic catalog fetches.
- Added reconnect warnings when Codex authentication is invalid or expired.
- Improved direct Codex response handling for text, image inputs, image generation, streaming events, usage data, and account IDs.

### OpenCode Go and Z.AI Coding Plan Catalogs

OpenCode Go and Z.AI Coding Plan now expose fresher provider catalogs with normalized capabilities.

- Reworked OpenCode Go model loading to use models.dev data.
- Reworked Z.AI Coding Plan model loading to use models.dev data.
- Added modality-aware filtering so Z.AI Coding Plan only exposes supported text-input models.
- Added context-length, release-date, pricing, and modality metadata to dynamic subscription models.
- Added OpenCode Go sampling overrides for fixed-sampling models such as `kimi-k2.7-code`.
- Improved OpenCode Go metadata handling for GLM, Kimi, MiMo, MiniMax, and Qwen model families.

### Ask User and Provider Tool Compatibility

Provider-native tool flows received compatibility hardening.

- Improved `ask_user` argument normalization for models that emit optional fields in incompatible shapes.
- Added normalization for legacy single-question Ask User payloads into the current multi-question shape.
- Added provider-specific supported Meridian tool metadata across subscription model discovery.
- Improved handling of optional validation, options, and `allow_other` fields in Ask User payloads.

### Frontend Reliability

Several responsive graph and chat controls now avoid hydration-time media-query mismatches.

- Added a `useHydratedMediaQuery` composable that only reports media query matches after the client has mounted.
- Updated chat box layout controls to use hydrated media queries.
- Updated graph canvas controls, node trash, and save-cron controls to use hydrated media queries.
- Reduced SSR/client mismatch risk for responsive canvas UI controls.

## Self-Hosting and Upgrade Notes

Self-hosted deployments should treat `1.6.3-beta` as a provider-integration upgrade.

- No database migration is required for this update.
- Outbound access to `https://models.dev/api.json` is now used for dynamic subscription model discovery.
- OpenAI Codex browser sign-in requires Meridian to be opened from localhost so the local OAuth callback can complete.
- Remote or hosted deployments should use OpenAI Codex device-code sign-in instead of browser callback sign-in.
- OpenAI Codex, OpenCode Go, and Z.AI Coding Plan still require users to connect the corresponding provider credentials in **Settings -> Account -> Providers**.
