### PR TITLE
fix(storage): widen usage totals to bigint

### DIFF
--- a/api/app/database/pg/models.py
+++ b/api/app/database/pg/models.py
@@ -12,7 +12,15 @@ from services.admin_user_creation import (
     AdminUserCreationMode,
     should_create_initial_userpass_as_admin,
 )
-from sqlalchemy import Column, ForeignKeyConstraint, Index, PrimaryKeyConstraint, func, select
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    ForeignKeyConstraint,
+    Index,
+    PrimaryKeyConstraint,
+    func,
+    select,
+)
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, JSONB, TEXT, TIMESTAMP
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.ext.asyncio import AsyncEngine as SQLAlchemyAsyncEngine
@@ -63,7 +71,10 @@ class UserStorageUsage(SQLModel, table=True):
             unique=True,
         )
     )
-    total_bytes_used: int = Field(default=0, nullable=False)
+    total_bytes_used: int = Field(
+        default=0,
+        sa_column=Column(BigInteger, nullable=False),
+    )
     updated_at: Optional[datetime.datetime] = Field(
         default=None,
         sa_column=Column(

--- a/api/migrations/versions/4e7a9c2b6d10_widen_storage_usage_to_bigint.py
+++ b/api/migrations/versions/4e7a9c2b6d10_widen_storage_usage_to_bigint.py
@@ -1,0 +1,36 @@
+"""widen storage usage to bigint
+
+Revision ID: 4e7a9c2b6d10
+Revises: f3a6b7c8d9e0
+Create Date: 2026-07-30 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4e7a9c2b6d10"
+down_revision = "f3a6b7c8d9e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "user_storage_usage",
+        "total_bytes_used",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "user_storage_usage",
+        "total_bytes_used",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+    )

--- a/api/tests/test_storage_usage_bigint.py
+++ b/api/tests/test_storage_usage_bigint.py
@@ -1,0 +1,49 @@
+import importlib
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import sqlalchemy as sa
+
+APP_DIR = Path(__file__).resolve().parents[1] / "app"
+sys.path.append(str(APP_DIR))
+
+UserStorageUsage = importlib.import_module("database.pg.models").UserStorageUsage
+migration = importlib.import_module(
+    "migrations.versions.4e7a9c2b6d10_widen_storage_usage_to_bigint"
+)
+
+
+def test_storage_usage_model_uses_bigint() -> None:
+    column = UserStorageUsage.__table__.c.total_bytes_used
+
+    assert isinstance(column.type, sa.BigInteger)
+    assert column.nullable is False
+
+    usage = UserStorageUsage(user_id=uuid.uuid4(), total_bytes_used=2_152_137_593)
+    assert usage.total_bytes_used == 2_152_137_593
+
+
+def test_storage_usage_migration_upgrades_integer_to_bigint() -> None:
+    with patch.object(migration.op, "alter_column") as alter_column:
+        migration.upgrade()
+
+    alter_column.assert_called_once()
+    args, kwargs = alter_column.call_args
+    assert args == ("user_storage_usage", "total_bytes_used")
+    assert isinstance(kwargs["existing_type"], sa.Integer)
+    assert isinstance(kwargs["type_"], sa.BigInteger)
+    assert kwargs["existing_nullable"] is False
+
+
+def test_storage_usage_migration_downgrades_bigint_to_integer() -> None:
+    with patch.object(migration.op, "alter_column") as alter_column:
+        migration.downgrade()
+
+    alter_column.assert_called_once()
+    args, kwargs = alter_column.call_args
+    assert args == ("user_storage_usage", "total_bytes_used")
+    assert isinstance(kwargs["existing_type"], sa.BigInteger)
+    assert isinstance(kwargs["type_"], sa.Integer)
+    assert kwargs["existing_nullable"] is False


### PR DESCRIPTION
Prevent storage usage counters from overflowing 32-bit integers by updating the
model and adding an Alembic migration with upgrade and downgrade coverage.