### PR TITLE
feat(text-cleaning): implement thinking block stripping functionality in title generation pipeline

### DIFF
--- a/api/app/services/node.py
+++ b/api/app/services/node.py
@@ -39,6 +39,17 @@ from services.repository_paths import build_repo_path
 from services.tool_calls import expand_tool_context_in_text, extract_tool_call_ids
 from sqlalchemy.ext.asyncio import AsyncEngine as SQLAlchemyAsyncEngine
 
+_THINKING_OPEN_TAG = r"(?:\[\s*THINK\s*\]|<\s*think(?:ing)?(?:\s+[^>]*)?\s*>)"
+_THINKING_CLOSE_TAG = r"(?:\[\s*!\s*THINK\s*\]|<\s*/\s*think(?:ing)?\s*>)"
+_THINKING_BLOCK_RE = re.compile(
+    rf"{_THINKING_OPEN_TAG}[\s\S]*?{_THINKING_CLOSE_TAG}",
+    re.IGNORECASE,
+)
+_THINKING_TAG_RE = re.compile(
+    rf"{_THINKING_OPEN_TAG}|{_THINKING_CLOSE_TAG}",
+    re.IGNORECASE,
+)
+
 
 def system_message_builder(
     system_prompt: str,
@@ -133,6 +144,13 @@ class CleanTextOption(Enum):
     REMOVE_TAG_AND_TEXT = 2
 
 
+def strip_thinking_blocks(text: str) -> str:
+    if not text:
+        return ""
+    without_blocks = _THINKING_BLOCK_RE.sub("", text)
+    return _THINKING_TAG_RE.sub("", without_blocks).strip()
+
+
 def text_cleaner(text: str, clean_text: CleanTextOption) -> str:
     """
     Cleans the provided text based on the specified cleaning option.
@@ -149,15 +167,11 @@ def text_cleaner(text: str, clean_text: CleanTextOption) -> str:
         case CleanTextOption.REMOVE_NOTHING:
             return text.strip() if text else ""
         case CleanTextOption.REMOVE_TAGS_ONLY:
-            # Remove [THINK] and [!THINK] tags but keep the text inside
-            return re.sub(r"\[THINK\]|\[!THINK\]", "", text).strip() if text else ""
+            # Remove thinking tags but keep the text inside.
+            return _THINKING_TAG_RE.sub("", text).strip() if text else ""
         case CleanTextOption.REMOVE_TAG_AND_TEXT:
-            # Remove [THINK] and [!THINK] tags along with the text inside
-            return (
-                re.sub(r"\[THINK\][\s\S]*?\[!THINK\]", "", text, flags=re.DOTALL).strip()
-                if text
-                else ""
-            )
+            # Remove thinking tags along with the text inside.
+            return strip_thinking_blocks(text)
         case _:
             raise ValueError(f"Unsupported clean_text option: {clean_text}")
 

--- a/api/app/services/stream.py
+++ b/api/app/services/stream.py
@@ -55,6 +55,7 @@ from services.node import (
     CleanTextOption,
     extract_context_prompt,
     get_first_user_prompt,
+    strip_thinking_blocks,
     system_message_builder,
 )
 from services.sandbox_inputs import (
@@ -1077,7 +1078,7 @@ async def propagate_stream_to_websocket(
                 {
                     "type": "title_response",
                     "node_id": request_data.node_id,
-                    "payload": {"title": title.strip()},
+                    "payload": {"title": strip_thinking_blocks(title)},
                 }
             )
 
@@ -1508,7 +1509,7 @@ async def regenerate_title_stream(
             {
                 "type": "title_response",
                 "node_id": graph_id,
-                "payload": {"title": title.strip()},
+                "payload": {"title": strip_thinking_blocks(title)},
             }
         )
 

--- a/api/tests/test_node_text_cleaner.py
+++ b/api/tests/test_node_text_cleaner.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
+
+from services.node import CleanTextOption, strip_thinking_blocks, text_cleaner
+
+
+def test_strip_thinking_blocks_removes_provider_thinking_markers() -> None:
+    title = "[THINK]\nChoosing a concise title\n[!THINK]\nArchitecture Refactor"
+
+    assert strip_thinking_blocks(title) == "Architecture Refactor"
+
+
+def test_strip_thinking_blocks_removes_xml_thinking_tags() -> None:
+    title = "<thinking>Need a short summary</thinking> API Error Handling"
+
+    assert strip_thinking_blocks(title) == "API Error Handling"
+
+
+def test_text_cleaner_remove_tags_only_keeps_thinking_text() -> None:
+    text = "<think>reasoning</think> Final answer"
+
+    assert text_cleaner(text, CleanTextOption.REMOVE_TAGS_ONLY) == "reasoning Final answer"
+
+
+def test_text_cleaner_remove_tag_and_text_removes_thinking_text() -> None:
+    text = "[THINK]\nreasoning\n[!THINK]\nFinal answer"
+
+    assert text_cleaner(text, CleanTextOption.REMOVE_TAG_AND_TEXT) == "Final answer"


### PR DESCRIPTION
- Added `strip_thinking_blocks` function to remove thinking markers from text.
- Updated `text_cleaner` to utilize the new function for cleaning options.
- Introduced unit tests for the new functionality to ensure correctness.