### PR TITLE
fix(opencode-go): handle model request protocols

### DIFF
--- a/api/app/services/opencode_go.py
+++ b/api/app/services/opencode_go.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import re
 import uuid
 from asyncio import TimeoutError as AsyncTimeoutError
 from dataclasses import dataclass, field
@@ -12,7 +13,7 @@ import sentry_sdk
 from database.pg.graph_ops.graph_node_crud import update_node_usage_data
 from database.redis.redis_ops import RedisManager
 from httpx import ConnectError, HTTPStatusError, TimeoutException
-from services.openrouter import _parse_openrouter_error, _process_tool_calls_and_continue
+from services.openrouter import _process_tool_calls_and_continue
 from services.providers.anthropic_protocol import (
     anthropic_tool_calls_to_openai,
     build_anthropic_messages,
@@ -34,6 +35,13 @@ from services.providers.openai_protocol import (
     sanitize_openai_messages,
     stream_openai_compatible_response,
 )
+from services.providers.openai_responses_protocol import (
+    build_openai_responses_payload,
+    extract_openai_responses_function_calls,
+    extract_openai_responses_text,
+    normalize_openai_responses_usage,
+    stream_openai_responses_response,
+)
 from services.providers.opencode_go_catalog import (
     OPENCODE_GO_MODEL_PREFIX,
     OPENCODE_GO_TEMPERATURE_OVERRIDES,
@@ -51,6 +59,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine as SQLAlchemyAsyncEngine
 logger = logging.getLogger("uvicorn.error")
 
 OPENCODE_GO_OPENAI_CHAT_URL = "https://opencode.ai/zen/go/v1/chat/completions"
+OPENCODE_GO_OPENAI_RESPONSES_URL = "https://opencode.ai/zen/go/v1/responses"
 OPENCODE_GO_ANTHROPIC_MESSAGES_URL = "https://opencode.ai/zen/go/v1/messages"
 OPENCODE_GO_VALIDATION_MODEL = f"{OPENCODE_GO_MODEL_PREFIX}qwen3.5-plus"
 OPENCODE_GO_NON_STREAMING_TIMEOUT = httpx.Timeout(300.0, connect=10.0, read=300.0)
@@ -62,6 +71,14 @@ OPENCODE_GO_REASONING_CONTENT_MODEL_IDS = {
     "kimi-k2.5",
     "kimi-k2.6",
 }
+OPENCODE_GO_ERROR_MESSAGE_LIMIT = 500
+OPENCODE_GO_CORRELATION_HEADERS = (
+    "x-request-id",
+    "request-id",
+    "x-correlation-id",
+    "cf-ray",
+    "traceparent",
+)
 
 
 def _normalize_selected_tool_names(selected_tools: list[Any]) -> list[str]:
@@ -104,6 +121,10 @@ def _build_opencode_go_authoritative_system_prompt(
 def _uses_anthropic_protocol(model_id: str) -> bool:
     model_key = strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX)
     return model_key.startswith(("minimax-", "qwen"))
+
+
+def _uses_openai_responses_protocol(model_id: str) -> bool:
+    return strip_model_prefix(model_id, OPENCODE_GO_MODEL_PREFIX) == "grok-4.5"
 
 
 def _supports_image_inputs(model_id: str) -> bool:
@@ -168,6 +189,209 @@ def _parse_anthropic_error(error_content: bytes) -> str:
     return str(error_payload or error_json)
 
 
+def _parse_opencode_go_error(error_content: bytes) -> str:
+    message: str | None = None
+    try:
+        payload = json.loads(error_content)
+        if isinstance(payload, dict):
+            message = _extract_opencode_go_error_message(payload)
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+        pass
+
+    if not message:
+        return "OpenCode Go returned an unknown API error."
+    return _sanitize_opencode_go_error_message(message)
+
+
+def _extract_opencode_go_error_message(
+    payload: dict[str, Any],
+    *,
+    raw_depth: int = 0,
+) -> str | None:
+    error = payload.get("error")
+    if isinstance(error, str) and error.strip():
+        return error
+
+    top_level_message = payload.get("message")
+    if isinstance(top_level_message, str) and top_level_message.strip():
+        return top_level_message
+
+    if not isinstance(error, dict):
+        return None
+    nested_message = error.get("message")
+    if isinstance(nested_message, str) and nested_message.strip():
+        return nested_message
+
+    metadata = error.get("metadata")
+    raw_error = metadata.get("raw") if isinstance(metadata, dict) else None
+    if not isinstance(raw_error, str) or raw_depth >= 1:
+        return None
+    try:
+        decoded_raw_error = json.loads(raw_error)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(decoded_raw_error, dict):
+        return None
+    return _extract_opencode_go_error_message(decoded_raw_error, raw_depth=raw_depth + 1)
+
+
+def _sanitize_opencode_go_error_message(message: str) -> str:
+    sanitized = " ".join(message.split())
+    sanitized = re.sub(
+        r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+",
+        "Bearer [REDACTED]",
+        sanitized,
+    )
+    sanitized = re.sub(
+        r"(?i)\b(api[_ -]?key|access[_ -]?token|authorization|auth|token)"
+        r"\s*[:=]\s*['\"]?[^\s,'\"]+",
+        lambda match: f"{match.group(1)}=[REDACTED]",
+        sanitized,
+    )
+    sanitized = re.sub(r"\bsk-[A-Za-z0-9._~+/=-]+", "[REDACTED]", sanitized)
+    return sanitized[:OPENCODE_GO_ERROR_MESSAGE_LIMIT]
+
+
+def _bounded_structure_keys(payload: dict[Any, Any]) -> list[str]:
+    return sorted({str(key)[:64] for key in payload})[:20]
+
+
+def _bounded_scalar(value: Any, limit: int) -> str | None:
+    if not isinstance(value, (str, int, float, bool)):
+        return None
+    normalized = " ".join(str(value).split())
+    return normalized[:limit] or None
+
+
+def _build_opencode_go_rejection_diagnostic(
+    req: Any,
+    response: httpx.Response,
+    request_payload: dict[str, Any],
+    response_content: bytes,
+) -> dict[str, Any]:
+    response_payload: dict[str, Any] = {}
+    try:
+        parsed_response = json.loads(response_content)
+        if isinstance(parsed_response, dict):
+            response_payload = parsed_response
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+        pass
+
+    error_payload = response_payload.get("error")
+    nested_error = error_payload if isinstance(error_payload, dict) else {}
+    correlation_headers = {
+        header_name: bounded_value
+        for header_name in OPENCODE_GO_CORRELATION_HEADERS
+        if (bounded_value := _bounded_scalar(response.headers.get(header_name), 256)) is not None
+    }
+
+    messages = request_payload.get("messages")
+    request_messages = messages if isinstance(messages, list) else []
+    role_counts: dict[str, int] = {}
+    for message in request_messages:
+        role = str(message.get("role") or "") if isinstance(message, dict) else ""
+        normalized_role = role if role in {"system", "user", "assistant", "tool"} else "other"
+        role_counts[normalized_role] = role_counts.get(normalized_role, 0) + 1
+
+    input_items = request_payload.get("input")
+    request_input = input_items if isinstance(input_items, list) else []
+    input_role_counts: dict[str, int] = {}
+    for item in request_input:
+        role = str(item.get("role") or "") if isinstance(item, dict) else ""
+        normalized_role = role if role in {"user", "assistant"} else "other"
+        input_role_counts[normalized_role] = input_role_counts.get(normalized_role, 0) + 1
+
+    tools = request_payload.get("tools")
+    token_field = next(
+        (
+            field_name
+            for field_name in ("max_tokens", "max_completion_tokens", "max_output_tokens")
+            if field_name in request_payload
+        ),
+        None,
+    )
+    content_type = str(response.headers.get("content-type") or "").split(";", 1)[0].strip()
+    diagnostic = {
+        "response_status": response.status_code,
+        "response_content_type": content_type[:128],
+        "response_byte_length": len(response_content),
+        "response_top_level_keys": _bounded_structure_keys(response_payload),
+        "response_error_keys": _bounded_structure_keys(nested_error),
+        "response_error_type": _bounded_scalar(
+            nested_error.get("type") or response_payload.get("type"), 128
+        ),
+        "response_error_code": _bounded_scalar(
+            nested_error.get("code") or response_payload.get("code"), 128
+        ),
+        "response_correlation_headers": correlation_headers,
+        "request_model": strip_model_prefix(req.model, OPENCODE_GO_MODEL_PREFIX)[:128],
+        "request_payload_keys": _bounded_structure_keys(request_payload),
+        "request_message_count": (len(request_messages) if "messages" in request_payload else None),
+        "request_message_role_counts": (
+            dict(sorted(role_counts.items())) if "messages" in request_payload else None
+        ),
+        "request_input_count": len(request_input) if "input" in request_payload else None,
+        "request_input_role_counts": (
+            dict(sorted(input_role_counts.items())) if "input" in request_payload else None
+        ),
+        "request_tool_count": len(tools) if isinstance(tools, list) else 0,
+        "request_token_field": token_field,
+    }
+    return {key: value for key, value in diagnostic.items() if value is not None}
+
+
+def _log_opencode_go_rejection(
+    req: Any,
+    response: httpx.Response,
+    request_payload: dict[str, Any],
+    response_content: bytes,
+) -> None:
+    diagnostic = _build_opencode_go_rejection_diagnostic(
+        req,
+        response,
+        request_payload,
+        response_content,
+    )
+    logger.warning("OpenCode Go request rejected: %s", json.dumps(diagnostic, sort_keys=True))
+
+
+def _log_opencode_go_terminal_event(
+    event_type: str,
+    event_payload: dict[str, Any],
+    event_counts: dict[str, int],
+) -> None:
+    response = event_payload.get("response")
+    response_payload = response if isinstance(response, dict) else {}
+    error = event_payload.get("error")
+    if not isinstance(error, dict):
+        response_error = response_payload.get("error")
+        error = response_error if isinstance(response_error, dict) else {}
+    incomplete = response_payload.get("incomplete_details")
+    incomplete_payload = incomplete if isinstance(incomplete, dict) else {}
+    output = response_payload.get("output")
+    diagnostic = {
+        "event_type": str(event_type)[:128],
+        "event_keys": _bounded_structure_keys(event_payload),
+        "response_keys": _bounded_structure_keys(response_payload),
+        "error_type": _bounded_scalar(error.get("type"), 128),
+        "error_code": _bounded_scalar(error.get("code"), 128),
+        "response_status": _bounded_scalar(response_payload.get("status"), 128),
+        "incomplete_reason": _bounded_scalar(incomplete_payload.get("reason"), 128),
+        "output_count": len(output) if isinstance(output, list) else None,
+        "event_counts": {
+            str(key)[:128]: min(max(int(value), 0), 9999)
+            for key, value in list(event_counts.items())[:20]
+        },
+    }
+    logger.warning(
+        "OpenCode Go Responses stream terminated: %s",
+        json.dumps(
+            {key: value for key, value in diagnostic.items() if value is not None},
+            sort_keys=True,
+        ),
+    )
+
+
 def _normalize_anthropic_usage_payload(usage: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(usage, dict):
         return None
@@ -227,11 +451,13 @@ class OpenCodeGoReq:
         self.model = model
         self.http_client = http_client
         self.uses_anthropic_protocol = _uses_anthropic_protocol(model)
-        self.api_url = (
-            OPENCODE_GO_ANTHROPIC_MESSAGES_URL
-            if self.uses_anthropic_protocol
-            else OPENCODE_GO_OPENAI_CHAT_URL
-        )
+        self.uses_openai_responses_protocol = _uses_openai_responses_protocol(model)
+        if self.uses_anthropic_protocol:
+            self.api_url = OPENCODE_GO_ANTHROPIC_MESSAGES_URL
+        elif self.uses_openai_responses_protocol:
+            self.api_url = OPENCODE_GO_OPENAI_RESPONSES_URL
+        else:
+            self.api_url = OPENCODE_GO_OPENAI_CHAT_URL
 
     @property
     def headers(self) -> dict[str, str]:
@@ -275,7 +501,10 @@ class OpenCodeGoReqChat(BaseProviderReq, OpenCodeGoReq):
     def get_payload(self) -> dict[str, Any]:
         if self.uses_anthropic_protocol:
             return self._get_anthropic_payload()
-        return self._get_openai_payload()
+        openai_payload = self._get_openai_payload()
+        if self.uses_openai_responses_protocol:
+            return build_openai_responses_payload(openai_payload)
+        return openai_payload
 
     def _get_openai_payload(self) -> dict[str, Any]:
         raw_messages = [
@@ -349,6 +578,13 @@ class OpenCodeGoReqChat(BaseProviderReq, OpenCodeGoReq):
         ]
         available_tool_names = _normalize_selected_tool_names(self.selected_tools)
         system_prompt, anthropic_messages = build_anthropic_messages(raw_messages)
+        if not anthropic_messages:
+            anthropic_messages.append(
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": OPENCODE_GO_FALLBACK_USER_CONTENT}],
+                }
+            )
         payload: dict[str, Any] = {
             "model": strip_model_prefix(self.model, OPENCODE_GO_MODEL_PREFIX),
             "messages": anthropic_messages,
@@ -400,7 +636,7 @@ async def validate_opencode_go_api_key(
             json=payload,
         )
         if response.status_code != 200:
-            error_message = _parse_openrouter_error(response.content)
+            error_message = _parse_opencode_go_error(response.content)
             raise ValueError(
                 f"OpenCode Go validation failed (status {response.status_code}): {error_message}"
             )
@@ -420,7 +656,95 @@ async def make_opencode_go_request_non_streaming(
     req.validate_request()
     if req.uses_anthropic_protocol:
         return await _make_opencode_go_anthropic_request_non_streaming(req, pg_engine)
+    if req.uses_openai_responses_protocol:
+        return await _make_opencode_go_responses_request_non_streaming(req, pg_engine)
     return await _make_opencode_go_openai_request_non_streaming(req, pg_engine)
+
+
+async def _make_opencode_go_responses_request_non_streaming(
+    req: OpenCodeGoReqChat,
+    pg_engine: SQLAlchemyAsyncEngine,
+) -> str:
+    client = req.http_client
+    if client is None:
+        raise ValueError("http_client must be provided")
+
+    with sentry_sdk.start_span(
+        op="ai.request", description="OpenCode Go Responses request"
+    ) as span:
+        span.set_tag("chat.model", req.model)
+        try:
+            payload = req.get_payload()
+            response = await client.post(
+                req.api_url,
+                headers=req.headers,
+                json=payload,
+                timeout=OPENCODE_GO_NON_STREAMING_TIMEOUT,
+            )
+            response.raise_for_status()
+            data = response.json()
+            if not isinstance(data, dict):
+                raise ValueError("OpenCode Go returned an invalid Responses payload.")
+            status = str(data.get("status") or "completed")
+            if status in {"failed", "incomplete"}:
+                _log_opencode_go_terminal_event(
+                    f"response.{status}", {"response": data}, {f"response.{status}": 1}
+                )
+                error_message = _extract_opencode_go_error_message(data)
+                if error_message:
+                    raise ValueError(_sanitize_opencode_go_error_message(error_message))
+                raise ValueError("OpenCode Go returned an incomplete response.")
+            output = data.get("output")
+            if not isinstance(output, list):
+                _log_opencode_go_terminal_event(
+                    "invalid_output", {"response": data}, {"invalid_output": 1}
+                )
+                raise ValueError("OpenCode Go returned an invalid Responses output.")
+            if extract_openai_responses_function_calls(output):
+                _log_opencode_go_terminal_event(
+                    "unexpected_function_call",
+                    {"response": data},
+                    {"unexpected_function_call": 1},
+                )
+                raise ValueError("OpenCode Go tool execution requires streaming mode.")
+            content = extract_openai_responses_text(output)
+            if not content:
+                _log_opencode_go_terminal_event(
+                    "empty_output", {"response": data}, {"empty_output": 1}
+                )
+                raise ValueError("OpenCode Go returned an empty Responses output.")
+
+            usage_data = normalize_openai_responses_usage(data.get("usage"))
+            if usage_data and req.graph_id and req.node_id and not req.is_title_generation:
+                await update_node_usage_data(
+                    pg_engine=pg_engine,
+                    graph_id=req.graph_id,
+                    node_id=req.node_id,
+                    usage_data=usage_data,
+                    node_type=req.node_type,
+                    model_id=req.model_id,
+                )
+            return content
+        except HTTPStatusError as exc:
+            error_message = _parse_opencode_go_error(exc.response.content)
+            _log_opencode_go_rejection(req, exc.response, payload, exc.response.content)
+            span.set_status("internal_error")
+            raise ValueError(
+                f"API Error (Status: {exc.response.status_code}): {error_message}"
+            ) from exc
+        except ValueError:
+            span.set_status("internal_error")
+            raise
+        except (ConnectError, TimeoutException, AsyncTimeoutError) as exc:
+            logger.error("Network/Timeout error connecting to OpenCode Go: %s", exc)
+            span.set_status("unavailable")
+            raise ConnectionError(
+                "Could not connect to the AI service. Please check your network."
+            ) from exc
+        except Exception as exc:
+            logger.error("Unexpected OpenCode Go Responses error: %s", exc, exc_info=True)
+            span.set_status("internal_error")
+            raise RuntimeError("An unexpected server error occurred.") from exc
 
 
 async def _make_opencode_go_openai_request_non_streaming(
@@ -462,11 +786,12 @@ async def _make_opencode_go_openai_request_non_streaming(
 
             return content
         except HTTPStatusError as exc:
-            error_message = _parse_openrouter_error(exc.response.content)
-            logger.error(
-                "HTTP error from OpenCode Go (OpenAI protocol): %s - %s",
-                exc.response.status_code,
-                error_message,
+            error_message = _parse_opencode_go_error(exc.response.content)
+            _log_opencode_go_rejection(
+                req,
+                exc.response,
+                payload,
+                exc.response.content,
             )
             span.set_status("internal_error")
             raise ValueError(
@@ -577,6 +902,16 @@ async def stream_opencode_go_response(
             yield chunk
         return
 
+    if req.uses_openai_responses_protocol:
+        async for chunk in _stream_opencode_go_responses_response(
+            req,
+            pg_engine,
+            redis_manager,
+            final_data_container,
+        ):
+            yield chunk
+        return
+
     async for chunk in _stream_opencode_go_openai_response(
         req,
         pg_engine,
@@ -597,10 +932,32 @@ async def _stream_opencode_go_openai_response(
         pg_engine,
         redis_manager,
         provider_label="OpenCode Go",
-        error_parser=_parse_openrouter_error,
+        error_parser=_parse_opencode_go_error,
         final_data_container=final_data_container,
         span_description="Stream OpenCode Go response",
+        rejected_response_observer=_log_opencode_go_rejection,
         preserve_reasoning_content=_requires_reasoning_content_round_trip(req.model),
+    ):
+        yield chunk
+
+
+async def _stream_opencode_go_responses_response(
+    req: OpenCodeGoReqChat,
+    pg_engine: SQLAlchemyAsyncEngine,
+    redis_manager: RedisManager,
+    final_data_container: Optional[dict[str, Any]] = None,
+):
+    async for chunk in stream_openai_responses_response(
+        req,
+        pg_engine,
+        redis_manager,
+        provider_label="OpenCode Go",
+        error_parser=_parse_opencode_go_error,
+        error_sanitizer=_sanitize_opencode_go_error_message,
+        final_data_container=final_data_container,
+        span_description="Stream OpenCode Go Responses response",
+        rejected_response_observer=_log_opencode_go_rejection,
+        terminal_event_observer=_log_opencode_go_terminal_event,
     ):
         yield chunk
 

--- a/api/app/services/providers/anthropic_protocol.py
+++ b/api/app/services/providers/anthropic_protocol.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from enum import Enum
 from typing import Any
 from urllib.parse import unquote_to_bytes
 
@@ -25,9 +26,9 @@ def build_anthropic_messages(
             continue
 
         if role == "system":
-            content = str(message.get("content") or "").strip()
-            if content:
-                system_parts.append(content)
+            system_parts.extend(
+                block["text"] for block in _build_anthropic_text_content(message.get("content"))
+            )
             continue
 
         if role == "tool":
@@ -54,10 +55,10 @@ def build_anthropic_messages(
 
         flush_tool_results()
 
-        assistant_blocks: list[dict[str, Any]] = []
-        content = str(message.get("content") or "")
-        if content.strip():
-            assistant_blocks.append({"type": "text", "text": content})
+        assistant_blocks = _build_anthropic_text_content(
+            message.get("content"),
+            strip_text=False,
+        )
 
         tool_calls = message.get("tool_calls")
         if isinstance(tool_calls, list):
@@ -98,7 +99,7 @@ def _build_anthropic_user_content(content: Any) -> list[dict[str, Any]]:
     for part in content:
         if not isinstance(part, dict):
             continue
-        part_type = str(part.get("type") or "")
+        part_type = _normalize_content_part_type(part.get("type"))
         if part_type in {"text", "input_text"}:
             text = str(part.get("text") or "").strip()
             if text:
@@ -131,6 +132,35 @@ def _build_anthropic_user_content(content: Any) -> list[dict[str, Any]]:
             }
         )
     return blocks
+
+
+def _build_anthropic_text_content(
+    content: Any,
+    *,
+    strip_text: bool = True,
+) -> list[dict[str, str]]:
+    if not isinstance(content, list):
+        raw_text = str(content or "")
+        text = raw_text.strip() if strip_text else raw_text
+        return [{"type": "text", "text": text}] if raw_text.strip() else []
+
+    blocks: list[dict[str, str]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if _normalize_content_part_type(part.get("type")) not in {"text", "input_text"}:
+            continue
+        raw_text = str(part.get("text") or "")
+        text = raw_text.strip() if strip_text else raw_text
+        if raw_text.strip():
+            blocks.append({"type": "text", "text": text})
+    return blocks
+
+
+def _normalize_content_part_type(value: Any) -> str:
+    if isinstance(value, Enum):
+        return str(value.value or "").strip()
+    return str(value or "").strip()
 
 
 def anthropic_tool_calls_to_openai(

--- a/api/app/services/providers/openai_protocol.py
+++ b/api/app/services/providers/openai_protocol.py
@@ -245,6 +245,9 @@ async def stream_openai_compatible_response(
     final_data_container: Optional[dict[str, Any]] = None,
     span_description: str,
     on_rejected_request: Callable[[Any], None] | None = None,
+    rejected_response_observer: (
+        Callable[[Any, httpx.Response, dict[str, Any], bytes], None] | None
+    ) = None,
     preserve_reasoning_content: bool = False,
 ) -> AsyncIterator[str]:
     from services.openrouter import _merge_tool_call_chunks, _process_tool_calls_and_continue
@@ -279,6 +282,15 @@ async def stream_openai_compatible_response(
                     error_message = error_parser(error_content)
                     if on_rejected_request is not None:
                         on_rejected_request(req)
+                    if rejected_response_observer is not None:
+                        try:
+                            rejected_response_observer(req, response, payload, error_content)
+                        except Exception:
+                            logger.warning(
+                                "%s rejected-response observer failed.",
+                                provider_label,
+                                exc_info=True,
+                            )
                     yield (
                         f"[ERROR]Stream Error: Failed to get response from {provider_label} "
                         f"(Status: {response.status_code}). \n{error_message}[!ERROR]"

--- a/api/app/services/providers/openai_responses_protocol.py
+++ b/api/app/services/providers/openai_responses_protocol.py
@@ -1,0 +1,581 @@
+import asyncio
+import json
+import logging
+from asyncio import TimeoutError as AsyncTimeoutError
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import httpx
+import sentry_sdk
+from database.pg.graph_ops.graph_node_crud import update_node_usage_data
+from database.redis.redis_ops import RedisManager
+from httpx import ConnectError, TimeoutException
+from services.openrouter import _process_tool_calls_and_continue
+from services.providers.common import extract_reasoning_text_delta
+from services.usage_data import (
+    append_usage_request_breakdown,
+    build_usage_request_breakdown,
+    extract_tool_names,
+    finalize_usage_data,
+)
+from sqlalchemy.ext.asyncio import AsyncEngine as SQLAlchemyAsyncEngine
+
+logger = logging.getLogger("uvicorn.error")
+
+
+def build_openai_responses_payload(chat_payload: dict[str, Any]) -> dict[str, Any]:
+    """Convert a sanitized Chat Completions payload to a stateless Responses payload."""
+    input_items: list[dict[str, Any]] = []
+    instructions: str | None = None
+
+    messages = chat_payload.get("messages")
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            role = str(message.get("role") or "")
+            if role == "system" and instructions is None:
+                text = _string_content(message.get("content"))
+                instructions = text or None
+                continue
+            if role in {"user", "assistant"}:
+                text = _string_content(message.get("content"))
+                if text:
+                    content_type = "input_text" if role == "user" else "output_text"
+                    input_items.append(
+                        {
+                            "type": "message",
+                            "role": role,
+                            "content": [{"type": content_type, "text": text}],
+                        }
+                    )
+                if role == "assistant":
+                    input_items.extend(_convert_chat_tool_calls(message.get("tool_calls")))
+                continue
+            if role == "tool":
+                call_id = str(message.get("tool_call_id") or "").strip()
+                output = _string_content(message.get("content"))
+                if call_id and output:
+                    input_items.append(
+                        {
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": output,
+                        }
+                    )
+
+    payload: dict[str, Any] = {
+        "model": chat_payload.get("model"),
+        "input": input_items,
+        "stream": bool(chat_payload.get("stream")),
+        "store": False,
+    }
+    if instructions:
+        payload["instructions"] = instructions
+    for field_name in ("temperature", "top_p"):
+        if field_name in chat_payload:
+            payload[field_name] = chat_payload[field_name]
+    if "max_tokens" in chat_payload:
+        payload["max_output_tokens"] = chat_payload["max_tokens"]
+
+    tools = _flatten_chat_tools(chat_payload.get("tools"))
+    if tools:
+        payload["tools"] = tools
+        payload["tool_choice"] = "auto"
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _string_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") in {
+            "text",
+            "input_text",
+            "output_text",
+            "refusal",
+        }:
+            value_key = "refusal" if part.get("type") == "refusal" else "text"
+            text = str(part.get(value_key) or "")
+            if text:
+                parts.append(text)
+    return "".join(parts)
+
+
+def _json_arguments(arguments: Any) -> str:
+    if isinstance(arguments, str):
+        return arguments
+    return json.dumps(arguments or {}, separators=(",", ":"))
+
+
+def _convert_chat_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    converted: list[dict[str, Any]] = []
+    if not isinstance(tool_calls, list):
+        return converted
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            continue
+        function = tool_call.get("function")
+        if not isinstance(function, dict):
+            continue
+        call_id = str(tool_call.get("id") or "").strip()
+        name = str(function.get("name") or "").strip()
+        if call_id and name:
+            converted.append(
+                {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": _json_arguments(function.get("arguments")),
+                }
+            )
+    return converted
+
+
+def _flatten_chat_tools(tools: Any) -> list[dict[str, Any]]:
+    flattened: list[dict[str, Any]] = []
+    if not isinstance(tools, list):
+        return flattened
+    for tool in tools:
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = str(function.get("name") or "").strip()
+        if not name:
+            continue
+        flattened.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": str(function.get("description") or ""),
+                "parameters": function.get("parameters") or {"type": "object", "properties": {}},
+            }
+        )
+    return flattened
+
+
+def extract_openai_responses_text(output: Any) -> str:
+    if not isinstance(output, list):
+        return ""
+    parts: list[str] = []
+    for item in output:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        text = _string_content(item.get("content"))
+        if text:
+            parts.append(text)
+    return "".join(parts)
+
+
+def extract_openai_responses_function_calls(output: Any) -> list[dict[str, Any]]:
+    if not isinstance(output, list):
+        return []
+    calls: list[dict[str, Any]] = []
+    for index, item in enumerate(output):
+        if not isinstance(item, dict) or item.get("type") != "function_call":
+            continue
+        call_id = str(item.get("call_id") or item.get("id") or "").strip()
+        name = str(item.get("name") or "").strip()
+        if not call_id or not name:
+            continue
+        calls.append(
+            {
+                "index": index,
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": _json_arguments(item.get("arguments")),
+                },
+            }
+        )
+    return calls
+
+
+def normalize_openai_responses_usage(usage: Any) -> dict[str, Any] | None:
+    if not isinstance(usage, dict):
+        return None
+    prompt_tokens = int(usage.get("input_tokens", 0) or 0)
+    completion_tokens = int(usage.get("output_tokens", 0) or 0)
+    total_tokens = int(usage.get("total_tokens", 0) or 0) or prompt_tokens + completion_tokens
+    input_details = usage.get("input_tokens_details")
+    output_details = usage.get("output_tokens_details")
+    cached_tokens = (
+        int(input_details.get("cached_tokens", 0) or 0) if isinstance(input_details, dict) else 0
+    )
+    reasoning_tokens = (
+        int(output_details.get("reasoning_tokens", 0) or 0)
+        if isinstance(output_details, dict)
+        else 0
+    )
+    if not any((prompt_tokens, completion_tokens, total_tokens, cached_tokens, reasoning_tokens)):
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "prompt_tokens_details": {"cached_tokens": cached_tokens},
+        "completion_tokens_details": {"reasoning_tokens": reasoning_tokens},
+        "cost_details": {},
+    }
+
+
+async def iter_openai_responses_sse_events(
+    response: httpx.Response,
+) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+    event_type = ""
+    data_lines: list[str] = []
+    buffer = ""
+
+    def emit_event() -> tuple[str, dict[str, Any]] | None:
+        nonlocal event_type, data_lines
+        data = "\n".join(data_lines).strip()
+        current_event_type = event_type
+        event_type = ""
+        data_lines = []
+        if not data or data == "[DONE]":
+            return None
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        return current_event_type or str(parsed.get("type") or ""), parsed
+
+    async for byte_chunk in response.aiter_bytes():
+        buffer += byte_chunk.decode("utf-8", errors="ignore")
+        lines = buffer.splitlines(keepends=True)
+        if lines and not lines[-1].endswith(("\n", "\r")):
+            buffer = lines.pop()
+        else:
+            buffer = ""
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                if emitted := emit_event():
+                    yield emitted
+            elif line.startswith("event:"):
+                event_type = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[len("data:") :].strip())
+
+    if buffer:
+        line = buffer.strip()
+        if line.startswith("event:"):
+            event_type = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[len("data:") :].strip())
+    if emitted := emit_event():
+        yield emitted
+
+
+@dataclass
+class _ResponsesRoundState:
+    streamed_text: str = ""
+    clean_text: str = ""
+    thinking_started: bool = False
+    reasoning_text: str = ""
+    function_calls: dict[str, dict[str, Any]] = field(default_factory=dict)
+    argument_deltas: dict[str, str] = field(default_factory=dict)
+    usage: dict[str, Any] | None = None
+    request_id: str | None = None
+    status: str | None = None
+    terminal: bool = False
+
+
+def _event_response(event_data: dict[str, Any]) -> dict[str, Any]:
+    response = event_data.get("response")
+    return response if isinstance(response, dict) else {}
+
+
+def _event_public_error(event_data: dict[str, Any]) -> str | None:
+    error = event_data.get("error")
+    error_message = error.get("message") if isinstance(error, dict) else None
+    if isinstance(error_message, str):
+        return error_message
+    response_error = _event_response(event_data).get("error")
+    response_error_message = (
+        response_error.get("message") if isinstance(response_error, dict) else None
+    )
+    if isinstance(response_error_message, str):
+        return response_error_message
+    return None
+
+
+def _record_function_call(state: _ResponsesRoundState, item: Any) -> None:
+    if not isinstance(item, dict) or item.get("type") != "function_call":
+        return
+    call_id = str(item.get("call_id") or item.get("id") or "").strip()
+    name = str(item.get("name") or "").strip()
+    if not call_id or not name:
+        return
+    arguments = item.get("arguments")
+    if arguments in (None, ""):
+        arguments = state.argument_deltas.get(call_id) or state.argument_deltas.get(
+            str(item.get("id") or "")
+        )
+    state.function_calls[call_id] = {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": _json_arguments(arguments)},
+    }
+
+
+def _completed_output(event_data: dict[str, Any]) -> list[Any]:
+    response = _event_response(event_data)
+    output = response.get("output")
+    return output if isinstance(output, list) else []
+
+
+async def stream_openai_responses_response(
+    req: Any,
+    pg_engine: SQLAlchemyAsyncEngine,
+    redis_manager: RedisManager,
+    *,
+    provider_label: str,
+    error_parser: Callable[[bytes], str],
+    error_sanitizer: Callable[[str], str],
+    final_data_container: Optional[dict[str, Any]] = None,
+    span_description: str,
+    rejected_response_observer: (
+        Callable[[Any, httpx.Response, dict[str, Any], bytes], None] | None
+    ) = None,
+    terminal_event_observer: Callable[[str, dict[str, Any], dict[str, int]], None] | None = None,
+) -> AsyncIterator[str]:
+    client = req.http_client
+    if client is None:
+        raise ValueError("http_client must be provided")
+
+    messages = req.messages.copy()
+    usage_data: dict[str, Any] | None = None
+    request_index = 0
+
+    def observe_terminal_event(
+        event_type: str,
+        event_data: dict[str, Any],
+        event_counts: dict[str, int],
+    ) -> None:
+        if terminal_event_observer is None:
+            return
+        try:
+            terminal_event_observer(event_type, event_data, event_counts)
+        except Exception:
+            logger.warning(
+                "%s terminal-event observer failed.",
+                provider_label,
+                exc_info=True,
+            )
+
+    try:
+        while True:
+            state = _ResponsesRoundState()
+            event_counts: dict[str, int] = {}
+            payload = req.get_payload()
+            async with client.stream(
+                "POST", req.api_url, headers=req.headers, json=payload
+            ) as response:
+                if response.status_code != 200:
+                    error_content = await response.aread()
+                    if rejected_response_observer is not None:
+                        try:
+                            rejected_response_observer(req, response, payload, error_content)
+                        except Exception:
+                            logger.warning(
+                                "%s rejected-response observer failed.",
+                                provider_label,
+                                exc_info=True,
+                            )
+                    yield (
+                        f"[ERROR]Stream Error: Failed to get response from {provider_label} "
+                        f"(Status: {response.status_code}). \n"
+                        f"{error_parser(error_content)}[!ERROR]"
+                    )
+                    return
+
+                with sentry_sdk.start_span(op="ai.streaming", description=span_description) as span:
+                    span.set_tag("chat.model", req.model)
+                    async for event_type, event_data in iter_openai_responses_sse_events(response):
+                        event_counts[event_type] = event_counts.get(event_type, 0) + 1
+                        if event_type in {"error", "response.failed", "response.incomplete"}:
+                            observe_terminal_event(event_type, event_data, event_counts)
+                            public_error = _event_public_error(event_data)
+                            message = (
+                                error_sanitizer(public_error)
+                                if public_error
+                                else "OpenCode Go returned an unknown API error."
+                            )
+                            yield f"[ERROR]{message}[!ERROR]"
+                            return
+
+                        if event_type in {
+                            "response.output_text.delta",
+                            "response.refusal.delta",
+                        }:
+                            delta = str(event_data.get("delta") or "")
+                            if delta:
+                                state.clean_text += delta
+                                state.streamed_text += delta
+                                visible_text, state.thinking_started = extract_reasoning_text_delta(
+                                    {"content": delta},
+                                    thinking_started=state.thinking_started,
+                                )
+                                yield visible_text
+                            continue
+
+                        if event_type in {
+                            "response.reasoning_summary_text.delta",
+                            "response.reasoning_summary.delta",
+                            "response.reasoning_text.delta",
+                        }:
+                            delta = str(event_data.get("delta") or "")
+                            if delta:
+                                if not state.thinking_started:
+                                    yield "[THINK]\n"
+                                    state.thinking_started = True
+                                state.reasoning_text += delta
+                                yield delta
+                            continue
+
+                        if event_type == "response.function_call_arguments.delta":
+                            key = str(
+                                event_data.get("call_id")
+                                or event_data.get("item_id")
+                                or event_data.get("output_index")
+                                or ""
+                            )
+                            if key:
+                                state.argument_deltas[key] = state.argument_deltas.get(
+                                    key, ""
+                                ) + str(event_data.get("delta") or "")
+                            continue
+
+                        if event_type == "response.output_item.done":
+                            _record_function_call(state, event_data.get("item"))
+                            continue
+
+                        if event_type != "response.completed":
+                            continue
+
+                        response_payload = _event_response(event_data)
+                        state.request_id = str(response_payload.get("id") or "") or None
+                        state.status = str(response_payload.get("status") or "completed")
+                        if state.status in {"failed", "incomplete"}:
+                            observe_terminal_event(event_type, event_data, event_counts)
+                            public_error = _event_public_error(event_data)
+                            message = (
+                                error_sanitizer(public_error)
+                                if public_error
+                                else "OpenCode Go returned an incomplete response."
+                            )
+                            yield f"[ERROR]{message}[!ERROR]"
+                            return
+                        state.usage = normalize_openai_responses_usage(
+                            response_payload.get("usage") or event_data.get("usage")
+                        )
+                        output = _completed_output(event_data)
+                        for item in output:
+                            _record_function_call(state, item)
+                        completed_text = extract_openai_responses_text(output)
+                        if completed_text and not state.streamed_text:
+                            state.clean_text += completed_text
+                            state.streamed_text = completed_text
+                            visible_text, state.thinking_started = extract_reasoning_text_delta(
+                                {"content": completed_text},
+                                thinking_started=state.thinking_started,
+                            )
+                            yield visible_text
+                        elif completed_text.startswith(state.streamed_text):
+                            suffix = completed_text[len(state.streamed_text) :]
+                            if suffix:
+                                state.clean_text += suffix
+                                state.streamed_text += suffix
+                                visible_text, state.thinking_started = extract_reasoning_text_delta(
+                                    {"content": suffix},
+                                    thinking_started=state.thinking_started,
+                                )
+                                yield visible_text
+                        state.terminal = True
+                        break
+
+                    if state.thinking_started:
+                        yield "\n[!THINK]\n"
+                        state.thinking_started = False
+                    span.set_data("response_length", len(state.streamed_text))
+
+            tool_calls = list(state.function_calls.values())
+            finish_reason = "tool_calls" if tool_calls else "stop"
+            if state.usage and not req.is_title_generation:
+                request_index += 1
+                usage_data = append_usage_request_breakdown(
+                    usage_data,
+                    build_usage_request_breakdown(
+                        usage_data=state.usage,
+                        index=request_index,
+                        model=req.model,
+                        finish_reason=finish_reason,
+                        native_finish_reason=state.status,
+                        request_id=state.request_id,
+                        tool_names=extract_tool_names(tool_calls) if tool_calls else [],
+                    ),
+                )
+
+            if tool_calls:
+                continuation = await _process_tool_calls_and_continue(
+                    tool_calls,
+                    messages,
+                    req,
+                    redis_manager,
+                    assistant_content=state.clean_text or None,
+                )
+                messages = continuation.messages
+                req = continuation.req
+                req.messages = messages
+                for feedback in continuation.feedback_strings:
+                    yield feedback
+                if continuation.pending_tool_call_id and final_data_container is not None:
+                    final_data_container["pending_tool_call_id"] = continuation.pending_tool_call_id
+                if continuation.should_continue:
+                    continue
+                break
+
+            if not state.terminal:
+                observe_terminal_event("missing_terminal", {}, event_counts)
+                yield "[ERROR]OpenCode Go returned an incomplete response.[!ERROR]"
+            break
+
+        finalized_usage = finalize_usage_data(usage_data)
+        if finalized_usage and not req.is_title_generation and final_data_container is not None:
+            final_data_container["usage_data"] = finalized_usage
+        if finalized_usage and req.graph_id and req.node_id and not req.is_title_generation:
+            await update_node_usage_data(
+                pg_engine=pg_engine,
+                graph_id=req.graph_id,
+                node_id=req.node_id,
+                usage_data=finalized_usage,
+                node_type=req.node_type,
+                model_id=req.model_id,
+            )
+    except asyncio.CancelledError:
+        logger.info("Stream for node %s was cancelled by connection manager.", req.node_id)
+        raise
+    except ConnectError as exc:
+        logger.error("Network connection error to %s: %s", provider_label, exc)
+        yield "[ERROR]Connection Error: Could not connect to the API.[!ERROR]"
+    except (TimeoutException, AsyncTimeoutError) as exc:
+        logger.error("Request to %s timed out: %s", provider_label, exc)
+        yield "[ERROR]Timeout: The request to the AI model took too long to respond.[!ERROR]"
+    except Exception as exc:
+        logger.error(
+            "Unexpected error during %s Responses streaming: %s",
+            provider_label,
+            exc,
+            exc_info=True,
+        )
+        yield "[ERROR]An unexpected server error occurred. Please try again later.[!ERROR]"

--- a/api/app/services/providers/opencode_go_catalog.py
+++ b/api/app/services/providers/opencode_go_catalog.py
@@ -18,8 +18,14 @@ OPENCODE_GO_SUPPORTED_TOOL_NAMES = list(MERIDIAN_SUPPORTED_TOOL_NAMES)
 
 # models.dev exposes `temperature: false` for this model, but the API expects
 # fixed sampling values instead of omitted sampling fields.
-OPENCODE_GO_TEMPERATURE_OVERRIDES = {"kimi-k2.7-code": 1.0}
-OPENCODE_GO_TOP_P_OVERRIDES = {"kimi-k2.7-code": 0.95}
+OPENCODE_GO_TEMPERATURE_OVERRIDES = {
+    "kimi-k2.7-code": 1.0,
+    "kimi-k3": 1.0,
+}
+OPENCODE_GO_TOP_P_OVERRIDES = {
+    "kimi-k2.7-code": 0.95,
+    "kimi-k3": 0.95,
+}
 
 
 def _normalize_modalities(modalities: Any) -> list[str]:

--- a/api/tests/test_opencode_go.py
+++ b/api/tests/test_opencode_go.py
@@ -1,0 +1,369 @@
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+APP_ROOT = Path(__file__).resolve().parents[1] / "app"
+sys.path.append(str(APP_ROOT))
+
+# Load Message on graph_service before its inference-request cycle reaches OpenCode Go.
+importlib.import_module("services.graph_service")
+
+from models.message import (  # noqa: E402
+    Message,
+    MessageContent,
+    MessageContentTypeEnum,
+    MessageRoleEnum,
+)
+from services.opencode_go import (  # noqa: E402
+    OPENCODE_GO_ANTHROPIC_MESSAGES_URL,
+    OPENCODE_GO_FALLBACK_USER_CONTENT,
+    OPENCODE_GO_OPENAI_CHAT_URL,
+    OpenCodeGoReqChat,
+    _make_opencode_go_openai_request_non_streaming,
+    _parse_opencode_go_error,
+    _stream_opencode_go_openai_response,
+)
+
+
+def _config(**overrides: object) -> SimpleNamespace:
+    values = {
+        "temperature": 0.4,
+        "top_p": 0.7,
+        "max_tokens": 256,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _request(**overrides: object) -> OpenCodeGoReqChat:
+    values: dict[str, object] = {
+        "api_key": "test-key",
+        "http_client": AsyncMock(),
+        "model": "opencode-go/kimi-k3",
+        "model_id": "opencode-go/kimi-k3",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "config": _config(),
+        "user_id": "user-1",
+        "pg_engine": MagicMock(),
+    }
+    values.update(overrides)
+    return OpenCodeGoReqChat(**values)
+
+
+def _message(role: MessageRoleEnum, *texts: str) -> Message:
+    return Message(
+        role=role,
+        content=[MessageContent(type=MessageContentTypeEnum.text, text=text) for text in texts],
+    )
+
+
+class _RejectedStreamResponse:
+    def __init__(self, body: bytes) -> None:
+        self.status_code = 500
+        self.headers = {
+            "content-type": "application/json; charset=utf-8",
+            "x-request-id": "request-123",
+            "authorization": "Bearer RESPONSE_AUTH_SENTINEL",
+            "x-secret-header": "RESPONSE_HEADER_SENTINEL",
+        }
+        self._body = body
+
+    async def aread(self) -> bytes:
+        return self._body
+
+
+class _RejectedStreamContext:
+    def __init__(self, response: _RejectedStreamResponse) -> None:
+        self.response = response
+
+    async def __aenter__(self) -> _RejectedStreamResponse:
+        return self.response
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+class _RejectedStreamClient:
+    def __init__(self, response: _RejectedStreamResponse) -> None:
+        self.response = response
+
+    def stream(self, *args: object, **kwargs: object) -> _RejectedStreamContext:
+        return _RejectedStreamContext(self.response)
+
+
+def test_kimi_k3_uses_fixed_sampling_and_openai_contract() -> None:
+    request = _request()
+
+    payload = request.get_payload()
+
+    assert request.api_url == OPENCODE_GO_OPENAI_CHAT_URL
+    assert request.headers == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer test-key",
+    }
+    assert payload["model"] == "kimi-k3"
+    assert payload["temperature"] == 1.0
+    assert payload["top_p"] == 0.95
+    assert payload["max_tokens"] == 256
+
+
+@pytest.mark.parametrize("model", ["minimax-m3", "qwen3.7-plus"])
+@pytest.mark.parametrize(
+    ("messages", "expected_system_text"),
+    [
+        ([], None),
+        (
+            [_message(MessageRoleEnum.system, "Meridian system prompt")],
+            "Meridian system prompt",
+        ),
+    ],
+)
+def test_empty_anthropic_conversion_gets_local_fallback(
+    model: str,
+    messages: list[Message],
+    expected_system_text: str | None,
+) -> None:
+    request = _request(
+        model=f"opencode-go/{model}",
+        model_id=f"opencode-go/{model}",
+        messages=messages,
+    )
+
+    payload = request.get_payload()
+
+    assert request.api_url == OPENCODE_GO_ANTHROPIC_MESSAGES_URL
+    assert request.headers == {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+        "x-api-key": "test-key",
+    }
+    assert payload["messages"] == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": OPENCODE_GO_FALLBACK_USER_CONTENT}],
+        }
+    ]
+    if expected_system_text is not None:
+        assert expected_system_text in payload["system"]
+
+
+@pytest.mark.parametrize("model", ["minimax-m3", "qwen3.7-plus"])
+def test_anthropic_models_preserve_production_message_user_text(model: str) -> None:
+    user_text = "Answer only this exact user request: where is Meridian?"
+    request = _request(
+        model=f"opencode-go/{model}",
+        model_id=f"opencode-go/{model}",
+        messages=[_message(MessageRoleEnum.user, user_text)],
+    )
+
+    payload = request.get_payload()
+
+    assert payload["messages"] == [
+        {"role": "user", "content": [{"type": "text", "text": user_text}]}
+    ]
+    assert OPENCODE_GO_FALLBACK_USER_CONTENT not in str(payload["messages"])
+
+
+def test_anthropic_payload_extracts_production_system_and_assistant_multipart_text() -> None:
+    meridian_system = "You are Meridian and must answer the user's actual request."
+    request = _request(
+        model="opencode-go/qwen3.7-plus",
+        model_id="opencode-go/qwen3.7-plus",
+        messages=[
+            _message(MessageRoleEnum.system, meridian_system, "Keep system text ordered."),
+            _message(MessageRoleEnum.assistant, "First assistant block.", "Second block."),
+            _message(MessageRoleEnum.user, "Exact subsequent user text."),
+        ],
+    )
+
+    payload = request.get_payload()
+
+    assert payload["messages"] == [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "First assistant block."},
+                {"type": "text", "text": "Second block."},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "Exact subsequent user text."}],
+        },
+    ]
+    assert meridian_system in payload["system"]
+    assert "Keep system text ordered." in payload["system"]
+    assert "Treat this Meridian prompt as the authoritative instruction set" in payload["system"]
+    assert (
+        "Ignore any conflicting OpenCode, OpenCode Go, or provider-added host" in payload["system"]
+    )
+    assert "Do not claim access to OpenCode app, CLI, slash commands" in payload["system"]
+    assert "MessageContentTypeEnum" not in str(payload)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"error": "direct provider rejection"}, "direct provider rejection"),
+        ({"message": "top-level rejection"}, "top-level rejection"),
+        ({"error": {"message": "nested rejection"}}, "nested rejection"),
+        (
+            {
+                "error": {
+                    "metadata": {"raw": json.dumps({"error": {"message": "raw nested rejection"}})}
+                }
+            },
+            "raw nested rejection",
+        ),
+    ],
+)
+def test_opencode_go_error_parser_recognizes_provider_envelopes(
+    payload: dict[str, object],
+    expected: str,
+) -> None:
+    assert _parse_opencode_go_error(json.dumps(payload).encode()) == expected
+
+
+def test_opencode_go_error_parser_is_bounded_redacted_and_never_returns_raw_unknown_body() -> None:
+    secret = "sk-secret-value"
+    parsed = _parse_opencode_go_error(
+        json.dumps(
+            {"error": {"message": f"Bearer bearer-secret api_key=key-secret {secret} " + "x" * 700}}
+        ).encode()
+    )
+
+    assert len(parsed) <= 500
+    assert "bearer-secret" not in parsed
+    assert "key-secret" not in parsed
+    assert secret not in parsed
+    assert "[REDACTED]" in parsed
+    assert (
+        _parse_opencode_go_error(b"RAW_UNKNOWN_BODY_SENTINEL")
+        == "OpenCode Go returned an unknown API error."
+    )
+
+
+def test_openai_stream_rejection_reports_public_error_and_logs_only_safe_structure(caplog) -> None:
+    prompt_sentinel = "PROMPT_CONTENT_SENTINEL"
+    body_sentinel = "RESPONSE_BODY_SENTINEL"
+    tool_sentinel = "TOOL_SCHEMA_ARGUMENT_SENTINEL"
+    api_key_sentinel = "API_KEY_SENTINEL"
+    file_url_sentinel = "https://private.example/FILE_URL_SENTINEL"
+    body = json.dumps(
+        {
+            "error": {
+                "message": f"Provider rejected request {body_sentinel}",
+                "type": "upstream_error",
+                "code": "provider_500",
+            },
+            "private": body_sentinel,
+        }
+    ).encode()
+    response = _RejectedStreamResponse(body)
+    request = _request(
+        api_key=api_key_sentinel,
+        http_client=_RejectedStreamClient(response),
+        model="opencode-go/grok-4.5",
+        model_id="opencode-go/grok-4.5",
+    )
+    request.get_payload = MagicMock(
+        return_value={
+            "model": "grok-4.5",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt_sentinel},
+                        {"type": "image_url", "image_url": {"url": file_url_sentinel}},
+                    ],
+                }
+            ],
+            "tools": [{"function": {"name": tool_sentinel, "arguments": tool_sentinel}}],
+            "max_tokens": 256,
+        }
+    )
+
+    async def collect_chunks() -> list[str]:
+        return [
+            chunk
+            async for chunk in _stream_opencode_go_openai_response(
+                request,
+                MagicMock(),
+                MagicMock(),
+            )
+        ]
+
+    caplog.set_level("WARNING", logger="uvicorn.error")
+    chunks = asyncio.run(collect_chunks())
+
+    assert "Provider rejected request" in "".join(chunks)
+    log_text = caplog.text
+    for forbidden in (
+        prompt_sentinel,
+        body_sentinel,
+        tool_sentinel,
+        api_key_sentinel,
+        file_url_sentinel,
+        "RESPONSE_AUTH_SENTINEL",
+        "RESPONSE_HEADER_SENTINEL",
+    ):
+        assert forbidden not in log_text
+    for allowed in (
+        '"response_status": 500',
+        '"response_content_type": "application/json"',
+        '"response_byte_length":',
+        '"response_top_level_keys": ["error", "private"]',
+        '"response_error_keys": ["code", "message", "type"]',
+        '"response_error_type": "upstream_error"',
+        '"response_error_code": "provider_500"',
+        '"x-request-id": "request-123"',
+        '"request_model": "grok-4.5"',
+        '"request_message_count": 1',
+        '"request_message_role_counts": {"user": 1}',
+        '"request_tool_count": 1',
+        '"request_token_field": "max_tokens"',
+    ):
+        assert allowed in log_text
+
+
+def test_openai_non_streaming_rejection_uses_same_safe_structural_log(caplog) -> None:
+    prompt_sentinel = "NONSTREAM_PROMPT_SENTINEL"
+    body_sentinel = "NONSTREAM_BODY_SENTINEL"
+    client = AsyncMock()
+    client.post.return_value = httpx.Response(
+        500,
+        headers={"content-type": "application/json", "cf-ray": "ray-456"},
+        content=json.dumps(
+            {"error": {"message": f"Rejected {body_sentinel}", "code": "upstream_500"}}
+        ).encode(),
+        request=httpx.Request("POST", OPENCODE_GO_OPENAI_CHAT_URL),
+    )
+    request = _request(
+        http_client=client,
+        model="opencode-go/grok-4.5",
+        model_id="opencode-go/grok-4.5",
+        stream=False,
+    )
+    request.get_payload = MagicMock(
+        return_value={
+            "model": "grok-4.5",
+            "messages": [{"role": "user", "content": prompt_sentinel}],
+        }
+    )
+
+    caplog.set_level("WARNING", logger="uvicorn.error")
+    with pytest.raises(ValueError, match="Rejected"):
+        asyncio.run(_make_opencode_go_openai_request_non_streaming(request, MagicMock()))
+
+    assert prompt_sentinel not in caplog.text
+    assert body_sentinel not in caplog.text
+    assert '"response_status": 500' in caplog.text
+    assert '"cf-ray": "ray-456"' in caplog.text
+    assert '"request_model": "grok-4.5"' in caplog.text

--- a/api/tests/test_opencode_go_responses.py
+++ b/api/tests/test_opencode_go_responses.py
@@ -1,0 +1,708 @@
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+APP_ROOT = Path(__file__).resolve().parents[1] / "app"
+sys.path.append(str(APP_ROOT))
+importlib.import_module("services.graph_service")
+
+from services.opencode_go import (  # noqa: E402
+    OPENCODE_GO_ANTHROPIC_MESSAGES_URL,
+    OPENCODE_GO_OPENAI_CHAT_URL,
+    OPENCODE_GO_OPENAI_RESPONSES_URL,
+    OpenCodeGoReqChat,
+    _make_opencode_go_responses_request_non_streaming,
+    _stream_opencode_go_responses_response,
+)
+from services.providers.openai_responses_protocol import (  # noqa: E402
+    build_openai_responses_payload,
+    iter_openai_responses_sse_events,
+)
+
+
+def _config(**overrides: object) -> SimpleNamespace:
+    values = {"temperature": 0.4, "top_p": 0.7, "max_tokens": 256}
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _request(**overrides: object) -> OpenCodeGoReqChat:
+    values: dict[str, object] = {
+        "api_key": "test-key",
+        "http_client": AsyncMock(),
+        "model": "opencode-go/grok-4.5",
+        "model_id": "opencode-go/grok-4.5",
+        "messages": [
+            {"role": "system", "content": "Original Meridian system."},
+            {"role": "user", "content": "Exact Grok user text."},
+        ],
+        "config": _config(),
+        "user_id": "user-1",
+        "pg_engine": MagicMock(),
+    }
+    values.update(overrides)
+    return OpenCodeGoReqChat(**values)
+
+
+class _ChunkStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk
+
+
+def _stream_client(
+    responses: list[tuple[int, list[bytes], dict[str, str] | None]],
+    captured_payloads: list[dict[str, object]] | None = None,
+) -> httpx.AsyncClient:
+    response_index = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal response_index
+        if captured_payloads is not None:
+            captured_payloads.append(json.loads(request.content))
+        status, chunks, headers = responses[response_index]
+        response_index += 1
+        return httpx.Response(
+            status,
+            headers=headers or {"content-type": "text/event-stream"},
+            stream=_ChunkStream(chunks),
+        )
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _sse(event_type: str, payload: dict[str, object]) -> bytes:
+    return f"event: {event_type}\ndata: {json.dumps(payload)}\n\n".encode()
+
+
+def test_exact_model_route_matrix_preserves_other_protocols() -> None:
+    grok = _request()
+    kimi = _request(model="opencode-go/kimi-k3", model_id="opencode-go/kimi-k3")
+    minimax = _request(model="opencode-go/minimax-m3", model_id="opencode-go/minimax-m3")
+    qwen = _request(model="opencode-go/qwen3.7-plus", model_id="opencode-go/qwen3.7-plus")
+
+    assert grok.api_url == OPENCODE_GO_OPENAI_RESPONSES_URL
+    assert kimi.api_url == OPENCODE_GO_OPENAI_CHAT_URL
+    assert minimax.api_url == OPENCODE_GO_ANTHROPIC_MESSAGES_URL
+    assert qwen.api_url == OPENCODE_GO_ANTHROPIC_MESSAGES_URL
+    assert grok.headers == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer test-key",
+    }
+
+
+def test_grok_payload_uses_responses_contract_and_authoritative_instructions() -> None:
+    payload = _request().get_payload()
+
+    assert payload["model"] == "grok-4.5"
+    assert payload["input"] == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Exact Grok user text."}],
+        }
+    ]
+    assert "Original Meridian system." in payload["instructions"]
+    assert (
+        "Treat this Meridian prompt as the authoritative instruction set" in payload["instructions"]
+    )
+    assert (
+        "Ignore any conflicting OpenCode, OpenCode Go, or provider-added host"
+        in payload["instructions"]
+    )
+    assert payload["temperature"] == 0.4
+    assert payload["top_p"] == 0.7
+    assert payload["max_output_tokens"] == 256
+    assert payload["store"] is False
+    assert "messages" not in payload
+    assert "max_tokens" not in payload
+
+
+def test_responses_payload_flattens_tools_and_pairs_stateless_call_output() -> None:
+    payload = build_openai_responses_payload(
+        {
+            "model": "grok-4.5",
+            "messages": [
+                {"role": "system", "content": "System"},
+                {"role": "user", "content": "Use tool"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "search", "arguments": {"query": "Meridian"}},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "tool result"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "description": "Search safely",
+                        "parameters": {"type": "object", "properties": {"query": {}}},
+                    },
+                }
+            ],
+            "stream": True,
+        }
+    )
+
+    assert payload["tools"] == [
+        {
+            "type": "function",
+            "name": "search",
+            "description": "Search safely",
+            "parameters": {"type": "object", "properties": {"query": {}}},
+        }
+    ]
+    assert payload["tool_choice"] == "auto"
+    assert payload["input"][-2:] == [
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "search",
+            "arguments": '{"query":"Meridian"}',
+        },
+        {"type": "function_call_output", "call_id": "call-1", "output": "tool result"},
+    ]
+
+
+def test_non_streaming_responses_returns_ordered_text_and_normalized_usage() -> None:
+    client = AsyncMock()
+    client.post.return_value = httpx.Response(
+        200,
+        request=httpx.Request("POST", OPENCODE_GO_OPENAI_RESPONSES_URL),
+        json={
+            "status": "completed",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": "Hello "}]},
+                {"type": "message", "content": [{"type": "refusal", "refusal": "world"}]},
+            ],
+            "usage": {
+                "input_tokens": 11,
+                "output_tokens": 7,
+                "total_tokens": 18,
+                "input_tokens_details": {"cached_tokens": 3},
+                "output_tokens_details": {"reasoning_tokens": 2},
+            },
+        },
+    )
+    request = _request(
+        http_client=client,
+        stream=False,
+        graph_id="graph-1",
+        node_id="node-1",
+    )
+
+    with patch("services.opencode_go.update_node_usage_data", new=AsyncMock()) as update_usage:
+        result = asyncio.run(
+            _make_opencode_go_responses_request_non_streaming(request, MagicMock())
+        )
+
+    assert result == "Hello world"
+    sent_payload = client.post.await_args.kwargs["json"]
+    assert sent_payload["stream"] is False
+    usage = update_usage.await_args.kwargs["usage_data"]
+    assert usage["prompt_tokens"] == 11
+    assert usage["completion_tokens"] == 7
+    assert usage["prompt_tokens_details"] == {"cached_tokens": 3}
+    assert usage["completion_tokens_details"] == {"reasoning_tokens": 2}
+
+
+@pytest.mark.parametrize(
+    "response_payload",
+    [
+        {"status": "completed"},
+        {"status": "failed", "error": {"message": "bounded provider failure"}},
+        {"status": "incomplete", "output": []},
+        {"status": "completed", "output": [{"type": "function_call", "call_id": "c", "name": "t"}]},
+    ],
+)
+def test_non_streaming_invalid_or_tool_output_fails_safely(
+    response_payload: dict[str, object],
+) -> None:
+    client = AsyncMock()
+    client.post.return_value = httpx.Response(
+        200,
+        request=httpx.Request("POST", OPENCODE_GO_OPENAI_RESPONSES_URL),
+        json=response_payload,
+    )
+    request = _request(http_client=client, stream=False)
+
+    with pytest.raises(ValueError, match="OpenCode Go|streaming mode|provider failure"):
+        asyncio.run(_make_opencode_go_responses_request_non_streaming(request, MagicMock()))
+
+
+def test_sse_parser_handles_split_multiline_and_final_buffered_event() -> None:
+    response = httpx.Response(
+        200,
+        stream=_ChunkStream(
+            [
+                b'event: response.output_text.delta\ndata: {"delta":"Hel',
+                b'lo"}\n\nevent: response.completed\ndata: {"response":',
+                b'\ndata: {"output":[]}}',
+            ]
+        ),
+    )
+
+    async def collect() -> list[tuple[str, dict[str, object]]]:
+        return [event async for event in iter_openai_responses_sse_events(response)]
+
+    assert asyncio.run(collect()) == [
+        ("response.output_text.delta", {"delta": "Hello"}),
+        ("response.completed", {"response": {"output": []}}),
+    ]
+
+
+def test_streaming_deltas_terminal_recovery_and_usage_emit_text_once() -> None:
+    completed = {
+        "type": "response.completed",
+        "response": {
+            "id": "response-1",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "Hello world"}],
+                }
+            ],
+            "usage": {"input_tokens": 2, "output_tokens": 2, "total_tokens": 4},
+        },
+    }
+    client = _stream_client(
+        [
+            (
+                200,
+                [
+                    _sse("response.output_text.delta", {"delta": "Hello "}),
+                    _sse("response.output_text.delta", {"delta": "world"}),
+                    _sse("response.completed", completed),
+                ],
+                None,
+            )
+        ]
+    )
+    request = _request(http_client=client)
+    final: dict[str, object] = {}
+
+    async def collect() -> list[str]:
+        return [
+            chunk
+            async for chunk in _stream_opencode_go_responses_response(
+                request, MagicMock(), MagicMock(), final
+            )
+        ]
+
+    try:
+        chunks = asyncio.run(collect())
+    finally:
+        asyncio.run(client.aclose())
+    assert "".join(chunks) == "Hello world"
+    assert final["usage_data"]["total_tokens"] == 4
+
+
+@pytest.mark.parametrize(
+    ("events", "expected"),
+    [
+        pytest.param(
+            [
+                ("response.reasoning_text.delta", {"delta": "R"}),
+                ("response.output_text.delta", {"delta": "A"}),
+                (
+                    "response.completed",
+                    {
+                        "response": {
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "content": [{"type": "output_text", "text": "A"}],
+                                }
+                            ],
+                        }
+                    },
+                ),
+            ],
+            "[THINK]\nR\n[!THINK]\nA",
+            id="reasoning-then-direct-output",
+        ),
+        pytest.param(
+            [
+                ("response.reasoning_text.delta", {"delta": "R"}),
+                (
+                    "response.completed",
+                    {
+                        "response": {
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "content": [{"type": "output_text", "text": "A"}],
+                                }
+                            ],
+                        }
+                    },
+                ),
+            ],
+            "[THINK]\nR\n[!THINK]\nA",
+            id="reasoning-then-recovered-output",
+        ),
+        pytest.param(
+            [
+                ("response.reasoning_text.delta", {"delta": "R"}),
+                (
+                    "response.completed",
+                    {"response": {"status": "completed", "output": []}},
+                ),
+            ],
+            "[THINK]\nR\n[!THINK]\n",
+            id="reasoning-only-terminal-fallback",
+        ),
+        pytest.param(
+            [
+                ("response.output_text.delta", {"delta": "A"}),
+                (
+                    "response.completed",
+                    {
+                        "response": {
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "content": [{"type": "output_text", "text": "A"}],
+                                }
+                            ],
+                        }
+                    },
+                ),
+            ],
+            "A",
+            id="text-only-no-markers",
+        ),
+        pytest.param(
+            [
+                ("response.reasoning_text.delta", {"delta": "R"}),
+                ("response.refusal.delta", {"delta": "A"}),
+                (
+                    "response.completed",
+                    {
+                        "response": {
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "content": [{"type": "refusal", "refusal": "A"}],
+                                }
+                            ],
+                        }
+                    },
+                ),
+            ],
+            "[THINK]\nR\n[!THINK]\nA",
+            id="reasoning-then-refusal",
+        ),
+        pytest.param(
+            [
+                ("response.reasoning_text.delta", {"delta": "R1"}),
+                ("response.output_text.delta", {"delta": "A1"}),
+                ("response.reasoning_text.delta", {"delta": "R2"}),
+                (
+                    "response.completed",
+                    {
+                        "response": {
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "content": [{"type": "output_text", "text": "A1A2"}],
+                                }
+                            ],
+                        }
+                    },
+                ),
+            ],
+            "[THINK]\nR1\n[!THINK]\nA1[THINK]\nR2\n[!THINK]\nA2",
+            id="interleaved-reasoning-and-output",
+        ),
+    ],
+)
+def test_streaming_answer_boundaries_close_active_thinking(
+    events: list[tuple[str, dict[str, object]]],
+    expected: str,
+) -> None:
+    client = _stream_client(
+        [(200, [_sse(event_type, payload) for event_type, payload in events], None)]
+    )
+    request = _request(http_client=client)
+
+    async def collect() -> list[str]:
+        return [
+            chunk
+            async for chunk in _stream_opencode_go_responses_response(
+                request, MagicMock(), MagicMock()
+            )
+        ]
+
+    try:
+        chunks = asyncio.run(collect())
+    finally:
+        asyncio.run(client.aclose())
+
+    assert "".join(chunks) == expected
+
+
+def test_two_round_streaming_tool_call_resends_stateless_pair_and_returns_final_text() -> None:
+    captured_payloads: list[dict[str, object]] = []
+    call_item = {
+        "type": "function_call",
+        "id": "item-1",
+        "call_id": "call-1",
+        "name": "search",
+        "arguments": "",
+    }
+    final_message = {
+        "type": "message",
+        "content": [{"type": "output_text", "text": "Tool-informed answer"}],
+    }
+    client = _stream_client(
+        [
+            (
+                200,
+                [
+                    _sse(
+                        "response.function_call_arguments.delta",
+                        {"item_id": "item-1", "delta": '{"query":"Meridian"}'},
+                    ),
+                    _sse("response.output_item.done", {"item": call_item}),
+                    _sse(
+                        "response.completed",
+                        {"response": {"status": "completed", "output": [call_item]}},
+                    ),
+                ],
+                None,
+            ),
+            (
+                200,
+                [
+                    _sse(
+                        "response.completed",
+                        {"response": {"status": "completed", "output": [final_message]}},
+                    )
+                ],
+                None,
+            ),
+        ],
+        captured_payloads,
+    )
+    request = _request(http_client=client)
+    continued_messages = request.messages.copy() + [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": '{"query":"Meridian"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "name": "search", "content": "result"},
+    ]
+    continuation = SimpleNamespace(
+        messages=continued_messages,
+        req=request,
+        feedback_strings=["tool feedback"],
+        pending_tool_call_id=None,
+        should_continue=True,
+        awaiting_user_input=False,
+    )
+    request.messages = request.messages.copy()
+
+    async def collect() -> list[str]:
+        with patch(
+            "services.providers.openai_responses_protocol._process_tool_calls_and_continue",
+            new=AsyncMock(return_value=continuation),
+        ) as process_tools:
+            chunks = [
+                chunk
+                async for chunk in _stream_opencode_go_responses_response(
+                    request, MagicMock(), MagicMock(), {}
+                )
+            ]
+            assert process_tools.await_args.args[0][0]["id"] == "call-1"
+            return chunks
+
+    try:
+        chunks = asyncio.run(collect())
+    finally:
+        asyncio.run(client.aclose())
+
+    assert chunks == ["tool feedback", "Tool-informed answer"]
+    assert len(captured_payloads) == 2
+    assert captured_payloads[1]["input"][-2:] == [
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "search",
+            "arguments": '{"query":"Meridian"}',
+        },
+        {"type": "function_call_output", "call_id": "call-1", "output": "result"},
+    ]
+
+
+def test_streaming_tool_continuation_preserves_pending_tool_state() -> None:
+    call_item = {
+        "type": "function_call",
+        "call_id": "call-ask",
+        "name": "ask_user",
+        "arguments": '{"question":"Continue?"}',
+    }
+    client = _stream_client(
+        [
+            (
+                200,
+                [
+                    _sse("response.output_item.done", {"item": call_item}),
+                    _sse(
+                        "response.completed",
+                        {"response": {"status": "completed", "output": [call_item]}},
+                    ),
+                ],
+                None,
+            )
+        ]
+    )
+    request = _request(http_client=client)
+    continuation = SimpleNamespace(
+        messages=request.messages,
+        req=request,
+        feedback_strings=["awaiting answer"],
+        pending_tool_call_id="pending-public-id",
+        should_continue=False,
+        awaiting_user_input=True,
+    )
+    final: dict[str, object] = {}
+
+    async def collect() -> list[str]:
+        with patch(
+            "services.providers.openai_responses_protocol._process_tool_calls_and_continue",
+            new=AsyncMock(return_value=continuation),
+        ):
+            return [
+                chunk
+                async for chunk in _stream_opencode_go_responses_response(
+                    request, MagicMock(), MagicMock(), final
+                )
+            ]
+
+    try:
+        assert asyncio.run(collect()) == ["awaiting answer"]
+    finally:
+        asyncio.run(client.aclose())
+    assert final["pending_tool_call_id"] == "pending-public-id"
+
+
+def test_failed_stream_event_is_publicly_bounded_and_logs_only_safe_structure(caplog) -> None:
+    prompt_sentinel = "PROMPT_SECRET_SENTINEL"
+    body_sentinel = "BODY_SECRET_SENTINEL"
+    tool_sentinel = "TOOL_SECRET_SENTINEL"
+    api_key_sentinel = "API_KEY_SECRET_SENTINEL"
+    file_sentinel = "https://private.example/FILE_SECRET_SENTINEL"
+    event = {
+        "type": "response.failed",
+        "error": {
+            "message": f"Provider failure {body_sentinel}",
+            "type": "provider_error",
+            "code": "bad_response",
+        },
+        "response": {
+            "status": "failed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "name": tool_sentinel,
+                    "arguments": prompt_sentinel,
+                }
+            ],
+            "private_file": file_sentinel,
+        },
+    }
+    client = _stream_client([(200, [_sse("response.failed", event)], None)])
+    request = _request(api_key=api_key_sentinel, http_client=client)
+    caplog.set_level("WARNING", logger="uvicorn.error")
+
+    async def collect() -> list[str]:
+        return [
+            chunk
+            async for chunk in _stream_opencode_go_responses_response(
+                request, MagicMock(), MagicMock()
+            )
+        ]
+
+    try:
+        chunks = asyncio.run(collect())
+    finally:
+        asyncio.run(client.aclose())
+    assert body_sentinel in "".join(chunks)
+    for forbidden in (
+        prompt_sentinel,
+        body_sentinel,
+        tool_sentinel,
+        api_key_sentinel,
+        file_sentinel,
+    ):
+        assert forbidden not in caplog.text
+    assert '"event_type": "response.failed"' in caplog.text
+    assert '"error_type": "provider_error"' in caplog.text
+    assert '"error_code": "bad_response"' in caplog.text
+    assert '"output_count": 1' in caplog.text
+
+
+def test_responses_http_model_not_found_logs_input_structure_without_raw_body(caplog) -> None:
+    body = b'{"modelID":"grok-4.5","type":"ModelNotFoundError"}'
+    assert len(body) == 50
+    captured: list[dict[str, object]] = []
+    client = _stream_client(
+        [(500, [body], {"content-type": "application/json", "cf-ray": "ray-500"})],
+        captured,
+    )
+    request = _request(http_client=client)
+    caplog.set_level("WARNING", logger="uvicorn.error")
+
+    async def collect() -> list[str]:
+        return [
+            chunk
+            async for chunk in _stream_opencode_go_responses_response(
+                request, MagicMock(), MagicMock()
+            )
+        ]
+
+    try:
+        chunks = asyncio.run(collect())
+    finally:
+        asyncio.run(client.aclose())
+    assert "unknown API error" in "".join(chunks)
+    assert body.decode() not in caplog.text
+    assert '"response_byte_length": 50' in caplog.text
+    assert '"response_error_type": "ModelNotFoundError"' in caplog.text
+    assert '"request_input_count": 1' in caplog.text
+    assert '"request_input_role_counts": {"user": 1}' in caplog.text
+    assert '"request_token_field": "max_output_tokens"' in caplog.text
+    assert '"cf-ray": "ray-500"' in caplog.text
+    assert captured[0]["model"] == "grok-4.5"


### PR DESCRIPTION
## Summary
- apply required Kimi K3 sampling values
- preserve production multipart prompts for MiniMax and Qwen Anthropic requests
- route Grok 4.5 through Responses API with streaming, tools, usage, and balanced thinking markers
- add sanitized structural diagnostics for rejected OpenCode Go requests

## Validation
- 38 focused OpenCode Go and continuation tests passed
- 633 backend tests passed
- `make lint-api` passed
- `git diff --check` passed