### PR TITLE
Release Meridian 1.7.5-beta

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,20 +2,19 @@ name: Lint, Build and Push Docker Images
 
 on:
   push:
-    branches: [main]
-    tags: ["v*"]
+    tags: ["*.*.*-beta"]
   pull_request:
     branches: [main]
-  create:
-    tags: ["v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 env:
   REGISTRY: ghcr.io
-  FRONTEND_IMAGE_NAME: ${{ github.repository }}/frontend
-  BACKEND_IMAGE_NAME: ${{ github.repository }}/backend
-  BROWSER_SERVICE_IMAGE_NAME: ${{ github.repository }}/browser-service
-  SANDBOX_MANAGER_IMAGE_NAME: ${{ github.repository }}/sandbox-manager
-  SANDBOX_PYTHON_IMAGE_NAME: ${{ github.repository }}/sandbox-python
 
 jobs:
   lint:
@@ -24,6 +23,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Validate release tag
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-beta$ ]]; then
+            echo "Tag must be a strict non-v X.Y.Z-beta version." >&2
+            exit 1
+          fi
+
+      - name: Run release automation tests
+        run: python -m unittest discover -s scripts/tests -p 'test_release_automation.py'
+
+      - name: Validate GitHub Actions workflows
+        run: docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.12
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -46,12 +61,10 @@ jobs:
           pip install -r sandbox_manager/requirements.txt -r sandbox_manager/requirements-dev.txt
 
       - name: Run backend linters
-        run: |
-          ./api/run-linter.sh
+        run: ./api/run-linter.sh
 
       - name: Run sandbox manager checks
-        run: |
-          ./sandbox_manager/run-checks.sh
+        run: ./sandbox_manager/run-checks.sh
 
       - name: Run browser service checks
         run: |
@@ -75,8 +88,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm dependencies
         uses: actions/cache@v4
@@ -93,13 +105,41 @@ jobs:
         run: cd ui && pnpm lint
 
   build-and-push:
-    name: Build and Push Docker Images
+    name: Build ${{ matrix.name }} image
     needs: lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: frontend
+            image: frontend
+            dockerfile: ./docker/ui.Dockerfile
+            cache-scope: frontend
+            frontend: true
+          - name: backend
+            image: backend
+            dockerfile: ./docker/api.Dockerfile
+            cache-scope: backend
+            frontend: false
+          - name: browser-service
+            image: browser-service
+            dockerfile: ./docker/browser-service.Dockerfile
+            cache-scope: browser-service
+            frontend: false
+          - name: sandbox-manager
+            image: sandbox-manager
+            dockerfile: ./docker/sandbox-manager.Dockerfile
+            cache-scope: sandbox-manager
+            frontend: false
+          - name: sandbox-python
+            image: sandbox-python
+            dockerfile: ./docker/sandbox-python.Dockerfile
+            cache-scope: sandbox-python
+            frontend: false
 
     steps:
       - name: Checkout repository
@@ -109,120 +149,32 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for frontend
-        id: meta-frontend
+      - name: Extract image metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Extract metadata for backend
-        id: meta-backend
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Extract metadata for browser service
-        id: meta-browser-service
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.BROWSER_SERVICE_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Extract metadata for sandbox manager
-        id: meta-sandbox-manager
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.SANDBOX_MANAGER_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Extract metadata for sandbox python
-        id: meta-sandbox-python
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.SANDBOX_PYTHON_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push frontend image
+      - name: Build and push image
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./docker/ui.Dockerfile
+          file: ${{ matrix.dockerfile }}
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta-frontend.outputs.tags }}
-          labels: ${{ steps.meta-frontend.outputs.labels }}
-          build-args: |
-            NUXT_PUBLIC_VERSION=${{ steps.meta-frontend.outputs.version }}
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,scope=frontend,mode=max
-
-      - name: Build and push backend image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/api.Dockerfile
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta-backend.outputs.tags }}
-          labels: ${{ steps.meta-backend.outputs.labels }}
-          cache-from: type=gha,scope=backend
-          cache-to: type=gha,scope=backend,mode=max
-
-      - name: Build and push browser service image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/browser-service.Dockerfile
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta-browser-service.outputs.tags }}
-          labels: ${{ steps.meta-browser-service.outputs.labels }}
-          cache-from: type=gha,scope=browser-service
-          cache-to: type=gha,scope=browser-service,mode=max
-
-      - name: Build and push sandbox manager image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/sandbox-manager.Dockerfile
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta-sandbox-manager.outputs.tags }}
-          labels: ${{ steps.meta-sandbox-manager.outputs.labels }}
-          cache-from: type=gha,scope=sandbox-manager
-          cache-to: type=gha,scope=sandbox-manager,mode=max
-
-      - name: Build and push sandbox python image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/sandbox-python.Dockerfile
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta-sandbox-python.outputs.tags }}
-          labels: ${{ steps.meta-sandbox-python.outputs.labels }}
-          cache-from: type=gha,scope=sandbox-python
-          cache-to: type=gha,scope=sandbox-python,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.frontend && format('NUXT_PUBLIC_VERSION={0}', steps.meta.outputs.version) || '' }}
+          cache-from: type=gha,scope=${{ matrix.cache-scope }}
+          cache-to: type=gha,scope=${{ matrix.cache-scope }},mode=max

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,53 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version component to increment
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: read
+
+concurrency:
+  group: meridian-release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare release PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require dispatch from main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Prepare Release must be dispatched from main." >&2
+          exit 1
+
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Create or update release PR
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          if [[ -z "$RELEASE_TOKEN" ]]; then
+            echo "RELEASE_TOKEN is required." >&2
+            exit 1
+          fi
+          python scripts/release_automation.py prepare \
+            --repository "$REPOSITORY" \
+            --bump "$BUMP" \
+            --base main \
+            --head dev

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,42 @@
+name: Publish Release
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: meridian-release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish merged release
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Create tag and prerelease
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ -z "$RELEASE_TOKEN" ]]; then
+            echo "RELEASE_TOKEN is required." >&2
+            exit 1
+          fi
+          python scripts/release_automation.py publish \
+            --repository "$REPOSITORY" \
+            --pull-request-number "$PULL_REQUEST_NUMBER"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ ui/test-results/
 api/app/data/cloned_repos/4c0a28f1-d50c-4825-bbd0-b8ff89ae7b8a/
 .cbmignore
 .codebase-memory/
+.opencode/skills/create-update-changelog/

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -206,6 +206,7 @@ async def lifespan(app: FastAPI):
         )
 
         app.state.connection_manager = connection_manager
+        await app.state.connection_manager.start(app.state.redis_manager)
 
         try:
             await refresh_models_dev_catalog(app)
@@ -234,6 +235,7 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         await shutdown_background_tasks(app.state.background_tasks)
+        await connection_manager.close()
         await browser_fetch_manager.close()
 
         if app.state.http_client is not None:

--- a/api/app/routers/files.py
+++ b/api/app/routers/files.py
@@ -43,10 +43,10 @@ from services.files import (
     copy_file_system_item,
     create_user_root_folder,
     delete_file_from_disk,
-    ensure_resized_image,
     get_user_storage_path,
     save_upload_file_to_disk,
 )
+from services.image_previews import ImagePreviewSize, ensure_image_preview
 from services.settings import get_user_settings
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -55,7 +55,7 @@ router = APIRouter(prefix="/files", tags=["files"])
 ConflictPolicy = Literal["fail", "replace", "keep_both", "skip"]
 
 EMBEDDABLE_HTML_CONTENT_TYPE = "text/html"
-FILE_CACHE_HEADERS = {"Cache-Control": "public, max-age=31536000"}
+FILE_CACHE_HEADERS = {"Cache-Control": "private, max-age=31536000"}
 HTML_EMBED_CACHE_HEADERS = {"Cache-Control": "private, no-store"}
 DOWNLOAD_EXTENSION_BY_CONTENT_TYPE = {
     "image/jpeg": "jpg",
@@ -998,14 +998,13 @@ async def copy_file_or_folder(
 async def view_file(
     request: Request,
     file_id: uuid.UUID,
-    size: Optional[str] = Query(None, pattern=r"^\d+x\d+$"),
+    size: Optional[ImagePreviewSize] = Query(None),
     download: bool = False,
     user_id_str: str = Depends(get_current_user_id),
 ):
     """
     Serves a file to the user after checking for ownership.
-    If 'size' is provided (e.g., '160x160') and the file is an image,
-    it returns a resized version, caching it if necessary.
+    If an allowed 'size' is provided for an image, returns a cached WebP preview.
     """
     user_id = uuid.UUID(user_id_str)
     file_record = await _get_owned_file_or_404(request, file_id, user_id)
@@ -1023,14 +1022,24 @@ async def view_file(
     )
     response_filename = _build_id_download_filename(file_record) if download else file_record.name
 
-    # Check if resize is requested for an image
-    if size and file_record.content_type and file_record.content_type.startswith("image/"):
-        resized_path = await ensure_resized_image(user_id, file_path, size)
-        if resized_path:
+    if (
+        not download
+        and size
+        and file_record.content_type
+        and file_record.content_type.startswith("image/")
+    ):
+        preview = await ensure_image_preview(
+            user_id,
+            file_path,
+            size,
+            file_record.content_hash,
+        )
+        if preview:
             return _build_file_response(
-                path=resized_path,
-                media_type=file_record.content_type,
+                path=preview.path,
+                media_type=preview.media_type,
                 filename=response_filename,
+                headers=FILE_CACHE_HEADERS,
                 content_disposition_type=content_disposition_type,
             )
 

--- a/api/app/routers/inference_providers.py
+++ b/api/app/routers/inference_providers.py
@@ -74,7 +74,7 @@ async def connect_claude_agent(
             CLAUDE_AGENT_PROVIDER_KEY,
             encrypted_token,
         )
-        invalidate_user_available_models_cache(request.app, user_id)
+        await invalidate_user_available_models_cache(request.app, user_id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
@@ -93,7 +93,7 @@ async def disconnect_claude_agent(
     user_id: str = Depends(get_current_user_id),
 ):
     await delete_provider_token(request.app.state.pg_engine, user_id, CLAUDE_AGENT_PROVIDER_KEY)
-    invalidate_user_available_models_cache(request.app, user_id)
+    await invalidate_user_available_models_cache(request.app, user_id)
     return {"message": "Claude Agent disconnected successfully."}
 
 
@@ -119,7 +119,7 @@ async def connect_github_copilot(
             GITHUB_COPILOT_PROVIDER_KEY,
             encrypted_token,
         )
-        invalidate_user_available_models_cache(request.app, user_id)
+        await invalidate_user_available_models_cache(request.app, user_id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
@@ -138,7 +138,7 @@ async def disconnect_github_copilot(
     user_id: str = Depends(get_current_user_id),
 ):
     await delete_provider_token(request.app.state.pg_engine, user_id, GITHUB_COPILOT_PROVIDER_KEY)
-    invalidate_user_available_models_cache(request.app, user_id)
+    await invalidate_user_available_models_cache(request.app, user_id)
     return {"message": "GitHub Copilot disconnected successfully."}
 
 
@@ -170,7 +170,7 @@ async def connect_z_ai_coding_plan(
             Z_AI_CODING_PLAN_PROVIDER_KEY,
             encrypted_api_key,
         )
-        invalidate_user_available_models_cache(request.app, user_id)
+        await invalidate_user_available_models_cache(request.app, user_id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
@@ -193,7 +193,7 @@ async def disconnect_z_ai_coding_plan(
         user_id,
         Z_AI_CODING_PLAN_PROVIDER_KEY,
     )
-    invalidate_user_available_models_cache(request.app, user_id)
+    await invalidate_user_available_models_cache(request.app, user_id)
     return {"message": "Z.AI Coding Plan disconnected successfully."}
 
 
@@ -222,7 +222,7 @@ async def connect_gemini_cli(
             GEMINI_CLI_PROVIDER_KEY,
             encrypted_oauth_creds,
         )
-        invalidate_user_available_models_cache(request.app, user_id)
+        await invalidate_user_available_models_cache(request.app, user_id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
@@ -241,7 +241,7 @@ async def disconnect_gemini_cli(
     user_id: str = Depends(get_current_user_id),
 ):
     await delete_provider_token(request.app.state.pg_engine, user_id, GEMINI_CLI_PROVIDER_KEY)
-    invalidate_user_available_models_cache(request.app, user_id)
+    await invalidate_user_available_models_cache(request.app, user_id)
     return {"message": "Gemini CLI disconnected successfully."}
 
 
@@ -261,7 +261,7 @@ async def _store_openai_codex_auth_json(
         OPENAI_CODEX_PROVIDER_KEY,
         encrypted_auth_json,
     )
-    invalidate_user_available_models_cache(request.app, user_id)
+    await invalidate_user_available_models_cache(request.app, user_id)
 
 
 @router.post(
@@ -327,7 +327,7 @@ async def disconnect_openai_codex(
     user_id: str = Depends(get_current_user_id),
 ):
     await delete_provider_token(request.app.state.pg_engine, user_id, OPENAI_CODEX_PROVIDER_KEY)
-    invalidate_user_available_models_cache(request.app, user_id)
+    await invalidate_user_available_models_cache(request.app, user_id)
     return {"message": "OpenAI Codex disconnected successfully."}
 
 
@@ -359,7 +359,7 @@ async def connect_opencode_go(
             OPENCODE_GO_PROVIDER_KEY,
             encrypted_api_key,
         )
-        invalidate_user_available_models_cache(request.app, user_id)
+        await invalidate_user_available_models_cache(request.app, user_id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
@@ -378,7 +378,7 @@ async def disconnect_opencode_go(
     user_id: str = Depends(get_current_user_id),
 ):
     await delete_provider_token(request.app.state.pg_engine, user_id, OPENCODE_GO_PROVIDER_KEY)
-    invalidate_user_available_models_cache(request.app, user_id)
+    await invalidate_user_available_models_cache(request.app, user_id)
     return {"message": "OpenCode Go disconnected successfully."}
 
 
@@ -410,7 +410,7 @@ async def connect_alibaba_token_plan(
             ALIBABA_TOKEN_PLAN_PROVIDER_KEY,
             encrypted_api_key,
         )
-        invalidate_user_available_models_cache(request.app, user_id)
+        await invalidate_user_available_models_cache(request.app, user_id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
@@ -437,5 +437,5 @@ async def disconnect_alibaba_token_plan(
         user_id,
         ALIBABA_TOKEN_PLAN_PROVIDER_KEY,
     )
-    invalidate_user_available_models_cache(request.app, user_id)
+    await invalidate_user_available_models_cache(request.app, user_id)
     return {"message": "Alibaba Personal Token Plan disconnected successfully."}

--- a/api/app/services/connection_manager.py
+++ b/api/app/services/connection_manager.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 from typing import Any
 
+from database.redis.redis_ops import RedisManager
 from fastapi import WebSocket
+from services.websocket_broker import RedisWebSocketBroker, hash_broker_target
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -10,33 +12,56 @@ logger = logging.getLogger("uvicorn.error")
 class ConnectionManager:
     def __init__(self):
         self.active_connections: dict[str, WebSocket] = {}
-        self.active_tasks: dict[str, asyncio.Task] = {}
+        self.active_tasks: dict[tuple[str, str], asyncio.Task] = {}
         self.client_user_ids: dict[str, str] = {}
         self.user_client_ids: dict[str, set[str]] = {}
         self.connection_locks: dict[str, asyncio.Lock] = {}
+        self._broker: RedisWebSocketBroker | None = None
+
+    async def start(self, redis_manager: RedisManager) -> None:
+        if self._broker is None:
+            self._broker = RedisWebSocketBroker(
+                redis_manager,
+                self._send_to_target,
+                self._cancel_broker_task,
+            )
+        await self._broker.start()
+
+    async def close(self) -> None:
+        broker = self._broker
+        self._broker = None
+        if broker is not None:
+            await broker.close()
 
     async def connect(self, websocket: WebSocket, client_id: str, user_id: str | None = None):
         await websocket.accept()
         self.active_connections[client_id] = websocket
         self.connection_locks[client_id] = asyncio.Lock()
         if user_id:
-            self.client_user_ids[client_id] = user_id
-            self.user_client_ids.setdefault(user_id, set()).add(client_id)
+            user_target = hash_broker_target(user_id)
+            self.client_user_ids[client_id] = user_target
+            self.user_client_ids.setdefault(user_target, set()).add(client_id)
         logger.info(f"WebSocket connected: {client_id}")
 
     def disconnect(self, client_id: str):
         if client_id in self.active_connections:
             del self.active_connections[client_id]
             self.connection_locks.pop(client_id, None)
-            user_id = self.client_user_ids.pop(client_id, None)
-            if user_id and user_id in self.user_client_ids:
-                self.user_client_ids[user_id].discard(client_id)
-                if not self.user_client_ids[user_id]:
-                    del self.user_client_ids[user_id]
+            user_target = self.client_user_ids.pop(client_id, None)
+            if user_target and user_target in self.user_client_ids:
+                self.user_client_ids[user_target].discard(client_id)
+                if not self.user_client_ids[user_target]:
+                    del self.user_client_ids[user_target]
             logger.info(f"WebSocket disconnected: {client_id}")
 
     async def send_to_user(self, user_id: str, message: dict[str, Any]) -> None:
-        client_ids = list(self.user_client_ids.get(user_id, set()))
+        user_target = hash_broker_target(user_id)
+        await self._send_to_target(user_target, message)
+        if self._broker is not None:
+            await self._broker.publish_user_event(user_target, message)
+
+    async def _send_to_target(self, user_target: str, message: dict[str, Any]) -> None:
+        client_ids = list(self.user_client_ids.get(user_target, set()))
         for client_id in client_ids:
             websocket = self.active_connections.get(client_id)
             lock = self.connection_locks.get(client_id)
@@ -49,16 +74,27 @@ class ConnectionManager:
                 logger.warning("Failed to send WebSocket message to %s: %s", client_id, exc)
                 self.disconnect(client_id)
 
-    def _get_task_key(self, user_id: str, node_id: str) -> str:
-        return f"{user_id}:{node_id}"
+    def _get_task_key(self, user_id: str, node_id: str) -> tuple[str, str]:
+        return hash_broker_target(user_id), hash_broker_target(node_id)
 
     def add_task(self, task: asyncio.Task, user_id: str, node_id: str):
         key = self._get_task_key(user_id, node_id)
         self.active_tasks[key] = task
-        logger.info(f"Started stream task for node {node_id} by user {user_id}")
+        logger.info("Started local stream task")
 
     async def cancel_task(self, user_id: str, node_id: str) -> bool:
-        key = self._get_task_key(user_id, node_id)
+        user_target, task_target = self._get_task_key(user_id, node_id)
+        try:
+            return await self._cancel_target_task(user_target, task_target)
+        finally:
+            if self._broker is not None:
+                await self._broker.publish_task_cancel(user_target, task_target)
+
+    async def _cancel_broker_task(self, user_target: str, task_target: str) -> None:
+        await self._cancel_target_task(user_target, task_target)
+
+    async def _cancel_target_task(self, user_target: str, task_target: str) -> bool:
+        key = (user_target, task_target)
         task = self.active_tasks.get(key)
         if task and not task.done():
             task.cancel()
@@ -67,18 +103,21 @@ class ConnectionManager:
                 await task
             except asyncio.CancelledError:
                 pass  # Expected
-            logger.info(f"Cancelled stream task for node {node_id} by user {user_id}")
-            self.remove_task(user_id, node_id)
+            logger.info("Cancelled local stream task")
+            self._remove_target_task(user_target, task_target)
             return True
         elif task:
-            self.remove_task(user_id, node_id)
+            self._remove_target_task(user_target, task_target)
         return False
 
     def remove_task(self, user_id: str, node_id: str):
-        key = self._get_task_key(user_id, node_id)
+        self._remove_target_task(*self._get_task_key(user_id, node_id))
+
+    def _remove_target_task(self, user_target: str, task_target: str) -> None:
+        key = (user_target, task_target)
         if key in self.active_tasks:
             del self.active_tasks[key]
-            logger.info(f"Completed stream task removed for node {node_id}")
+            logger.info("Completed local stream task removed")
 
 
 manager = ConnectionManager()

--- a/api/app/services/files.py
+++ b/api/app/services/files.py
@@ -20,13 +20,11 @@ from database.pg.file_ops.file_crud import (
 from database.pg.models import Files
 from database.pg.user_ops.storage_crud import check_and_reserve_storage, release_storage
 from fastapi import HTTPException, UploadFile
-from PIL import Image, ImageOps
 from sqlalchemy.ext.asyncio import AsyncEngine as SQLAlchemyAsyncEngine
 from sqlmodel import and_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 USER_FILES_BASE_DIR = "data/user_files"
-ALLOWED_RESIZES = ["48x48", "160x160", "512x512"]
 FILE_UPLOAD_CHUNK_SIZE = 1024 * 1024
 
 logger = logging.getLogger("uvicorn.error")
@@ -392,92 +390,3 @@ async def get_or_calculate_file_hash(
     await update_file_hash(pg_engine, file_id, calculated_hash)
 
     return calculated_hash
-
-
-def _resize_image_sync(source_path: str, target_path: str, width: int, height: int):
-    """Synchronously resize image using Pillow (Center Crop)."""
-    temp_path = f"{target_path}.{uuid.uuid4()}.tmp"
-
-    try:
-        with Image.open(source_path) as img:
-            resized_img = ImageOps.fit(
-                img,
-                (width, height),
-                method=Image.Resampling.LANCZOS,
-                centering=(0.5, 0.5),
-            )
-
-            ext = os.path.splitext(target_path)[1].lower()
-            if ext in [".jpg", ".jpeg"] and resized_img.mode in ("RGBA", "P"):
-                resized_img = resized_img.convert("RGB")
-
-            img_format = Image.registered_extensions().get(ext)
-            resized_img.save(temp_path, format=img_format, optimize=True)
-
-        os.replace(temp_path, target_path)
-    except Exception as e:
-        logger.error(f"Error resizing image {source_path}: {e}")
-        if os.path.exists(temp_path):
-            os.remove(temp_path)
-        raise e
-
-
-async def ensure_resized_image(
-    user_id: uuid.UUID,
-    unique_filename: str,
-    size_str: str,
-) -> Optional[str]:
-    """
-    Ensures a resized version of the image exists in the cache.
-    Returns the path to the resized image or None if it fails.
-    """
-    if size_str not in ALLOWED_RESIZES:
-        return None
-
-    try:
-        width, height = map(int, size_str.lower().split("x"))
-    except ValueError:
-        return None
-
-    user_base = get_user_storage_path(user_id)
-    cache_base = os.path.join(user_base, ".cache", "resized")
-
-    # Original full path
-    source_path = os.path.join(user_base, unique_filename)
-
-    # Construct target path preserving structure to avoid collisions
-    relative_dir = os.path.dirname(unique_filename)
-    filename = os.path.basename(unique_filename)
-    name, ext = os.path.splitext(filename)
-
-    resized_filename = f"{name}_{width}x{height}{ext}"
-
-    # Target directory inside cache
-    target_dir = os.path.join(cache_base, relative_dir)
-    target_path = os.path.join(target_dir, resized_filename)
-
-    # Check existence
-    if not await aiofiles.os.path.exists(source_path):
-        return None
-
-    # Cache Invalidation Check
-    if await aiofiles.os.path.exists(target_path):
-        source_stat = await aiofiles.os.stat(source_path)
-        target_stat = await aiofiles.os.stat(target_path)
-
-        # If cache is newer than source, return cache
-        if target_stat.st_mtime > source_stat.st_mtime:
-            return target_path
-
-    if not await aiofiles.os.path.exists(target_dir):
-        await aiofiles.os.makedirs(target_dir, exist_ok=True)
-
-    # Resize (CPU bound, run in executor)
-    loop = asyncio.get_running_loop()
-    try:
-        await loop.run_in_executor(
-            None, _resize_image_sync, source_path, target_path, width, height
-        )
-        return target_path
-    except Exception:
-        return None

--- a/api/app/services/github_copilot.py
+++ b/api/app/services/github_copilot.py
@@ -17,6 +17,7 @@ from database.redis.redis_ops import RedisManager
 from models.inference import ModelInfo
 from models.message import ToolEnum
 from models.tool_question import AskUserPendingResult
+from services.github_copilot_lifecycle import build_scoped_copilot_env, shutdown_copilot_runtime
 from services.provider_runtime import (
     build_runtime_directory_layout,
     cleanup_runtime_dir,
@@ -90,14 +91,13 @@ class GitHubCopilotToolExecutionState:
 
 
 try:
-    from copilot import CopilotClient, SubprocessConfig
+    from copilot import CopilotClient
     from copilot.session import PermissionHandler
     from copilot.tools import Tool, ToolInvocation, ToolResult
 
     GITHUB_COPILOT_SDK_AVAILABLE = True
 except ImportError:  # pragma: no cover - exercised when SDK missing
     CopilotClient = None  # type: ignore[misc,assignment]
-    SubprocessConfig = None  # type: ignore[misc,assignment]
     PermissionHandler = None  # type: ignore[misc,assignment]
     Tool = None  # type: ignore[misc,assignment]
     ToolInvocation = None  # type: ignore[misc,assignment]
@@ -106,7 +106,7 @@ except ImportError:  # pragma: no cover - exercised when SDK missing
 
 
 def _require_github_copilot_sdk() -> None:
-    if not GITHUB_COPILOT_SDK_AVAILABLE or CopilotClient is None or SubprocessConfig is None:
+    if not GITHUB_COPILOT_SDK_AVAILABLE or CopilotClient is None:
         raise ValueError(
             "GitHub Copilot support is not available because the github-copilot-sdk package "
             "is not installed."
@@ -358,44 +358,22 @@ def _public_github_copilot_stream_error_message(error: BaseException, model: str
     return GENERIC_STREAM_ERROR_MESSAGE
 
 
-def _is_sdk_model_billing_parse_error(error: Exception) -> bool:
-    return "Missing required field 'multiplier' in ModelBilling" in str(error)
-
-
-async def _list_raw_sdk_models(client: Any) -> list[Any]:
-    rpc_client = getattr(client, "_client", None)
-    if rpc_client is None:
-        raise RuntimeError("Client not connected")
-
-    response = await rpc_client.request("models.list", {})
-    raw_models = response.get("models", []) if isinstance(response, dict) else []
-    return raw_models if isinstance(raw_models, list) else []
-
-
 async def _list_sdk_models(github_token: str) -> list[Any]:
     _require_github_copilot_sdk()
 
     runtime_context = _build_runtime_context()
     heartbeat_task = start_runtime_heartbeat(runtime_context.root_dir)
-    client = CopilotClient(
-        SubprocessConfig(
-            cwd=str(runtime_context.cwd),
-            env=runtime_context.env,
+    scope_id = str(runtime_context.root_dir)
+    client = None
+    try:
+        client = CopilotClient(
+            working_directory=str(runtime_context.cwd),
+            env=build_scoped_copilot_env(runtime_context.env, scope_id),
             github_token=github_token,
             use_logged_in_user=False,
         )
-    )
-    try:
         await client.start()
-        try:
-            return await client.list_models()
-        except ValueError as exc:
-            if not _is_sdk_model_billing_parse_error(exc):
-                raise
-            logger.info(
-                "GitHub Copilot SDK could not parse model billing metadata; using raw model list."
-            )
-            return await _list_raw_sdk_models(client)
+        return await client.list_models()
     except FileNotFoundError as exc:
         raise ValueError(
             "GitHub Copilot CLI runtime is unavailable. Install the SDK bundled binary or set a "
@@ -404,10 +382,11 @@ async def _list_sdk_models(github_token: str) -> list[Any]:
     except Exception as exc:
         raise ValueError(f"GitHub Copilot model listing failed: {exc}") from exc
     finally:
+        await shutdown_copilot_runtime(client, None, scope_id)
         with contextlib.suppress(Exception):
-            await client.force_stop()
-        await stop_runtime_heartbeat(heartbeat_task)
-        _cleanup_runtime_context(runtime_context)
+            await stop_runtime_heartbeat(heartbeat_task)
+        with contextlib.suppress(Exception):
+            _cleanup_runtime_context(runtime_context)
 
 
 async def list_github_copilot_models(
@@ -701,24 +680,24 @@ async def _run_copilot_session(
     prompt = build_prompt(prompt_messages) or "Please respond to the available context."
     runtime_context = _build_runtime_context()
     heartbeat_task = start_runtime_heartbeat(runtime_context.root_dir)
-    client = CopilotClient(
-        SubprocessConfig(
-            cwd=str(runtime_context.cwd),
-            env=runtime_context.env,
+    scope_id = str(runtime_context.root_dir)
+    client = None
+    session = None
+    try:
+        client = CopilotClient(
+            working_directory=str(runtime_context.cwd),
+            env=build_scoped_copilot_env(runtime_context.env, scope_id),
             github_token=req.github_token,
             use_logged_in_user=False,
         )
-    )
-    session = None
-    abort_tasks: list[asyncio.Task[None]] = []
-    execution_state = execution_state or GitHubCopilotToolExecutionState()
+        abort_tasks: list[asyncio.Task[None]] = []
+        execution_state = execution_state or GitHubCopilotToolExecutionState()
 
-    def _abort_current_turn() -> None:
-        if session is None:
-            return
-        abort_tasks.append(asyncio.create_task(session.abort()))
+        def _abort_current_turn() -> None:
+            if session is None:
+                return
+            abort_tasks.append(asyncio.create_task(session.abort()))
 
-    try:
         await client.start()
         tools = _build_tools(
             req,
@@ -745,7 +724,7 @@ async def _run_copilot_session(
                 available_tools=available_tool_names,
                 streaming=streaming,
                 working_directory=str(runtime_context.cwd),
-                config_dir=str(runtime_context.config_dir),
+                config_directory=str(runtime_context.config_dir),
                 enable_config_discovery=False,
                 infinite_sessions={"enabled": False},
                 client_name="Meridian",
@@ -767,16 +746,14 @@ async def _run_copilot_session(
             raise ValueError(_format_model_unavailable_error(req.model)) from exc
         raise
     finally:
-        for abort_task in abort_tasks:
-            with contextlib.suppress(Exception):
+        for abort_task in locals().get("abort_tasks", []):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await abort_task
-        if session is not None:
-            with contextlib.suppress(Exception):
-                await session.destroy()
+        await shutdown_copilot_runtime(client, session, scope_id)
         with contextlib.suppress(Exception):
-            await client.force_stop()
-        await stop_runtime_heartbeat(heartbeat_task)
-        _cleanup_runtime_context(runtime_context)
+            await stop_runtime_heartbeat(heartbeat_task)
+        with contextlib.suppress(Exception):
+            _cleanup_runtime_context(runtime_context)
 
 
 async def make_github_copilot_request_non_streaming(

--- a/api/app/services/github_copilot_lifecycle.py
+++ b/api/app/services/github_copilot_lifecycle.py
@@ -1,0 +1,266 @@
+import asyncio
+import logging
+import os
+import signal
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable
+
+logger = logging.getLogger("uvicorn.error")
+
+GITHUB_COPILOT_SCOPE_ENV = "MERIDIAN_GITHUB_COPILOT_SCOPE"
+SESSION_DISCONNECT_TIMEOUT_SECONDS = 5.0
+CLIENT_STOP_TIMEOUT_SECONDS = 25.0
+CLIENT_FORCE_STOP_TIMEOUT_SECONDS = 5.0
+PROCESS_TERM_GRACE_SECONDS = 1.0
+PROCESS_KILL_GRACE_SECONDS = 1.0
+PROCESS_POLL_INTERVAL_SECONDS = 0.05
+_PROC_ROOT = Path("/proc")
+
+
+@dataclass(frozen=True)
+class CopilotProcessIdentity:
+    pid: int
+    start_time_ticks: int
+
+
+def build_scoped_copilot_env(env: dict[str, str], scope_id: str) -> dict[str, str]:
+    scoped_env = env.copy()
+    scoped_env[GITHUB_COPILOT_SCOPE_ENV] = scope_id
+    return scoped_env
+
+
+def _read_process_start_time(pid: int, proc_root: Path = _PROC_ROOT) -> int | None:
+    try:
+        stat = (proc_root / str(pid) / "stat").read_text()
+    except (OSError, UnicodeError):
+        return None
+
+    closing_paren = stat.rfind(")")
+    if closing_paren < 0:
+        return None
+    fields_after_command = stat[closing_paren + 1 :].split()
+    try:
+        return int(fields_after_command[19])
+    except (IndexError, ValueError):
+        return None
+
+
+def _process_has_scope(pid: int, scope_id: str, proc_root: Path = _PROC_ROOT) -> bool:
+    expected_entry = f"{GITHUB_COPILOT_SCOPE_ENV}={scope_id}".encode()
+    try:
+        environ = (proc_root / str(pid) / "environ").read_bytes()
+    except OSError:
+        return False
+    return expected_entry in environ.split(b"\0")
+
+
+def _find_scoped_processes(
+    scope_id: str,
+    proc_root: Path = _PROC_ROOT,
+) -> set[CopilotProcessIdentity]:
+    identities: set[CopilotProcessIdentity] = set()
+    try:
+        process_entries = list(proc_root.iterdir())
+    except OSError as exc:
+        logger.warning("GitHub Copilot scoped process scan unavailable: %s", exc)
+        return identities
+
+    current_pid = os.getpid()
+    for entry in process_entries:
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        if pid == current_pid or not _process_has_scope(pid, scope_id, proc_root):
+            continue
+        start_time = _read_process_start_time(pid, proc_root)
+        if start_time is not None:
+            identities.add(CopilotProcessIdentity(pid=pid, start_time_ticks=start_time))
+    return identities
+
+
+def _identity_is_current(
+    identity: CopilotProcessIdentity,
+    proc_root: Path = _PROC_ROOT,
+) -> bool:
+    return _read_process_start_time(identity.pid, proc_root) == identity.start_time_ticks
+
+
+def _signal_process(
+    identity: CopilotProcessIdentity,
+    process_signal: signal.Signals,
+    proc_root: Path,
+) -> None:
+    if not _identity_is_current(identity, proc_root):
+        return
+    try:
+        os.kill(identity.pid, process_signal)
+    except (ProcessLookupError, PermissionError):
+        return
+
+
+def _reap_process(identity: CopilotProcessIdentity, proc_root: Path) -> None:
+    if not _identity_is_current(identity, proc_root):
+        return
+    try:
+        os.waitpid(identity.pid, os.WNOHANG)
+    except (ChildProcessError, ProcessLookupError):
+        return
+
+
+def _current_identities(
+    identities: set[CopilotProcessIdentity],
+    proc_root: Path,
+) -> set[CopilotProcessIdentity]:
+    return {identity for identity in identities if _identity_is_current(identity, proc_root)}
+
+
+def _terminate_scoped_processes(
+    scope_id: str,
+    initial_identities: set[CopilotProcessIdentity] | None = None,
+    *,
+    proc_root: Path = _PROC_ROOT,
+) -> set[CopilotProcessIdentity]:
+    tracked = set(initial_identities or ())
+    discovered = _find_scoped_processes(scope_id, proc_root)
+    tracked.update(discovered)
+    if not tracked:
+        return set()
+
+    term_signalled: set[CopilotProcessIdentity] = set()
+    term_deadline = time.monotonic() + PROCESS_TERM_GRACE_SECONDS
+    while True:
+        discovered = _find_scoped_processes(scope_id, proc_root)
+        tracked.update(discovered)
+        active = _current_identities(tracked, proc_root)
+        for identity in active - term_signalled:
+            _signal_process(identity, signal.SIGTERM, proc_root)
+            term_signalled.add(identity)
+        for identity in tracked:
+            _reap_process(identity, proc_root)
+        if time.monotonic() >= term_deadline:
+            break
+        time.sleep(PROCESS_POLL_INTERVAL_SECONDS)
+
+    kill_signalled: set[CopilotProcessIdentity] = set()
+    tracked.update(_find_scoped_processes(scope_id, proc_root))
+    survivors = _current_identities(tracked, proc_root)
+    kill_deadline = time.monotonic() + PROCESS_KILL_GRACE_SECONDS
+    while True:
+        for identity in survivors - kill_signalled:
+            _signal_process(identity, signal.SIGKILL, proc_root)
+            kill_signalled.add(identity)
+        for identity in tracked:
+            _reap_process(identity, proc_root)
+        if time.monotonic() >= kill_deadline:
+            break
+        time.sleep(PROCESS_POLL_INTERVAL_SECONDS)
+        tracked.update(_find_scoped_processes(scope_id, proc_root))
+        survivors = _current_identities(tracked, proc_root)
+
+    tracked.update(_find_scoped_processes(scope_id, proc_root))
+    survivors = _current_identities(tracked, proc_root)
+    for identity in tracked:
+        _reap_process(identity, proc_root)
+    if survivors:
+        logger.warning(
+            "GitHub Copilot scoped cleanup left %d process(es): %s",
+            len(survivors),
+            sorted(identity.pid for identity in survivors),
+        )
+    return survivors
+
+
+async def _run_bounded_cleanup(
+    operation: Awaitable[Any],
+    *,
+    label: str,
+    timeout: float,
+) -> bool:
+    try:
+        await asyncio.wait_for(operation, timeout=timeout)
+        return True
+    except asyncio.CancelledError:
+        raise
+    except asyncio.TimeoutError:
+        logger.warning("GitHub Copilot %s timed out after %.1f seconds", label, timeout)
+    except Exception as exc:
+        logger.warning("GitHub Copilot %s failed: %s", label, exc)
+    return False
+
+
+async def shutdown_copilot_runtime(
+    client: Any | None,
+    session: Any | None,
+    scope_id: str,
+) -> None:
+    current_task = asyncio.current_task()
+    initial_cancellation_count = current_task.cancelling() if current_task is not None else 0
+    cancelled_during_cleanup = False
+
+    def _record_new_cancellation() -> None:
+        nonlocal cancelled_during_cleanup
+        if current_task is not None and current_task.cancelling() > initial_cancellation_count:
+            cancelled_during_cleanup = True
+
+    try:
+        initial_identities = await asyncio.to_thread(_find_scoped_processes, scope_id)
+    except asyncio.CancelledError:
+        _record_new_cancellation()
+        initial_identities = set()
+    except Exception as exc:
+        logger.warning("GitHub Copilot initial scoped process scan failed: %s", exc)
+        initial_identities = set()
+
+    if session is not None:
+        try:
+            await _run_bounded_cleanup(
+                session.disconnect(),
+                label="session disconnect",
+                timeout=SESSION_DISCONNECT_TIMEOUT_SECONDS,
+            )
+        except asyncio.CancelledError:
+            _record_new_cancellation()
+        except Exception as exc:
+            logger.warning("GitHub Copilot session disconnect failed: %s", exc)
+
+    stopped = client is None
+    if client is not None:
+        try:
+            stopped = await _run_bounded_cleanup(
+                client.stop(),
+                label="client stop",
+                timeout=CLIENT_STOP_TIMEOUT_SECONDS,
+            )
+        except asyncio.CancelledError:
+            _record_new_cancellation()
+            stopped = False
+        except Exception as exc:
+            logger.warning("GitHub Copilot client stop failed: %s", exc)
+            stopped = False
+        if not stopped:
+            try:
+                await _run_bounded_cleanup(
+                    client.force_stop(),
+                    label="client force stop",
+                    timeout=CLIENT_FORCE_STOP_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                _record_new_cancellation()
+            except Exception as exc:
+                logger.warning("GitHub Copilot client force stop failed: %s", exc)
+
+    try:
+        await asyncio.to_thread(
+            _terminate_scoped_processes,
+            scope_id,
+            initial_identities,
+        )
+    except asyncio.CancelledError:
+        _record_new_cancellation()
+    except Exception as exc:
+        logger.warning("GitHub Copilot scoped process cleanup failed: %s", exc)
+
+    if cancelled_during_cleanup:
+        raise asyncio.CancelledError

--- a/api/app/services/image_playground/generated_files.py
+++ b/api/app/services/image_playground/generated_files.py
@@ -1,16 +1,18 @@
 import hashlib
 import uuid
+from datetime import datetime, timezone
 from io import BytesIO
 from math import gcd
 from pathlib import Path
 
 from database.pg.file_ops.file_crud import create_db_file, get_root_folder_for_user
-from database.pg.models import Files
+from database.pg.models import Files, ImageGenerationJob
 from database.pg.user_ops.storage_crud import check_and_reserve_storage, release_storage
 from fastapi import HTTPException
 from PIL import Image
 from services.files import delete_file_from_disk, save_file_to_disk
 from sqlalchemy.ext.asyncio import AsyncEngine as SQLAlchemyAsyncEngine
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 VIDEO_CONTENT_TYPES_BY_EXTENSION = {
     "mov": "video/quicktime",
@@ -30,6 +32,63 @@ def generated_video_content_type(extension: str) -> str:
     return VIDEO_CONTENT_TYPES_BY_EXTENSION.get(
         normalized_extension, f"video/{normalized_extension}"
     )
+
+
+async def create_completed_generation_job(
+    *,
+    pg_engine: SQLAlchemyAsyncEngine,
+    user_id: uuid.UUID,
+    file_id: uuid.UUID,
+    prompt: str,
+    model: str,
+    media_type: str,
+    aspect_ratio: str,
+    resolution: str,
+    source_image_ids: list[str],
+    generation_started_at: datetime,
+    duration: int | None = None,
+    generate_audio: bool = False,
+    actual_width: int | None = None,
+    actual_height: int | None = None,
+    actual_aspect_ratio: str | None = None,
+) -> ImageGenerationJob:
+    completed_at = datetime.now(timezone.utc)
+    job = ImageGenerationJob(
+        batch_id=uuid.uuid4(),
+        user_id=user_id,
+        file_id=file_id,
+        status="completed",
+        prompt=prompt.strip(),
+        effective_prompt=prompt.strip(),
+        model=model.strip(),
+        media_type=media_type,
+        aspect_ratio=aspect_ratio,
+        resolution=resolution,
+        duration=duration,
+        generate_audio=generate_audio,
+        actual_width=actual_width,
+        actual_height=actual_height,
+        actual_aspect_ratio=actual_aspect_ratio,
+        style_preset=None,
+        source_image_ids=[str(image_id) for image_id in source_image_ids],
+        error=None,
+        attempts=1,
+        max_attempts=1,
+        is_preview=False,
+        created_at=generation_started_at,
+        updated_at=completed_at,
+        completed_at=completed_at,
+    )
+    async with AsyncSession(pg_engine) as session:
+        try:
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+        except Exception:
+            await session.rollback()
+            raise
+
+    return job
 
 
 async def create_generated_image_file(

--- a/api/app/services/image_previews.py
+++ b/api/app/services/image_previews.py
@@ -1,0 +1,132 @@
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Literal, Optional
+
+import aiofiles.os
+from PIL import Image, ImageOps
+from services.files import get_user_storage_path
+
+ImagePreviewSize = Literal["48x48", "160x160", "512x512"]
+
+
+@dataclass(frozen=True)
+class ImagePreviewSpec:
+    width: int
+    height: int
+    output_format: str = "WEBP"
+    extension: str = ".webp"
+    media_type: str = "image/webp"
+    quality: int = 80
+    optimize: bool = True
+    resampling: str = "LANCZOS"
+    centering: tuple[float, float] = (0.5, 0.5)
+    transform_version: int = 1
+
+
+@dataclass(frozen=True)
+class ImagePreviewArtifact:
+    path: str
+    media_type: str
+
+
+IMAGE_PREVIEW_PRESETS: dict[ImagePreviewSize, ImagePreviewSpec] = {
+    "48x48": ImagePreviewSpec(width=48, height=48),
+    "160x160": ImagePreviewSpec(width=160, height=160),
+    "512x512": ImagePreviewSpec(width=512, height=512),
+}
+
+logger = logging.getLogger("uvicorn.error")
+
+
+def _build_cache_key(
+    *,
+    relative_source_path: str,
+    content_hash: Optional[str],
+    source_size: int,
+    source_mtime_ns: int,
+    spec: ImagePreviewSpec,
+) -> str:
+    identity = {
+        "relative_source_path": relative_source_path,
+        "content_hash": content_hash,
+        "source_size": source_size,
+        "source_mtime_ns": source_mtime_ns,
+        "transform": asdict(spec),
+    }
+    encoded_identity = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded_identity).hexdigest()
+
+
+def _render_preview_sync(
+    source_path: str,
+    target_path: str,
+    spec: ImagePreviewSpec,
+) -> None:
+    temp_path = f"{target_path}.{uuid.uuid4().hex}.tmp"
+    try:
+        with Image.open(source_path) as image:
+            preview = ImageOps.fit(
+                image,
+                (spec.width, spec.height),
+                method=getattr(Image.Resampling, spec.resampling),
+                centering=spec.centering,
+            )
+            if preview.mode not in ("RGB", "RGBA"):
+                has_alpha = "A" in preview.getbands() or "transparency" in preview.info
+                preview = preview.convert("RGBA" if has_alpha else "RGB")
+            preview.save(
+                temp_path,
+                format=spec.output_format,
+                quality=spec.quality,
+                optimize=spec.optimize,
+            )
+        os.replace(temp_path, target_path)
+    except Exception:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+        raise
+
+
+async def ensure_image_preview(
+    user_id: uuid.UUID,
+    unique_filename: str,
+    size: ImagePreviewSize,
+    content_hash: Optional[str],
+) -> Optional[ImagePreviewArtifact]:
+    spec = IMAGE_PREVIEW_PRESETS[size]
+    user_base = get_user_storage_path(user_id)
+    source_path = os.path.join(user_base, unique_filename)
+
+    try:
+        source_stat = await aiofiles.os.stat(source_path)
+    except OSError:
+        return None
+
+    cache_key = _build_cache_key(
+        relative_source_path=unique_filename,
+        content_hash=content_hash,
+        source_size=source_stat.st_size,
+        source_mtime_ns=source_stat.st_mtime_ns,
+        spec=spec,
+    )
+    relative_dir = os.path.dirname(unique_filename)
+    source_stem = os.path.splitext(os.path.basename(unique_filename))[0]
+    target_dir = os.path.join(user_base, ".cache", "previews", relative_dir)
+    target_path = os.path.join(target_dir, f"{source_stem}_{cache_key}{spec.extension}")
+
+    if await aiofiles.os.path.exists(target_path):
+        return ImagePreviewArtifact(path=target_path, media_type=spec.media_type)
+
+    try:
+        await aiofiles.os.makedirs(target_dir, exist_ok=True)
+        await asyncio.to_thread(_render_preview_sync, source_path, target_path, spec)
+    except Exception as error:
+        logger.error("Failed to render image preview for %s: %s", source_path, error)
+        return None
+
+    return ImagePreviewArtifact(path=target_path, media_type=spec.media_type)

--- a/api/app/services/inference.py
+++ b/api/app/services/inference.py
@@ -1,9 +1,7 @@
 import asyncio
 import hashlib
 import logging
-import time
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from typing import Any
 
 from database.pg.token_ops.provider_token_crud import get_provider_token
@@ -19,6 +17,19 @@ from models.inference import (
 )
 from models.message import ToolEnum
 from services.crypto import decrypt_api_key
+from services.inference_cache import (
+    ALIBABA_OFFICIAL_CATALOG_CACHE_VERSION,
+    AlibabaOfficialVideoCatalogSnapshot,
+    build_alibaba_subscription_models_key,
+    build_subscription_models_key,
+    delete_user_available_models,
+    read_alibaba_official_snapshot,
+    read_subscription_models,
+    read_user_available_models,
+    write_alibaba_official_snapshot,
+    write_subscription_models,
+    write_user_available_models,
+)
 from services.providers.alibaba_token_plan_catalog import (
     ALIBABA_TOKEN_PLAN_LABEL,
     ALIBABA_TOKEN_PLAN_MODEL_PREFIX,
@@ -76,19 +87,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine as SQLAlchemyAsyncEngine
 logger = logging.getLogger("uvicorn.error")
 
 MERIDIAN_TOOL_NAMES = [tool.value for tool in ToolEnum]
-SUBSCRIPTION_MODEL_CACHE_TTL_SECONDS = 60 * 10
-USER_AVAILABLE_MODELS_CACHE_TTL_SECONDS = 60
-ALIBABA_OFFICIAL_CATALOG_SUCCESS_TTL_SECONDS = 60 * 10
-ALIBABA_OFFICIAL_CATALOG_FAILURE_TTL_SECONDS = 60
-ALIBABA_OFFICIAL_CATALOG_CACHE_VERSION = "official-video-v1"
-
-
-@dataclass(frozen=True)
-class _AlibabaOfficialVideoCatalogSnapshot:
-    model_ids: tuple[str, ...]
-    fetched_at: float
-    available: bool
-    fingerprint: str
 
 
 def _copy_models(models: list[ModelInfo]) -> list[ModelInfo]:
@@ -102,16 +100,6 @@ def _copy_response_model(response: ResponseModel) -> ResponseModel:
     )
 
 
-def _get_subscription_model_cache(
-    app: FastAPI,
-) -> dict[str, tuple[float, list[ModelInfo]]]:
-    cache = getattr(app.state, "subscription_provider_model_cache", None)
-    if cache is None:
-        cache = {}
-        app.state.subscription_provider_model_cache = cache
-    return cache
-
-
 def _get_subscription_model_inflight(
     app: FastAPI,
 ) -> dict[str, asyncio.Task[list[ModelInfo]]]:
@@ -120,16 +108,6 @@ def _get_subscription_model_inflight(
         inflight = {}
         app.state.subscription_provider_model_inflight = inflight
     return inflight
-
-
-def _get_user_available_models_cache(
-    app: FastAPI,
-) -> dict[str, tuple[float, ResponseModel]]:
-    cache = getattr(app.state, "user_available_models_cache", None)
-    if cache is None:
-        cache = {}
-        app.state.user_available_models_cache = cache
-    return cache
 
 
 def _get_user_available_models_inflight(
@@ -142,13 +120,9 @@ def _get_user_available_models_inflight(
     return inflight
 
 
-def invalidate_user_available_models_cache(app: FastAPI, user_id: str) -> None:
-    _get_user_available_models_cache(app).pop(user_id, None)
+async def invalidate_user_available_models_cache(app: FastAPI, user_id: str) -> None:
     _get_user_available_models_inflight(app).pop(user_id, None)
-
-
-def _build_subscription_model_cache_key(provider_key: str, credential: str) -> str:
-    return f"{provider_key}:{hashlib.sha256(credential.encode('utf-8')).hexdigest()}"
+    await delete_user_available_models(getattr(app.state, "redis_manager", None), user_id)
 
 
 async def _get_cached_subscription_models(
@@ -158,13 +132,10 @@ async def _get_cached_subscription_models(
     loader: Callable[[], Awaitable[list[ModelInfo]]],
     cache_empty: bool = True,
 ) -> list[ModelInfo]:
-    cache = _get_subscription_model_cache(app)
-    cached_entry = cache.get(cache_key)
-    if cached_entry is not None:
-        cached_at, cached_models = cached_entry
-        if (time.monotonic() - cached_at) < SUBSCRIPTION_MODEL_CACHE_TTL_SECONDS:
-            return _copy_models(cached_models)
-        cache.pop(cache_key, None)
+    redis_manager = getattr(app.state, "redis_manager", None)
+    cached_models = await read_subscription_models(redis_manager, cache_key)
+    if cached_models is not None:
+        return _copy_models(cached_models)
 
     inflight = _get_subscription_model_inflight(app)
     existing_task = inflight.get(cache_key)
@@ -174,7 +145,7 @@ async def _get_cached_subscription_models(
     async def _load_models() -> list[ModelInfo]:
         models = await loader()
         if models or cache_empty:
-            cache[cache_key] = (time.monotonic(), _copy_models(models))
+            await write_subscription_models(redis_manager, cache_key, models)
         return models
 
     task = asyncio.create_task(_load_models())
@@ -187,7 +158,7 @@ async def _get_cached_subscription_models(
 
 def _build_alibaba_official_snapshot(
     model_ids: list[str], *, available: bool
-) -> _AlibabaOfficialVideoCatalogSnapshot:
+) -> AlibabaOfficialVideoCatalogSnapshot:
     sorted_ids = tuple(sorted(model_ids))
     fingerprint_payload = "\0".join(
         [
@@ -196,9 +167,8 @@ def _build_alibaba_official_snapshot(
             *sorted_ids,
         ]
     )
-    return _AlibabaOfficialVideoCatalogSnapshot(
+    return AlibabaOfficialVideoCatalogSnapshot(
         model_ids=sorted_ids,
-        fetched_at=time.monotonic(),
         available=available,
         fingerprint=hashlib.sha256(fingerprint_payload.encode("utf-8")).hexdigest(),
     )
@@ -206,20 +176,11 @@ def _build_alibaba_official_snapshot(
 
 async def _get_alibaba_official_video_catalog_snapshot(
     app: FastAPI,
-) -> _AlibabaOfficialVideoCatalogSnapshot:
-    cached_snapshot = getattr(
-        app.state,
-        "alibaba_token_plan_official_video_catalog_cache",
-        None,
-    )
-    if isinstance(cached_snapshot, _AlibabaOfficialVideoCatalogSnapshot):
-        ttl = (
-            ALIBABA_OFFICIAL_CATALOG_SUCCESS_TTL_SECONDS
-            if cached_snapshot.available
-            else ALIBABA_OFFICIAL_CATALOG_FAILURE_TTL_SECONDS
-        )
-        if (time.monotonic() - cached_snapshot.fetched_at) < ttl:
-            return cached_snapshot
+) -> AlibabaOfficialVideoCatalogSnapshot:
+    redis_manager = getattr(app.state, "redis_manager", None)
+    cached_snapshot = await read_alibaba_official_snapshot(redis_manager)
+    if cached_snapshot is not None:
+        return cached_snapshot
 
     existing_task = getattr(
         app.state,
@@ -229,7 +190,7 @@ async def _get_alibaba_official_video_catalog_snapshot(
     if isinstance(existing_task, asyncio.Task):
         return await asyncio.shield(existing_task)
 
-    async def _load_snapshot() -> _AlibabaOfficialVideoCatalogSnapshot:
+    async def _load_snapshot() -> AlibabaOfficialVideoCatalogSnapshot:
         try:
             model_ids = await fetch_alibaba_token_plan_official_video_model_ids(
                 app.state.http_client
@@ -241,13 +202,13 @@ async def _get_alibaba_official_video_catalog_snapshot(
                 type(exc).__name__,
             )
             snapshot = _build_alibaba_official_snapshot([], available=False)
-        app.state.alibaba_token_plan_official_video_catalog_cache = snapshot
+        await write_alibaba_official_snapshot(redis_manager, snapshot)
         return snapshot
 
     task = asyncio.create_task(_load_snapshot())
     app.state.alibaba_token_plan_official_video_catalog_inflight = task
 
-    def _clear_inflight(_: asyncio.Task[_AlibabaOfficialVideoCatalogSnapshot]) -> None:
+    def _clear_inflight(_: asyncio.Task[AlibabaOfficialVideoCatalogSnapshot]) -> None:
         if (
             getattr(
                 app.state,
@@ -262,50 +223,15 @@ async def _get_alibaba_official_video_catalog_snapshot(
     return await asyncio.shield(task)
 
 
-def _build_alibaba_subscription_cache_key(
-    credential: str,
-    snapshot_fingerprint: str,
-) -> str:
-    credential_fingerprint = hashlib.sha256(credential.encode("utf-8")).hexdigest()
-    return (
-        f"{ALIBABA_TOKEN_PLAN_PROVIDER_KEY}:{ALIBABA_OFFICIAL_CATALOG_CACHE_VERSION}:"
-        f"{credential_fingerprint}:{snapshot_fingerprint}"
-    )
-
-
-def _prune_obsolete_alibaba_subscription_cache_entries(
-    app: FastAPI,
-    snapshot_fingerprint: str,
-) -> None:
-    provider_prefix = f"{ALIBABA_TOKEN_PLAN_PROVIDER_KEY}:"
-    current_prefix = f"{provider_prefix}{ALIBABA_OFFICIAL_CATALOG_CACHE_VERSION}:"
-    current_suffix = f":{snapshot_fingerprint}"
-
-    def _is_obsolete(key: str) -> bool:
-        return key.startswith(provider_prefix) and not (
-            key.startswith(current_prefix) and key.endswith(current_suffix)
-        )
-
-    cache = _get_subscription_model_cache(app)
-    for key in list(cache):
-        if _is_obsolete(key):
-            cache.pop(key, None)
-    inflight = _get_subscription_model_inflight(app)
-    for key in list(inflight):
-        if _is_obsolete(key):
-            inflight.pop(key, None)
-
-
 async def _get_cached_alibaba_token_plan_models(
     app: FastAPI,
     *,
     api_key: str,
 ) -> list[ModelInfo]:
     snapshot = await _get_alibaba_official_video_catalog_snapshot(app)
-    _prune_obsolete_alibaba_subscription_cache_entries(app, snapshot.fingerprint)
     return await _get_cached_subscription_models(
         app,
-        cache_key=_build_alibaba_subscription_cache_key(api_key, snapshot.fingerprint),
+        cache_key=build_alibaba_subscription_models_key(api_key, snapshot.fingerprint),
         loader=lambda: get_alibaba_token_plan_models_safe(
             models_dev_catalog=getattr(app.state, "models_dev_catalog", None),
             api_key=api_key,
@@ -542,13 +468,10 @@ def normalize_openrouter_model(model: ModelInfo) -> ModelInfo:
 
 
 async def get_available_models_for_user(app: FastAPI, user_id: str) -> ResponseModel:
-    user_cache = _get_user_available_models_cache(app)
-    cached_response = user_cache.get(user_id)
+    redis_manager = getattr(app.state, "redis_manager", None)
+    cached_response = await read_user_available_models(redis_manager, user_id)
     if cached_response is not None:
-        cached_at, response = cached_response
-        if (time.monotonic() - cached_at) < USER_AVAILABLE_MODELS_CACHE_TTL_SECONDS:
-            return _copy_response_model(response)
-        user_cache.pop(user_id, None)
+        return _copy_response_model(cached_response)
 
     user_inflight = _get_user_available_models_inflight(app)
     existing_task = user_inflight.get(user_id)
@@ -556,7 +479,9 @@ async def get_available_models_for_user(app: FastAPI, user_id: str) -> ResponseM
         return _copy_response_model(await asyncio.shield(existing_task))
 
     async def _load_available_models() -> ResponseModel:
-        return await _build_available_models_for_user(app, user_id)
+        response = await _build_available_models_for_user(app, user_id)
+        await write_user_available_models(redis_manager, user_id, response)
+        return response
 
     task = asyncio.create_task(_load_available_models())
     user_inflight[user_id] = task
@@ -564,7 +489,6 @@ async def get_available_models_for_user(app: FastAPI, user_id: str) -> ResponseM
         lambda _: user_inflight.pop(user_id, None) if user_inflight.get(user_id) is task else None
     )
     response = await asyncio.shield(task)
-    user_cache[user_id] = (time.monotonic(), _copy_response_model(response))
     return _copy_response_model(response)
 
 
@@ -586,7 +510,7 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
         provider_model_tasks.append(
             _get_cached_subscription_models(
                 app,
-                cache_key=_build_subscription_model_cache_key(
+                cache_key=build_subscription_models_key(
                     CLAUDE_AGENT_PROVIDER_KEY,
                     claude_oauth_token,
                 ),
@@ -598,7 +522,7 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
         provider_model_tasks.append(
             _get_cached_subscription_models(
                 app,
-                cache_key=_build_subscription_model_cache_key(
+                cache_key=build_subscription_models_key(
                     GITHUB_COPILOT_PROVIDER_KEY,
                     github_copilot_token,
                 ),
@@ -609,7 +533,7 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
         provider_model_tasks.append(
             _get_cached_subscription_models(
                 app,
-                cache_key=_build_subscription_model_cache_key(
+                cache_key=build_subscription_models_key(
                     Z_AI_CODING_PLAN_PROVIDER_KEY,
                     credentials.z_ai_coding_plan_api_key,
                 ),
@@ -622,7 +546,7 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
         provider_model_tasks.append(
             _get_cached_subscription_models(
                 app,
-                cache_key=_build_subscription_model_cache_key(
+                cache_key=build_subscription_models_key(
                     GEMINI_CLI_PROVIDER_KEY,
                     credentials.gemini_cli_oauth_creds_json,
                 ),
@@ -634,7 +558,7 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
         provider_model_tasks.append(
             _get_cached_subscription_models(
                 app,
-                cache_key=_build_subscription_model_cache_key(
+                cache_key=build_subscription_models_key(
                     OPENAI_CODEX_PROVIDER_KEY,
                     openai_codex_auth_json,
                 ),
@@ -652,7 +576,7 @@ async def _build_available_models_for_user(app: FastAPI, user_id: str) -> Respon
         provider_model_tasks.append(
             _get_cached_subscription_models(
                 app,
-                cache_key=_build_subscription_model_cache_key(
+                cache_key=build_subscription_models_key(
                     OPENCODE_GO_PROVIDER_KEY,
                     credentials.opencode_go_api_key,
                 ),

--- a/api/app/services/inference_cache.py
+++ b/api/app/services/inference_cache.py
@@ -1,0 +1,233 @@
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from database.redis.redis_ops import RedisManager
+from models.inference import ModelInfo, ResponseModel
+from pydantic import TypeAdapter
+
+logger = logging.getLogger("uvicorn.error")
+
+SUBSCRIPTION_MODEL_CACHE_TTL_SECONDS = 60 * 10
+USER_AVAILABLE_MODELS_CACHE_TTL_SECONDS = 60
+ALIBABA_OFFICIAL_CATALOG_SUCCESS_TTL_SECONDS = 60 * 10
+ALIBABA_OFFICIAL_CATALOG_FAILURE_TTL_SECONDS = 60
+ALIBABA_OFFICIAL_CATALOG_CACHE_VERSION = "official-video-v1"
+
+_CACHE_NAMESPACE = "inference:model-catalog:v1"
+_SUBSCRIPTION_MODELS_ADAPTER = TypeAdapter(list[ModelInfo])
+
+
+@dataclass(frozen=True)
+class AlibabaOfficialVideoCatalogSnapshot:
+    model_ids: tuple[str, ...]
+    available: bool
+    fingerprint: str
+
+
+def _sha256_hex(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def build_subscription_models_key(provider_key: str, credential: str) -> str:
+    return f"{_CACHE_NAMESPACE}:provider:{provider_key}:{_sha256_hex(credential)}"
+
+
+def build_alibaba_subscription_models_key(
+    credential: str,
+    snapshot_fingerprint: str,
+) -> str:
+    return (
+        f"{_CACHE_NAMESPACE}:provider:alibaba-token-plan:"
+        f"{ALIBABA_OFFICIAL_CATALOG_CACHE_VERSION}:{_sha256_hex(credential)}:"
+        f"{snapshot_fingerprint}"
+    )
+
+
+def _user_available_models_key(user_id: str) -> str:
+    return f"{_CACHE_NAMESPACE}:user:{_sha256_hex(user_id)}"
+
+
+def _alibaba_official_snapshot_key() -> str:
+    return f"{_CACHE_NAMESPACE}:alibaba-official:" f"{ALIBABA_OFFICIAL_CATALOG_CACHE_VERSION}"
+
+
+def _log_cache_failure(cache_kind: str, operation: str, exc: Exception) -> None:
+    logger.warning(
+        "Inference Redis cache %s %s failed (%s).",
+        cache_kind,
+        operation,
+        type(exc).__name__,
+    )
+
+
+async def _read_json(
+    redis_manager: RedisManager | None,
+    *,
+    key: str,
+    cache_kind: str,
+) -> Any | None:
+    if redis_manager is None:
+        return None
+    try:
+        payload = await redis_manager.client.get(key)
+        if payload is None:
+            return None
+        return json.loads(payload)
+    except Exception as exc:
+        _log_cache_failure(cache_kind, "GET", exc)
+        return None
+
+
+async def _write_json(
+    redis_manager: RedisManager | None,
+    *,
+    key: str,
+    value: Any,
+    ttl_seconds: int,
+    cache_kind: str,
+) -> None:
+    if redis_manager is None:
+        return
+    try:
+        await redis_manager.client.set(
+            key,
+            json.dumps(value),
+            ex=ttl_seconds,
+        )
+    except Exception as exc:
+        _log_cache_failure(cache_kind, "SET", exc)
+
+
+async def read_subscription_models(
+    redis_manager: RedisManager | None,
+    cache_key: str,
+) -> list[ModelInfo] | None:
+    payload = await _read_json(
+        redis_manager,
+        key=cache_key,
+        cache_kind="subscription models",
+    )
+    if payload is None:
+        return None
+    try:
+        return _SUBSCRIPTION_MODELS_ADAPTER.validate_python(payload)
+    except Exception as exc:
+        _log_cache_failure("subscription models", "validation", exc)
+        return None
+
+
+async def write_subscription_models(
+    redis_manager: RedisManager | None,
+    cache_key: str,
+    models: list[ModelInfo],
+) -> None:
+    await _write_json(
+        redis_manager,
+        key=cache_key,
+        value=[model.model_dump(mode="json") for model in models],
+        ttl_seconds=SUBSCRIPTION_MODEL_CACHE_TTL_SECONDS,
+        cache_kind="subscription models",
+    )
+
+
+async def read_user_available_models(
+    redis_manager: RedisManager | None,
+    user_id: str,
+) -> ResponseModel | None:
+    payload = await _read_json(
+        redis_manager,
+        key=_user_available_models_key(user_id),
+        cache_kind="user models",
+    )
+    if payload is None:
+        return None
+    try:
+        return ResponseModel.model_validate(payload)
+    except Exception as exc:
+        _log_cache_failure("user models", "validation", exc)
+        return None
+
+
+async def write_user_available_models(
+    redis_manager: RedisManager | None,
+    user_id: str,
+    response: ResponseModel,
+) -> None:
+    await _write_json(
+        redis_manager,
+        key=_user_available_models_key(user_id),
+        value=response.model_dump(mode="json"),
+        ttl_seconds=USER_AVAILABLE_MODELS_CACHE_TTL_SECONDS,
+        cache_kind="user models",
+    )
+
+
+async def delete_user_available_models(
+    redis_manager: RedisManager | None,
+    user_id: str,
+) -> None:
+    if redis_manager is None:
+        return
+    try:
+        await redis_manager.client.delete(_user_available_models_key(user_id))
+    except Exception as exc:
+        _log_cache_failure("user models", "DEL", exc)
+
+
+async def read_alibaba_official_snapshot(
+    redis_manager: RedisManager | None,
+) -> AlibabaOfficialVideoCatalogSnapshot | None:
+    payload = await _read_json(
+        redis_manager,
+        key=_alibaba_official_snapshot_key(),
+        cache_kind="Alibaba official snapshot",
+    )
+    if payload is None:
+        return None
+    try:
+        if not isinstance(payload, dict):
+            raise TypeError("snapshot must be an object")
+        model_ids = payload.get("model_ids")
+        available = payload.get("available")
+        fingerprint = payload.get("fingerprint")
+        if not isinstance(model_ids, list) or not all(
+            isinstance(model_id, str) for model_id in model_ids
+        ):
+            raise TypeError("model_ids must be strings")
+        if not isinstance(available, bool):
+            raise TypeError("available must be boolean")
+        if not isinstance(fingerprint, str):
+            raise TypeError("fingerprint must be a string")
+        return AlibabaOfficialVideoCatalogSnapshot(
+            model_ids=tuple(model_ids),
+            available=available,
+            fingerprint=fingerprint,
+        )
+    except Exception as exc:
+        _log_cache_failure("Alibaba official snapshot", "validation", exc)
+        return None
+
+
+async def write_alibaba_official_snapshot(
+    redis_manager: RedisManager | None,
+    snapshot: AlibabaOfficialVideoCatalogSnapshot,
+) -> None:
+    ttl_seconds = (
+        ALIBABA_OFFICIAL_CATALOG_SUCCESS_TTL_SECONDS
+        if snapshot.available
+        else ALIBABA_OFFICIAL_CATALOG_FAILURE_TTL_SECONDS
+    )
+    await _write_json(
+        redis_manager,
+        key=_alibaba_official_snapshot_key(),
+        value={
+            "model_ids": list(snapshot.model_ids),
+            "available": snapshot.available,
+            "fingerprint": snapshot.fingerprint,
+        },
+        ttl_seconds=ttl_seconds,
+        cache_kind="Alibaba official snapshot",
+    )

--- a/api/app/services/rate_limit.py
+++ b/api/app/services/rate_limit.py
@@ -1,4 +1,20 @@
+import os
+from urllib.parse import quote
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address)
+
+def build_redis_storage_uri(host: str, port: int, password: str | None) -> str:
+    credentials = f":{quote(password, safe='')}@" if password is not None else ""
+    return f"redis://{credentials}{host}:{port}"
+
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    storage_uri=build_redis_storage_uri(
+        host=os.getenv("REDIS_HOST", "localhost"),
+        port=int(os.getenv("REDIS_PORT", "6379")),
+        password=os.getenv("REDIS_PASSWORD"),
+    ),
+)

--- a/api/app/services/tools/image_generation.py
+++ b/api/app/services/tools/image_generation.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -10,7 +11,11 @@ from fastapi import HTTPException
 from models.inference import InferenceProviderEnum
 from services.file_encoding import encode_file_as_data_uri
 from services.files import get_user_storage_path, save_file_to_disk
-from services.image_playground.generated_files import create_generated_video_file
+from services.image_playground.generated_files import (
+    create_completed_generation_job,
+    create_generated_video_file,
+    measure_image_dimensions,
+)
 from services.inference import get_request_inference_credentials, resolve_model_provider
 from services.provider_image_generation import (
     ImageGenerationProviderError,
@@ -313,6 +318,7 @@ async def generate_image(arguments: dict, req) -> dict:
 
     if not prompt:
         return {"error": "Prompt is required for image generation."}
+    prompt = str(prompt)
 
     message_content = await _build_image_content_payload(
         arguments,
@@ -326,6 +332,7 @@ async def generate_image(arguments: dict, req) -> dict:
 
     try:
         credentials = await get_request_inference_credentials(req)
+        generation_started_at = datetime.now(timezone.utc)
         generated_image = await generate_image_with_provider(
             credentials=credentials,
             model=model,
@@ -362,6 +369,24 @@ async def generate_image(arguments: dict, req) -> dict:
             content_type=f"image/{generated_image.extension}",
             hash=hashlib.sha256(generated_image.image_bytes).hexdigest(),
         )
+        actual_width, actual_height, actual_aspect_ratio = measure_image_dimensions(
+            generated_image.image_bytes
+        )
+        await create_completed_generation_job(
+            pg_engine=pg_engine,
+            user_id=user_id,
+            file_id=new_file.id,
+            prompt=prompt,
+            model=generated_image.model,
+            media_type="image",
+            aspect_ratio=aspect_ratio,
+            resolution=resolution,
+            source_image_ids=source_image_ids,
+            generation_started_at=generation_started_at,
+            actual_width=actual_width,
+            actual_height=actual_height,
+            actual_aspect_ratio=actual_aspect_ratio,
+        )
 
         return {
             "success": True,
@@ -395,6 +420,7 @@ async def generate_video(arguments: dict, req) -> dict:
 
     if not prompt:
         return {"error": "Prompt is required for video generation."}
+    prompt = str(prompt)
     if duration is not None:
         try:
             duration = int(duration)
@@ -415,6 +441,7 @@ async def generate_video(arguments: dict, req) -> dict:
 
     try:
         credentials = await get_request_inference_credentials(req)
+        generation_started_at = datetime.now(timezone.utc)
         generated_video = await generate_video_with_provider(
             credentials=credentials,
             model=model,
@@ -434,6 +461,20 @@ async def generate_video(arguments: dict, req) -> dict:
             source_image_ids=source_image_ids,
             video_bytes=generated_video.video_bytes,
             extension=generated_video.extension,
+        )
+        await create_completed_generation_job(
+            pg_engine=pg_engine,
+            user_id=user_id,
+            file_id=new_file.id,
+            prompt=prompt,
+            model=generated_video.model,
+            media_type="video",
+            aspect_ratio=aspect_ratio,
+            resolution=resolution,
+            source_image_ids=source_image_ids,
+            generation_started_at=generation_started_at,
+            duration=duration,
+            generate_audio=generate_audio,
         )
 
         return {

--- a/api/app/services/websocket_broker.py
+++ b/api/app/services/websocket_broker.py
@@ -1,0 +1,192 @@
+import asyncio
+import hashlib
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Annotated, Any, Literal
+
+from database.redis.redis_ops import RedisManager
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+
+logger = logging.getLogger("uvicorn.error")
+
+WEBSOCKET_BROKER_CHANNEL = "meridian:websocket:v1"
+_ORIGIN_PATTERN = r"^[0-9a-f]{32}$"
+_TARGET_PATTERN = r"^[0-9a-f]{64}$"
+_MAX_RECONNECT_DELAY_SECONDS = 30
+
+Origin = Annotated[str, Field(pattern=_ORIGIN_PATTERN)]
+Target = Annotated[str, Field(pattern=_TARGET_PATTERN)]
+UserEventCallback = Callable[[str, dict[str, Any]], Awaitable[None]]
+TaskCancelCallback = Callable[[str, str], Awaitable[None]]
+SleepCallback = Callable[[float], Awaitable[None]]
+
+
+class UserEventEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    version: Literal[1]
+    kind: Literal["user_event"]
+    origin: Origin
+    user_target: Target
+    message: dict[str, Any]
+
+
+class TaskCancelEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    version: Literal[1]
+    kind: Literal["task_cancel"]
+    origin: Origin
+    user_target: Target
+    task_target: Target
+
+
+BrokerEnvelope = Annotated[UserEventEnvelope | TaskCancelEnvelope, Field(discriminator="kind")]
+_ENVELOPE_ADAPTER: TypeAdapter[BrokerEnvelope] = TypeAdapter(BrokerEnvelope)
+
+
+def hash_broker_target(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class RedisWebSocketBroker:
+    def __init__(
+        self,
+        redis_manager: RedisManager,
+        on_user_event: UserEventCallback,
+        on_task_cancel: TaskCancelCallback,
+        sleep: SleepCallback = asyncio.sleep,
+    ) -> None:
+        self._redis_client = redis_manager.client
+        self._on_user_event = on_user_event
+        self._on_task_cancel = on_task_cancel
+        self._sleep = sleep
+        self._origin = uuid.uuid4().hex
+        self._listener_task: asyncio.Task[None] | None = None
+        self._pubsub: Any | None = None
+        self._first_attempt_complete = asyncio.Event()
+        self._closing = False
+
+    @property
+    def origin(self) -> str:
+        return self._origin
+
+    async def start(self) -> None:
+        if self._listener_task is None:
+            self._listener_task = asyncio.create_task(
+                self._listen_forever(), name="redis_websocket_broker"
+            )
+        await self._first_attempt_complete.wait()
+
+    async def publish_user_event(self, user_target: str, message: dict[str, Any]) -> None:
+        envelope = UserEventEnvelope(
+            version=1,
+            kind="user_event",
+            origin=self._origin,
+            user_target=user_target,
+            message=message,
+        )
+        await self._publish(envelope)
+
+    async def publish_task_cancel(self, user_target: str, task_target: str) -> None:
+        envelope = TaskCancelEnvelope(
+            version=1,
+            kind="task_cancel",
+            origin=self._origin,
+            user_target=user_target,
+            task_target=task_target,
+        )
+        await self._publish(envelope)
+
+    async def _publish(self, envelope: UserEventEnvelope | TaskCancelEnvelope) -> None:
+        try:
+            await self._redis_client.publish(WEBSOCKET_BROKER_CHANNEL, envelope.model_dump_json())
+        except Exception as exc:
+            logger.warning("WebSocket broker publish failed (%s)", type(exc).__name__)
+
+    async def _listen_forever(self) -> None:
+        reconnect_delay = 1
+        while not self._closing:
+            pubsub = None
+            try:
+                pubsub = self._redis_client.pubsub()
+                self._pubsub = pubsub
+                await pubsub.subscribe(WEBSOCKET_BROKER_CHANNEL)
+
+                async for frame in pubsub.listen():
+                    if self._is_subscription_ack(frame):
+                        reconnect_delay = 1
+                        self._first_attempt_complete.set()
+                    elif self._is_message(frame):
+                        await self._dispatch(frame.get("data"))
+
+                if not self._closing:
+                    raise ConnectionError("WebSocket broker listener ended")
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("WebSocket broker listen failed (%s)", type(exc).__name__)
+                self._first_attempt_complete.set()
+            finally:
+                if pubsub is not None:
+                    try:
+                        await pubsub.close()
+                    except Exception as exc:
+                        logger.warning("WebSocket broker close failed (%s)", type(exc).__name__)
+                if self._pubsub is pubsub:
+                    self._pubsub = None
+
+            if not self._closing:
+                await self._sleep(reconnect_delay)
+                reconnect_delay = min(reconnect_delay * 2, _MAX_RECONNECT_DELAY_SECONDS)
+
+    @staticmethod
+    def _is_subscription_ack(frame: Any) -> bool:
+        return (
+            isinstance(frame, dict)
+            and frame.get("type") == "subscribe"
+            and frame.get("channel") == WEBSOCKET_BROKER_CHANNEL
+        )
+
+    @staticmethod
+    def _is_message(frame: Any) -> bool:
+        return (
+            isinstance(frame, dict)
+            and frame.get("type") == "message"
+            and frame.get("channel") == WEBSOCKET_BROKER_CHANNEL
+        )
+
+    async def _dispatch(self, raw_data: Any) -> None:
+        if not isinstance(raw_data, (str, bytes, bytearray)):
+            return
+
+        try:
+            envelope = _ENVELOPE_ADAPTER.validate_json(raw_data)
+        except (ValidationError, ValueError, TypeError):
+            logger.warning("WebSocket broker dropped invalid envelope")
+            return
+
+        if envelope.origin == self._origin:
+            return
+
+        try:
+            if isinstance(envelope, UserEventEnvelope):
+                await self._on_user_event(envelope.user_target, envelope.message)
+            else:
+                await self._on_task_cancel(envelope.user_target, envelope.task_target)
+        except Exception as exc:
+            logger.warning(
+                "WebSocket broker callback failed for %s (%s)",
+                envelope.kind,
+                type(exc).__name__,
+            )
+
+    async def close(self) -> None:
+        self._closing = True
+        task = self._listener_task
+        self._listener_task = None
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        self._pubsub = None

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -25,4 +25,4 @@ numpy
 opencv-python-headless
 httpx[http2]
 claude-agent-sdk==0.1.58
-github-copilot-sdk==0.2.3
+github-copilot-sdk==1.0.8

--- a/api/run-dev.sh
+++ b/api/run-dev.sh
@@ -40,7 +40,9 @@ esac
 
 cd "${APP_DIR}"
 
-exec "${SCRIPT_DIR}/venv/bin/uvicorn" main:app \
+exec "${SCRIPT_DIR}/venv/bin/uvicorn" \
+    --env-file "${SCRIPT_DIR}/../docker/env/.env.local" \
+    main:app \
     --host 0.0.0.0 \
     --port "${API_PORT:-8000}" \
     --reload \

--- a/api/tests/test_alibaba_token_plan.py
+++ b/api/tests/test_alibaba_token_plan.py
@@ -50,7 +50,7 @@ stub_modules["services.github_copilot"].validate_github_copilot_token = AsyncMoc
 stub_modules["services.inference"].get_inference_provider_statuses = AsyncMock(  # type: ignore[attr-defined]
     return_value=[]
 )
-stub_modules["services.inference"].invalidate_user_available_models_cache = MagicMock()  # type: ignore[attr-defined]
+stub_modules["services.inference"].invalidate_user_available_models_cache = AsyncMock()  # type: ignore[attr-defined]
 stub_modules["services.openai_codex"].complete_openai_codex_device_oauth = AsyncMock()  # type: ignore[attr-defined]
 stub_modules["services.openai_codex"].start_openai_codex_device_oauth = AsyncMock()  # type: ignore[attr-defined]
 stub_modules["services.openai_codex"].validate_openai_codex_oauth_auth_json = AsyncMock()  # type: ignore[attr-defined]
@@ -369,7 +369,7 @@ def test_connect_route_validates_encrypts_stores_then_invalidates() -> None:
         assert args[2:] == (ALIBABA_TOKEN_PLAN_PROVIDER_KEY, "encrypted")
         events.append("store")
 
-    def invalidate(*args: object) -> None:
+    async def invalidate(*args: object) -> None:
         events.append("invalidate")
 
     with (
@@ -418,7 +418,7 @@ def test_connect_route_does_not_store_failed_validation() -> None:
 def test_disconnect_route_deletes_token_and_invalidates_cache() -> None:
     request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(pg_engine=MagicMock())))
     delete = AsyncMock()
-    invalidate = MagicMock()
+    invalidate = AsyncMock()
     with (
         patch("routers.inference_providers.delete_provider_token", new=delete),
         patch(
@@ -433,5 +433,5 @@ def test_disconnect_route_deletes_token_and_invalidates_cache() -> None:
         "user-1",
         ALIBABA_TOKEN_PLAN_PROVIDER_KEY,
     )
-    invalidate.assert_called_once_with(request.app, "user-1")
+    invalidate.assert_awaited_once_with(request.app, "user-1")
     assert result == {"message": "Alibaba Personal Token Plan disconnected successfully."}

--- a/api/tests/test_alibaba_token_plan_catalog.py
+++ b/api/tests/test_alibaba_token_plan_catalog.py
@@ -11,12 +11,12 @@ from fastapi import FastAPI
 sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
 
 import services.inference as inference
+import services.inference_cache as inference_cache
 import services.providers.alibaba_token_plan_official_catalog as official_catalog
 from models.inference import Architecture, ModelInfo, Pricing, ResponseModel
 from services.inference import get_alibaba_token_plan_models_safe
 from services.model_catalog import encode_model_catalog
 from services.providers.alibaba_token_plan_catalog import (
-    ALIBABA_TOKEN_PLAN_PROVIDER_KEY,
     build_alibaba_token_plan_models_from_models_dev,
 )
 from services.providers.alibaba_token_plan_official_catalog import (
@@ -25,6 +25,37 @@ from services.providers.alibaba_token_plan_official_catalog import (
     fetch_alibaba_token_plan_official_video_model_ids,
     parse_alibaba_token_plan_official_video_model_ids,
 )
+
+
+class _ExpiringFakeRedis:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.values: dict[str, str] = {}
+        self.expires_at: dict[str, float] = {}
+        self.set_calls: list[tuple[str, int | None]] = []
+        self.delete_calls: list[str] = []
+
+    async def get(self, key: str) -> str | None:
+        expires_at = self.expires_at.get(key)
+        if expires_at is not None and self.now >= expires_at:
+            self.values.pop(key, None)
+            self.expires_at.pop(key, None)
+        return self.values.get(key)
+
+    async def set(self, key: str, value: str, *, ex: int | None = None) -> None:
+        self.values[key] = value
+        if ex is not None:
+            self.expires_at[key] = self.now + ex
+        self.set_calls.append((key, ex))
+
+    async def delete(self, key: str) -> None:
+        self.values.pop(key, None)
+        self.expires_at.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def _redis_manager(redis: _ExpiringFakeRedis) -> SimpleNamespace:
+    return SimpleNamespace(client=redis)
 
 
 def _official_html(*rows: str) -> bytes:
@@ -259,39 +290,48 @@ def test_alibaba_token_plan_live_failure_preserves_official_video(caplog: pytest
 
 
 def test_alibaba_token_plan_official_cache_ttls_and_failed_refresh_drop_stale(
-    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ):
-    app = SimpleNamespace(state=SimpleNamespace(http_client=object()))
-    clock = [100.0]
-    fetch = AsyncMock(return_value=["happyhorse-first-t2v"])
-    monkeypatch.setattr(inference.time, "monotonic", lambda: clock[0])
+    async def run() -> tuple[object, object, object, object, object, AsyncMock, _ExpiringFakeRedis]:
+        redis = _ExpiringFakeRedis()
+        first_app = SimpleNamespace(
+            state=SimpleNamespace(http_client=object(), redis_manager=_redis_manager(redis))
+        )
+        second_app = SimpleNamespace(
+            state=SimpleNamespace(http_client=object(), redis_manager=_redis_manager(redis))
+        )
+        fetch = AsyncMock(return_value=["happyhorse-first-t2v"])
 
-    with patch(
-        "services.inference.fetch_alibaba_token_plan_official_video_model_ids",
-        new=fetch,
-    ):
-        first = asyncio.run(inference._get_alibaba_official_video_catalog_snapshot(app))
-        clock[0] += 599
-        reused = asyncio.run(inference._get_alibaba_official_video_catalog_snapshot(app))
-        fetch.side_effect = RuntimeError("sentinel-body")
-        clock[0] += 2
-        unavailable = asyncio.run(inference._get_alibaba_official_video_catalog_snapshot(app))
-        clock[0] += 59
-        reused_failure = asyncio.run(inference._get_alibaba_official_video_catalog_snapshot(app))
-        fetch.side_effect = None
-        fetch.return_value = ["happyhorse-recovered-i2v"]
-        clock[0] += 2
-        recovered = asyncio.run(inference._get_alibaba_official_video_catalog_snapshot(app))
+        with patch(
+            "services.inference.fetch_alibaba_token_plan_official_video_model_ids",
+            new=fetch,
+        ):
+            first = await inference._get_alibaba_official_video_catalog_snapshot(first_app)
+            redis.now += 599
+            reused = await inference._get_alibaba_official_video_catalog_snapshot(second_app)
+            fetch.side_effect = RuntimeError("sentinel-body")
+            redis.now += 2
+            unavailable = await inference._get_alibaba_official_video_catalog_snapshot(second_app)
+            redis.now += 59
+            reused_failure = await inference._get_alibaba_official_video_catalog_snapshot(first_app)
+            fetch.side_effect = None
+            fetch.return_value = ["happyhorse-recovered-i2v"]
+            redis.now += 2
+            recovered = await inference._get_alibaba_official_video_catalog_snapshot(first_app)
+        return first, reused, unavailable, reused_failure, recovered, fetch, redis
 
-    assert first is reused
+    first, reused, unavailable, reused_failure, recovered, fetch, redis = asyncio.run(run())
+
+    assert first == reused
     assert first.available is True
-    assert unavailable is reused_failure
+    assert unavailable == reused_failure
     assert unavailable.available is False
     assert unavailable.model_ids == ()
     assert first.fingerprint != unavailable.fingerprint != recovered.fingerprint
     assert recovered.model_ids == ("happyhorse-recovered-i2v",)
     assert fetch.await_count == 3
+    snapshot_key = "inference:model-catalog:v1:alibaba-official:official-video-v1"
+    assert redis.set_calls == [(snapshot_key, 600), (snapshot_key, 60), (snapshot_key, 600)]
     assert "sentinel-body" not in caplog.text
 
 
@@ -333,64 +373,60 @@ def test_alibaba_token_plan_official_cache_shields_shared_inflight_and_cancellat
     assert asyncio.run(run()) == (1, ("happyhorse-shared-t2v",))
 
 
-def test_alibaba_token_plan_snapshot_fingerprint_versions_and_prunes_provider_cache():
-    app = FastAPI()
-    app.state.http_client = object()
-    app.state.models_dev_catalog = None
-    legacy_key = inference._build_subscription_model_cache_key(
-        ALIBABA_TOKEN_PLAN_PROVIDER_KEY,
-        "credential-a",
-    )
-    app.state.subscription_provider_model_cache = {
-        legacy_key: (0.0, [_model("alibaba-token-plan/stale-image")]),
-        "unrelated:key": (0.0, [_model("unrelated/model")]),
-    }
-    loader = AsyncMock(return_value=[_model("alibaba-token-plan/happyhorse-current-t2v")])
-    official_fetch = AsyncMock(return_value=["happyhorse-current-t2v"])
-
-    with (
-        patch(
-            "services.inference.fetch_alibaba_token_plan_official_video_model_ids",
-            new=official_fetch,
-        ),
-        patch("services.inference.get_alibaba_token_plan_models_safe", new=loader),
+def test_alibaba_token_plan_snapshot_fingerprint_versions_provider_cache_without_scans():
+    async def run() -> (
+        tuple[list[ModelInfo], list[ModelInfo], AsyncMock, AsyncMock, _ExpiringFakeRedis]
     ):
-        models = asyncio.run(
-            inference._get_cached_alibaba_token_plan_models(
+        redis = _ExpiringFakeRedis()
+        app = FastAPI()
+        app.state.http_client = object()
+        app.state.models_dev_catalog = None
+        app.state.redis_manager = _redis_manager(redis)
+        loader = AsyncMock(return_value=[_model("alibaba-token-plan/happyhorse-current-t2v")])
+        official_fetch = AsyncMock(return_value=["happyhorse-current-t2v"])
+
+        with (
+            patch(
+                "services.inference.fetch_alibaba_token_plan_official_video_model_ids",
+                new=official_fetch,
+            ),
+            patch("services.inference.get_alibaba_token_plan_models_safe", new=loader),
+        ):
+            models = await inference._get_cached_alibaba_token_plan_models(
                 app,
                 api_key="credential-a",
             )
-        )
-        asyncio.run(
-            inference._get_cached_alibaba_token_plan_models(
+            await inference._get_cached_alibaba_token_plan_models(
                 app,
                 api_key="credential-b",
             )
-        )
-        app.state.alibaba_token_plan_official_video_catalog_cache = (
-            inference._build_alibaba_official_snapshot(
+            changed_snapshot = inference._build_alibaba_official_snapshot(
                 ["happyhorse-changed-i2v"],
                 available=True,
             )
-        )
-        loader.return_value = [_model("alibaba-token-plan/happyhorse-changed-i2v")]
-        changed_models = asyncio.run(
-            inference._get_cached_alibaba_token_plan_models(
+            await inference_cache.write_alibaba_official_snapshot(
+                app.state.redis_manager,
+                changed_snapshot,
+            )
+            loader.return_value = [_model("alibaba-token-plan/happyhorse-changed-i2v")]
+            changed_models = await inference._get_cached_alibaba_token_plan_models(
                 app,
                 api_key="credential-a",
             )
-        )
+        return models, changed_models, loader, official_fetch, redis
+
+    models, changed_models, loader, official_fetch, redis = asyncio.run(run())
 
     assert [model.id for model in models] == ["alibaba-token-plan/happyhorse-current-t2v"]
-    assert legacy_key not in app.state.subscription_provider_model_cache
-    assert "unrelated:key" in app.state.subscription_provider_model_cache
     alibaba_keys = [
         key
-        for key in app.state.subscription_provider_model_cache
-        if key.startswith(f"{ALIBABA_TOKEN_PLAN_PROVIDER_KEY}:")
+        for key in redis.values
+        if key.startswith(
+            "inference:model-catalog:v1:provider:alibaba-token-plan:official-video-v1:"
+        )
     ]
-    assert len(alibaba_keys) == 1
-    assert all("official-video-v1" in key for key in alibaba_keys)
+    assert len(alibaba_keys) == 3
+    assert not redis.delete_calls
     assert [model.id for model in changed_models] == ["alibaba-token-plan/happyhorse-changed-i2v"]
     assert official_fetch.await_count == 1
     assert loader.await_count == 3

--- a/api/tests/test_connection_manager.py
+++ b/api/tests/test_connection_manager.py
@@ -1,0 +1,380 @@
+import asyncio
+import json
+import logging
+import sys
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
+
+from services.connection_manager import ConnectionManager
+from services.websocket_broker import (
+    WEBSOCKET_BROKER_CHANNEL,
+    RedisWebSocketBroker,
+    hash_broker_target,
+)
+
+
+class FakeWebSocket:
+    def __init__(self) -> None:
+        self.accepted = False
+        self.messages: list[dict[str, Any]] = []
+        self.message_sent = asyncio.Event()
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_json(self, message: dict[str, Any]) -> None:
+        self.messages.append(json.loads(json.dumps(message)))
+        self.message_sent.set()
+
+
+class FakeRedisBackend:
+    def __init__(self) -> None:
+        self.pubsubs: list[FakePubSub] = []
+        self.published: list[tuple[str, str]] = []
+        self.fail_publish = False
+
+    async def publish(self, channel: str, payload: str) -> int:
+        if self.fail_publish:
+            raise ConnectionError("raw-user raw-node broker-body")
+        self.published.append((channel, payload))
+        subscribers = [pubsub for pubsub in self.pubsubs if pubsub.subscribed and not pubsub.closed]
+        for pubsub in subscribers:
+            await pubsub.frames.put({"type": "message", "channel": channel, "data": payload})
+        return len(subscribers)
+
+
+class FakePubSub:
+    def __init__(self, backend: FakeRedisBackend, auto_ack: bool = True) -> None:
+        self.backend = backend
+        self.auto_ack = auto_ack
+        self.frames: asyncio.Queue[Any] = asyncio.Queue()
+        self.subscribed = False
+        self.closed = False
+        self.subscribe_called = asyncio.Event()
+        self._consumed = 0
+        self._consumed_changed = asyncio.Condition()
+        backend.pubsubs.append(self)
+
+    async def subscribe(self, channel: str) -> None:
+        self.subscribed = True
+        self.subscribe_called.set()
+        if self.auto_ack:
+            await self.acknowledge(channel)
+
+    async def acknowledge(self, channel: str = WEBSOCKET_BROKER_CHANNEL) -> None:
+        await self.frames.put({"type": "subscribe", "channel": channel, "data": 1})
+
+    async def listen(self) -> AsyncIterator[Any]:
+        while True:
+            frame = await self.frames.get()
+            if isinstance(frame, BaseException):
+                raise frame
+            yield frame
+            async with self._consumed_changed:
+                self._consumed += 1
+                self._consumed_changed.notify_all()
+
+    async def wait_consumed(self, count: int) -> None:
+        async with self._consumed_changed:
+            await self._consumed_changed.wait_for(lambda: self._consumed >= count)
+
+    async def close(self) -> None:
+        self.closed = True
+        self.subscribed = False
+
+
+class FakeRedisClient:
+    def __init__(self, backend: FakeRedisBackend, *, auto_ack: bool = True) -> None:
+        self.backend = backend
+        self.auto_ack = auto_ack
+        self.pubsub_failures = 0
+        self.pubsub_created = asyncio.Event()
+
+    def pubsub(self) -> FakePubSub:
+        if self.pubsub_failures:
+            self.pubsub_failures -= 1
+            raise ConnectionError("raw-user raw-node broker-body")
+        pubsub = FakePubSub(self.backend, auto_ack=self.auto_ack)
+        self.pubsub_created.set()
+        return pubsub
+
+    async def publish(self, channel: str, payload: str) -> int:
+        return await self.backend.publish(channel, payload)
+
+
+def redis_manager(client: FakeRedisClient) -> Any:
+    return SimpleNamespace(client=client)
+
+
+async def close_managers(managers: list[ConnectionManager]) -> None:
+    await asyncio.gather(*(manager.close() for manager in managers))
+
+
+def test_websocket_broker_waits_for_subscription_ack_and_closes() -> None:
+    async def scenario() -> None:
+        backend = FakeRedisBackend()
+        client = FakeRedisClient(backend, auto_ack=False)
+
+        async def on_user_event(_user_target: str, _message: dict[str, Any]) -> None:
+            pass
+
+        async def on_task_cancel(_user_target: str, _task_target: str) -> None:
+            pass
+
+        broker = RedisWebSocketBroker(redis_manager(client), on_user_event, on_task_cancel)
+        start_task = asyncio.create_task(broker.start())
+        await client.pubsub_created.wait()
+        pubsub = backend.pubsubs[0]
+        await pubsub.subscribe_called.wait()
+        assert not start_task.done()
+
+        await pubsub.acknowledge()
+        await start_task
+        await broker.close()
+
+        assert pubsub.closed
+        assert broker._listener_task is None
+
+    asyncio.run(scenario())
+
+
+def test_websocket_broker_validates_frames_and_continues() -> None:
+    async def scenario() -> None:
+        backend = FakeRedisBackend()
+        client = FakeRedisClient(backend)
+        received: list[tuple[str, dict[str, Any]]] = []
+        received_event = asyncio.Event()
+        callback_failed = asyncio.Event()
+
+        async def on_user_event(user_target: str, message: dict[str, Any]) -> None:
+            if message.get("type") == "callback_failure":
+                callback_failed.set()
+                raise RuntimeError("broker-body")
+            received.append((user_target, message))
+            received_event.set()
+
+        async def on_task_cancel(_user_target: str, _task_target: str) -> None:
+            raise AssertionError("unexpected cancellation")
+
+        broker = RedisWebSocketBroker(redis_manager(client), on_user_event, on_task_cancel)
+        await broker.start()
+        target = hash_broker_target("user-1")
+        invalid_payloads = [
+            "not-json",
+            json.dumps({"version": 2, "kind": "user_event"}),
+            json.dumps(
+                {
+                    "version": 1,
+                    "kind": "user_event",
+                    "origin": "f" * 32,
+                    "user_target": target,
+                    "message": {},
+                    "extra": True,
+                }
+            ),
+        ]
+        for payload in invalid_payloads:
+            await backend.publish(WEBSOCKET_BROKER_CHANNEL, payload)
+        await backend.publish(
+            WEBSOCKET_BROKER_CHANNEL,
+            json.dumps(
+                {
+                    "version": 1,
+                    "kind": "user_event",
+                    "origin": "f" * 32,
+                    "user_target": target,
+                    "message": {"type": "callback_failure"},
+                }
+            ),
+        )
+        await backend.publish(
+            WEBSOCKET_BROKER_CHANNEL,
+            json.dumps(
+                {
+                    "version": 1,
+                    "kind": "user_event",
+                    "origin": "f" * 32,
+                    "user_target": target,
+                    "message": {"type": "node_data_replace", "payload": {"name": "é"}},
+                }
+            ),
+        )
+
+        await callback_failed.wait()
+        await received_event.wait()
+        assert received == [(target, {"type": "node_data_replace", "payload": {"name": "é"}})]
+        await broker.close()
+
+    asyncio.run(scenario())
+
+
+def test_websocket_broker_start_failure_is_ready_and_reconnects() -> None:
+    async def scenario() -> None:
+        backend = FakeRedisBackend()
+        client = FakeRedisClient(backend)
+        client.pubsub_failures = 1
+        backoff_started = asyncio.Event()
+        release_backoff = asyncio.Event()
+        delays: list[float] = []
+
+        async def controlled_sleep(delay: float) -> None:
+            delays.append(delay)
+            backoff_started.set()
+            await release_backoff.wait()
+
+        async def on_user_event(_user_target: str, _message: dict[str, Any]) -> None:
+            pass
+
+        async def on_task_cancel(_user_target: str, _task_target: str) -> None:
+            pass
+
+        broker = RedisWebSocketBroker(
+            redis_manager(client), on_user_event, on_task_cancel, sleep=controlled_sleep
+        )
+        await broker.start()
+        await backoff_started.wait()
+        assert delays == [1]
+
+        release_backoff.set()
+        await client.pubsub_created.wait()
+        pubsub = backend.pubsubs[0]
+        await pubsub.wait_consumed(1)
+        assert pubsub.subscribed
+
+        await broker.close()
+        assert pubsub.closed
+
+    asyncio.run(scenario())
+
+
+def test_connection_manager_four_worker_fanout_is_exact_and_isolated() -> None:
+    async def scenario() -> None:
+        backend = FakeRedisBackend()
+        managers = [ConnectionManager() for _ in range(4)]
+        clients = [FakeRedisClient(backend) for _ in managers]
+        for manager, client in zip(managers, clients):
+            await manager.start(redis_manager(client))
+        await managers[0].start(redis_manager(clients[0]))
+        assert len(backend.pubsubs) == 4
+
+        sockets = [FakeWebSocket() for _ in range(6)]
+        await managers[0].connect(sockets[0], "client-0", "target-user")
+        await managers[0].connect(sockets[1], "client-1", "target-user")
+        await managers[1].connect(sockets[2], "client-2", "target-user")
+        await managers[2].connect(sockets[3], "client-3", "other-user")
+        await managers[3].connect(sockets[4], "client-4", "target-user")
+        await managers[3].connect(sockets[5], "client-5", None)
+
+        message = {
+            "type": "image_generation_job_update",
+            "payload": {"prompt": "draw 🌊", "source_image_ids": ["one", "two"]},
+        }
+        await managers[0].send_to_user("target-user", message)
+        await asyncio.gather(
+            sockets[0].message_sent.wait(),
+            sockets[1].message_sent.wait(),
+            sockets[2].message_sent.wait(),
+            sockets[4].message_sent.wait(),
+        )
+        await asyncio.gather(*(pubsub.wait_consumed(2) for pubsub in backend.pubsubs))
+
+        for socket in (sockets[0], sockets[1], sockets[2], sockets[4]):
+            assert socket.messages == [message]
+        assert sockets[3].messages == []
+        assert sockets[5].messages == []
+
+        assert len(backend.published) == 1
+        channel, raw_envelope = backend.published[0]
+        envelope = json.loads(raw_envelope)
+        assert channel == WEBSOCKET_BROKER_CHANNEL
+        assert envelope["message"] == message
+        assert envelope["user_target"] == hash_broker_target("target-user")
+        assert "target-user" not in raw_envelope
+
+        await close_managers(managers)
+        assert all(pubsub.closed for pubsub in backend.pubsubs)
+
+    asyncio.run(scenario())
+
+
+def test_connection_manager_routes_remote_cancellation_and_removes_task() -> None:
+    async def scenario() -> None:
+        backend = FakeRedisBackend()
+        owner = ConnectionManager()
+        caller = ConnectionManager()
+        await owner.start(redis_manager(FakeRedisClient(backend)))
+        await caller.start(redis_manager(FakeRedisClient(backend)))
+        running = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def stream() -> None:
+            running.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        task = asyncio.create_task(stream())
+        await running.wait()
+        owner.add_task(task, "raw-user", "raw-node")
+
+        assert await caller.cancel_task("raw-user", "raw-node") is False
+        await cancelled.wait()
+        await backend.pubsubs[0].wait_consumed(2)
+
+        assert task.cancelled()
+        assert owner.active_tasks == {}
+        _, raw_envelope = backend.published[0]
+        assert "raw-user" not in raw_envelope
+        assert "raw-node" not in raw_envelope
+        assert json.loads(raw_envelope)["task_target"] == hash_broker_target("raw-node")
+
+        await close_managers([owner, caller])
+
+    asyncio.run(scenario())
+
+
+def test_connection_manager_local_only_and_publish_failure_fall_back(caplog: Any) -> None:
+    async def scenario() -> None:
+        local_manager = ConnectionManager()
+        local_socket = FakeWebSocket()
+        await local_manager.connect(local_socket, "local-client", "user")
+        await local_manager.send_to_user("user", {"type": "local"})
+        assert local_socket.messages == [{"type": "local"}]
+
+        local_task_started = asyncio.Event()
+
+        async def local_stream() -> None:
+            local_task_started.set()
+            await asyncio.Event().wait()
+
+        local_task = asyncio.create_task(local_stream())
+        await local_task_started.wait()
+        local_manager.add_task(local_task, "user", "node")
+        assert await local_manager.cancel_task("user", "node") is True
+        assert local_task.cancelled()
+
+        backend = FakeRedisBackend()
+        manager = ConnectionManager()
+        await manager.start(redis_manager(FakeRedisClient(backend)))
+        socket = FakeWebSocket()
+        await manager.connect(socket, "client", "user")
+        backend.fail_publish = True
+
+        with caplog.at_level(logging.WARNING, logger="uvicorn.error"):
+            await manager.send_to_user("user", {"type": "still-local"})
+        assert socket.messages == [{"type": "still-local"}]
+        assert "ConnectionError" in caplog.text
+        assert "raw-user" not in caplog.text
+        assert "raw-node" not in caplog.text
+        assert "broker-body" not in caplog.text
+        assert "still-local" not in caplog.text
+
+        await close_managers([local_manager, manager])
+
+    asyncio.run(scenario())

--- a/api/tests/test_files_router.py
+++ b/api/tests/test_files_router.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 APP_DIR = Path(__file__).resolve().parents[1] / "app"
 
@@ -24,8 +25,10 @@ from routers.files import (
     bulk_delete_items,
     bulk_move_items,
     upload_file,
+    view_file,
 )
 from services.files import copy_file_system_item
+from services.image_previews import ImagePreviewArtifact
 
 
 def patch_filter_top_level_item_ids(monkeypatch):
@@ -737,3 +740,148 @@ def test_copy_file_system_item_rejects_copy_into_own_subtree(monkeypatch) -> Non
 
     assert exc_info.value.status_code == 400
     assert calls == ["subtree-check"]
+
+
+def _view_file_record(*, content_type: str = "image/png") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        name="source.png",
+        file_path="images/source.png",
+        content_type=content_type,
+        content_hash="source-hash",
+    )
+
+
+def test_view_file_serves_webp_preview_with_private_cache(monkeypatch) -> None:
+    user_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    file_record = _view_file_record()
+    request = SimpleNamespace()
+    calls: list[tuple[object, ...]] = []
+
+    async def fake_get_owned_file_or_404(*args):
+        return file_record
+
+    async def fake_ensure_image_preview(*args):
+        calls.append(args)
+        return ImagePreviewArtifact(path="/cache/source.webp", media_type="image/webp")
+
+    monkeypatch.setattr("routers.files._get_owned_file_or_404", fake_get_owned_file_or_404)
+    monkeypatch.setattr("routers.files.ensure_image_preview", fake_ensure_image_preview)
+
+    response = asyncio.run(
+        view_file(
+            request,
+            file_id,
+            size="160x160",
+            download=False,
+            user_id_str=str(user_id),
+        )
+    )
+
+    assert calls == [(user_id, "images/source.png", "160x160", "source-hash")]
+    assert response.path == "/cache/source.webp"
+    assert response.media_type == "image/webp"
+    assert response.headers["cache-control"] == "private, max-age=31536000"
+    assert response.headers["content-disposition"].startswith("inline;")
+
+
+@pytest.mark.parametrize(
+    ("size", "download", "content_type"),
+    [
+        (None, False, "image/png"),
+        ("160x160", True, "image/png"),
+        ("160x160", False, "application/pdf"),
+    ],
+)
+def test_view_file_preserves_original_for_no_size_download_and_non_image(
+    monkeypatch,
+    size,
+    download: bool,
+    content_type: str,
+) -> None:
+    user_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    file_record = _view_file_record(content_type=content_type)
+
+    async def fake_get_owned_file_or_404(*args):
+        return file_record
+
+    async def fail_preview(*args):
+        raise AssertionError("preview generation must be bypassed")
+
+    monkeypatch.setattr("routers.files._get_owned_file_or_404", fake_get_owned_file_or_404)
+    monkeypatch.setattr("routers.files.ensure_image_preview", fail_preview)
+    monkeypatch.setattr(
+        "routers.files._get_full_file_path",
+        lambda current_user_id, path: f"/original/{path}",
+    )
+
+    response = asyncio.run(
+        view_file(
+            SimpleNamespace(),
+            file_id,
+            size=size,
+            download=download,
+            user_id_str=str(user_id),
+        )
+    )
+
+    assert response.path == "/original/images/source.png"
+    assert response.media_type == content_type
+    assert response.headers["cache-control"] == "private, max-age=31536000"
+    expected_disposition = (
+        "attachment" if download or content_type == "application/pdf" else "inline"
+    )
+    assert response.headers["content-disposition"].startswith(f"{expected_disposition};")
+
+
+def test_view_file_falls_back_to_original_when_preview_render_fails(monkeypatch) -> None:
+    file_record = _view_file_record()
+
+    async def fake_get_owned_file_or_404(*args):
+        return file_record
+
+    async def fake_ensure_image_preview(*args):
+        return None
+
+    monkeypatch.setattr("routers.files._get_owned_file_or_404", fake_get_owned_file_or_404)
+    monkeypatch.setattr("routers.files.ensure_image_preview", fake_ensure_image_preview)
+    monkeypatch.setattr(
+        "routers.files._get_full_file_path", lambda user_id, path: f"/original/{path}"
+    )
+
+    response = asyncio.run(
+        view_file(
+            SimpleNamespace(),
+            uuid.uuid4(),
+            size="512x512",
+            download=False,
+            user_id_str=str(uuid.uuid4()),
+        )
+    )
+
+    assert response.path == "/original/images/source.png"
+    assert response.media_type == "image/png"
+    assert response.headers["cache-control"] == "private, max-age=31536000"
+
+
+@pytest.mark.parametrize("invalid_size", ["320x320", "512x256", "invalid"])
+def test_view_file_rejects_invalid_preview_size(monkeypatch, invalid_size: str) -> None:
+    from routers import files as files_router
+
+    async def fake_auth() -> str:
+        return str(uuid.uuid4())
+
+    async def fail_owned_lookup(*args):
+        raise AssertionError("invalid query must fail before ownership lookup")
+
+    monkeypatch.setattr(files_router, "_get_owned_file_or_404", fail_owned_lookup)
+    app = FastAPI()
+    app.include_router(files_router.router)
+    app.dependency_overrides[files_router.get_current_user_id] = fake_auth
+
+    with TestClient(app) as client:
+        response = client.get(f"/files/view/{uuid.uuid4()}?size={invalid_size}")
+
+    assert response.status_code == 422

--- a/api/tests/test_image_generation_tools.py
+++ b/api/tests/test_image_generation_tools.py
@@ -1,12 +1,207 @@
 import asyncio
 import sys
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
 
 import services.tools.image_generation as tools
+
+
+def test_generate_image_records_completed_gallery_metadata(monkeypatch):
+    calls: dict[str, object] = {}
+    user_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    source_image_id = uuid.uuid4()
+    req = SimpleNamespace(
+        user_id=str(user_id),
+        pg_engine="engine",
+        http_client="client",
+    )
+
+    async def fake_get_user_settings(pg_engine, requested_user_id):
+        return SimpleNamespace()
+
+    async def fake_get_model(req, settings):
+        return "requested/image-model"
+
+    async def fake_build_payload(arguments, **kwargs):
+        calls["payload"] = (arguments, kwargs)
+        return "A mountain lake"
+
+    async def fake_get_credentials(request):
+        return "credentials"
+
+    async def fake_generate_image(**kwargs):
+        calls["provider"] = kwargs
+        return SimpleNamespace(
+            image_bytes=b"generated-image",
+            extension="png",
+            model="provider/resolved-image-model",
+        )
+
+    async def fake_save_file(**kwargs):
+        calls["saved"] = kwargs
+        return "generated.png"
+
+    async def fake_get_root(pg_engine, requested_user_id):
+        return SimpleNamespace(id=uuid.uuid4())
+
+    async def fake_create_file(**kwargs):
+        calls["file"] = kwargs
+        return SimpleNamespace(id=file_id)
+
+    def fake_measure(image_bytes):
+        calls["measured"] = image_bytes
+        return 1600, 900, "16:9"
+
+    async def fake_create_job(**kwargs):
+        calls["job"] = kwargs
+        return SimpleNamespace(id=uuid.uuid4())
+
+    monkeypatch.setattr(tools, "get_user_settings", fake_get_user_settings)
+    monkeypatch.setattr(tools, "_get_image_model_for_request", fake_get_model)
+    monkeypatch.setattr(tools, "_build_image_content_payload", fake_build_payload)
+    monkeypatch.setattr(tools, "get_request_inference_credentials", fake_get_credentials)
+    monkeypatch.setattr(tools, "generate_image_with_provider", fake_generate_image)
+    monkeypatch.setattr(tools, "save_file_to_disk", fake_save_file)
+    monkeypatch.setattr(tools, "get_root_folder_for_user", fake_get_root)
+    monkeypatch.setattr(tools, "create_db_file", fake_create_file)
+    monkeypatch.setattr(tools, "measure_image_dimensions", fake_measure)
+    monkeypatch.setattr(tools, "create_completed_generation_job", fake_create_job)
+
+    result = asyncio.run(
+        tools.generate_image(
+            {
+                "prompt": "A mountain lake",
+                "aspect_ratio": "16:9",
+                "resolution": "2K",
+                "source_image_id": str(source_image_id),
+            },
+            req,
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "id": str(file_id),
+        "prompt": "A mountain lake",
+        "model": "provider/resolved-image-model",
+    }
+    provider_kwargs = calls["provider"]
+    assert provider_kwargs["model"] == "requested/image-model"
+    assert provider_kwargs["aspect_ratio"] == "16:9"
+    assert provider_kwargs["resolution"] == "2K"
+    assert provider_kwargs["source_image_ids"] == [str(source_image_id)]
+    assert calls["measured"] == b"generated-image"
+    job_kwargs = calls["job"]
+    assert job_kwargs["pg_engine"] == "engine"
+    assert job_kwargs["user_id"] == user_id
+    assert job_kwargs["file_id"] == file_id
+    assert job_kwargs["prompt"] == "A mountain lake"
+    assert job_kwargs["model"] == "provider/resolved-image-model"
+    assert job_kwargs["media_type"] == "image"
+    assert job_kwargs["aspect_ratio"] == "16:9"
+    assert job_kwargs["resolution"] == "2K"
+    assert job_kwargs["source_image_ids"] == [str(source_image_id)]
+    assert job_kwargs["actual_width"] == 1600
+    assert job_kwargs["actual_height"] == 900
+    assert job_kwargs["actual_aspect_ratio"] == "16:9"
+    assert isinstance(job_kwargs["generation_started_at"], datetime)
+    assert job_kwargs["generation_started_at"].tzinfo == timezone.utc
+
+
+def test_generate_video_records_normalized_completed_gallery_metadata(monkeypatch):
+    calls: dict[str, object] = {}
+    user_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    source_image_id = uuid.uuid4()
+    req = SimpleNamespace(
+        user_id=str(user_id),
+        pg_engine="engine",
+        http_client="client",
+    )
+
+    async def fake_get_user_settings(pg_engine, requested_user_id):
+        return SimpleNamespace()
+
+    async def fake_get_model(req, settings):
+        return "requested/video-model"
+
+    async def fake_build_references(arguments, **kwargs):
+        calls["references"] = (arguments, kwargs)
+        return [{"type": "image_url"}]
+
+    async def fake_get_credentials(request):
+        return "credentials"
+
+    async def fake_generate_video(**kwargs):
+        calls["provider"] = kwargs
+        return SimpleNamespace(
+            video_bytes=b"generated-video",
+            extension="mp4",
+            model="provider/resolved-video-model",
+            job_id="provider-job-id",
+        )
+
+    async def fake_create_video_file(**kwargs):
+        calls["file"] = kwargs
+        return SimpleNamespace(id=file_id)
+
+    async def fake_create_job(**kwargs):
+        calls["job"] = kwargs
+        return SimpleNamespace(id=uuid.uuid4())
+
+    monkeypatch.setattr(tools, "get_user_settings", fake_get_user_settings)
+    monkeypatch.setattr(tools, "_get_video_model_for_request", fake_get_model)
+    monkeypatch.setattr(tools, "_build_video_reference_payload", fake_build_references)
+    monkeypatch.setattr(tools, "get_request_inference_credentials", fake_get_credentials)
+    monkeypatch.setattr(tools, "generate_video_with_provider", fake_generate_video)
+    monkeypatch.setattr(tools, "create_generated_video_file", fake_create_video_file)
+    monkeypatch.setattr(tools, "create_completed_generation_job", fake_create_job)
+
+    result = asyncio.run(
+        tools.generate_video(
+            {
+                "prompt": "Clouds moving over a valley",
+                "aspect_ratio": "9:16",
+                "resolution": "1080p",
+                "duration": "6",
+                "generate_audio": 1,
+                "source_image_ids": str(source_image_id),
+            },
+            req,
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "id": str(file_id),
+        "prompt": "Clouds moving over a valley",
+        "model": "provider/resolved-video-model",
+        "job_id": "provider-job-id",
+    }
+    provider_kwargs = calls["provider"]
+    assert provider_kwargs["model"] == "requested/video-model"
+    assert provider_kwargs["duration"] == 6
+    assert provider_kwargs["generate_audio"] is True
+    assert provider_kwargs["input_references"] == [{"type": "image_url"}]
+    file_kwargs = calls["file"]
+    assert file_kwargs["source_image_ids"] == [str(source_image_id)]
+    job_kwargs = calls["job"]
+    assert job_kwargs["file_id"] == file_id
+    assert job_kwargs["prompt"] == "Clouds moving over a valley"
+    assert job_kwargs["model"] == "provider/resolved-video-model"
+    assert job_kwargs["media_type"] == "video"
+    assert job_kwargs["aspect_ratio"] == "9:16"
+    assert job_kwargs["resolution"] == "1080p"
+    assert job_kwargs["duration"] == 6
+    assert job_kwargs["generate_audio"] is True
+    assert job_kwargs["source_image_ids"] == [str(source_image_id)]
+    assert isinstance(job_kwargs["generation_started_at"], datetime)
+    assert job_kwargs["generation_started_at"].tzinfo == timezone.utc
 
 
 def test_alibaba_image_reference_count_is_rejected_before_file_lookup(monkeypatch):

--- a/api/tests/test_image_playground_gallery.py
+++ b/api/tests/test_image_playground_gallery.py
@@ -4,10 +4,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
-
 sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
 
-from services.image_playground.gallery import gallery_item
+from services.image_playground.gallery import gallery_item, video_gallery_item
 
 
 def _file_record(**overrides):
@@ -34,6 +33,8 @@ def _job_record(**overrides):
         "model": "google/gemini-image",
         "aspect_ratio": "1:1",
         "resolution": "1K",
+        "duration": None,
+        "generate_audio": False,
         "actual_width": 1024,
         "actual_height": 1024,
         "actual_aspect_ratio": "1:1",
@@ -70,3 +71,43 @@ def test_gallery_item_uses_safe_defaults_without_job_metadata():
     assert item.prompt is None
     assert item.model is None
     assert item.source_image_ids == []
+
+
+def test_video_gallery_item_maps_persisted_generation_metadata():
+    file_created_at = datetime(2026, 8, 5, 10, 0, tzinfo=timezone.utc)
+    generation_started_at = datetime(2026, 8, 5, 9, 58, tzinfo=timezone.utc)
+    generation_completed_at = datetime(2026, 8, 5, 9, 59, tzinfo=timezone.utc)
+    source_image_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+    file_record = _file_record(
+        name="generated-video.mp4",
+        content_type="video/mp4",
+        created_at=file_created_at,
+        updated_at=file_created_at,
+    )
+    job_record = _job_record(
+        created_at=generation_started_at,
+        completed_at=generation_completed_at,
+        prompt="A cinematic valley",
+        effective_prompt="A cinematic valley",
+        model="provider/resolved-video-model",
+        aspect_ratio="16:9",
+        resolution="1080p",
+        duration=6,
+        generate_audio=True,
+        source_image_ids=source_image_ids,
+    )
+
+    item = video_gallery_item(file_record, job_record)
+
+    assert item.id == file_record.id
+    assert item.path == "/Generated Videos/generated-video.mp4"
+    assert item.generation_started_at == generation_started_at
+    assert item.generation_completed_at == generation_completed_at
+    assert item.prompt == "A cinematic valley"
+    assert item.effective_prompt == "A cinematic valley"
+    assert item.model == "provider/resolved-video-model"
+    assert item.aspect_ratio == "16:9"
+    assert item.resolution == "1080p"
+    assert item.duration == 6
+    assert item.generate_audio is True
+    assert item.source_image_ids == source_image_ids

--- a/api/tests/test_image_playground_generated_files.py
+++ b/api/tests/test_image_playground_generated_files.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import sys
 import uuid
+from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,11 +11,11 @@ import pytest
 from fastapi import HTTPException
 from PIL import Image
 
-
 sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
 
 from services.image_playground import generated_files
 from services.image_playground.generated_files import (
+    create_completed_generation_job,
     create_generated_image_file,
     create_generated_video_file,
     generated_video_content_type,
@@ -37,6 +38,135 @@ def test_generated_video_content_type_maps_mov_to_quicktime():
     assert generated_video_content_type("mov") == "video/quicktime"
     assert generated_video_content_type(".MOV") == "video/quicktime"
     assert generated_video_content_type("mp4") == "video/mp4"
+
+
+def test_create_completed_generation_job_persists_completed_metadata(monkeypatch):
+    calls: dict[str, object] = {}
+    user_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    generation_started_at = datetime(2020, 8, 5, 10, 30, tzinfo=timezone.utc)
+    source_image_ids = [str(uuid.uuid4())]
+
+    class FakeSession:
+        def __init__(self, pg_engine):
+            calls["engine"] = pg_engine
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        def add(self, job):
+            calls["job"] = job
+
+        async def commit(self):
+            calls["committed"] = True
+
+        async def refresh(self, job):
+            calls["refreshed"] = job
+
+        async def rollback(self):
+            calls["rolled_back"] = True
+
+    monkeypatch.setattr(generated_files, "AsyncSession", FakeSession)
+
+    job = asyncio.run(
+        create_completed_generation_job(
+            pg_engine="engine",
+            user_id=user_id,
+            file_id=file_id,
+            prompt="  Generated prompt  ",
+            model="  provider/resolved-model  ",
+            media_type="image",
+            aspect_ratio="4:3",
+            resolution="2K",
+            source_image_ids=source_image_ids,
+            generation_started_at=generation_started_at,
+            actual_width=1200,
+            actual_height=900,
+            actual_aspect_ratio="4:3",
+        )
+    )
+
+    assert calls["engine"] == "engine"
+    assert calls["job"] is job
+    assert calls["committed"] is True
+    assert calls["refreshed"] is job
+    assert "rolled_back" not in calls
+    assert job.user_id == user_id
+    assert job.file_id == file_id
+    assert job.status == "completed"
+    assert job.prompt == "Generated prompt"
+    assert job.effective_prompt == "Generated prompt"
+    assert job.model == "provider/resolved-model"
+    assert job.media_type == "image"
+    assert job.aspect_ratio == "4:3"
+    assert job.resolution == "2K"
+    assert job.duration is None
+    assert job.generate_audio is False
+    assert job.actual_width == 1200
+    assert job.actual_height == 900
+    assert job.actual_aspect_ratio == "4:3"
+    assert job.style_preset is None
+    assert job.source_image_ids == source_image_ids
+    assert job.error is None
+    assert job.attempts == 1
+    assert job.max_attempts == 1
+    assert job.is_preview is False
+    assert job.created_at == generation_started_at
+    assert job.updated_at == job.completed_at
+    assert job.completed_at >= generation_started_at
+
+
+def test_create_completed_generation_job_rolls_back_and_reraises(monkeypatch):
+    calls: dict[str, object] = {}
+
+    class FakeSession:
+        def __init__(self, pg_engine):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        def add(self, job):
+            calls["added"] = job
+
+        async def commit(self):
+            raise RuntimeError("database unavailable")
+
+        async def refresh(self, job):
+            calls["refreshed"] = True
+
+        async def rollback(self):
+            calls["rolled_back"] = True
+
+    monkeypatch.setattr(generated_files, "AsyncSession", FakeSession)
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        asyncio.run(
+            create_completed_generation_job(
+                pg_engine="engine",
+                user_id=uuid.uuid4(),
+                file_id=uuid.uuid4(),
+                prompt="prompt",
+                model="provider/model",
+                media_type="video",
+                aspect_ratio="16:9",
+                resolution="720p",
+                source_image_ids=[],
+                generation_started_at=datetime.now(timezone.utc),
+                duration=6,
+                generate_audio=True,
+            )
+        )
+
+    assert "added" in calls
+    assert calls["rolled_back"] is True
+    assert "refreshed" not in calls
 
 
 def test_create_generated_image_file_saves_under_generated_images(monkeypatch):

--- a/api/tests/test_image_previews.py
+++ b/api/tests/test_image_previews.py
@@ -1,0 +1,170 @@
+import asyncio
+import os
+import random
+import sys
+import uuid
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from PIL import Image, features
+
+APP_DIR = Path(__file__).resolve().parents[1] / "app"
+sys.path.append(str(APP_DIR))
+
+from services import image_previews
+from services.image_previews import (
+    IMAGE_PREVIEW_PRESETS,
+    ImagePreviewSpec,
+    _build_cache_key,
+    ensure_image_preview,
+)
+
+
+def _write_image(path: Path, size: tuple[int, int] = (800, 600)) -> None:
+    Image.new("RGBA", size, (20, 80, 160, 120)).save(path, format="PNG")
+
+
+def test_image_preview_presets_have_fixed_quality_and_version() -> None:
+    assert {
+        size: (spec.width, spec.height, spec.output_format, spec.quality, spec.transform_version)
+        for size, spec in IMAGE_PREVIEW_PRESETS.items()
+    } == {
+        "48x48": (48, 48, "WEBP", 80, 1),
+        "160x160": (160, 160, "WEBP", 80, 1),
+        "512x512": (512, 512, "WEBP", 80, 1),
+    }
+
+
+@pytest.mark.parametrize(
+    ("size", "expected_dimensions"),
+    [
+        ("48x48", (48, 48)),
+        ("160x160", (160, 160)),
+        ("512x512", (512, 512)),
+    ],
+)
+def test_image_preview_renders_exact_webp_presets(
+    tmp_path: Path,
+    monkeypatch,
+    size,
+    expected_dimensions: tuple[int, int],
+) -> None:
+    assert features.check("webp"), "Installed Pillow must support WebP"
+    user_id = uuid.uuid4()
+    source_path = tmp_path / "images" / "source.png"
+    source_path.parent.mkdir()
+    _write_image(source_path)
+    monkeypatch.setattr(image_previews, "get_user_storage_path", lambda _: str(tmp_path))
+
+    artifact = asyncio.run(ensure_image_preview(user_id, "images/source.png", size, "hash-a"))
+
+    assert artifact is not None
+    assert artifact.media_type == "image/webp"
+    assert artifact.path.endswith(".webp")
+    with Image.open(artifact.path) as preview:
+        assert preview.format == "WEBP"
+        assert preview.size == expected_dimensions
+
+
+def test_image_preview_is_smaller_than_deterministic_multimegabyte_png(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_path = tmp_path / "source.png"
+    random_bytes = random.Random(1729).randbytes(1024 * 1024 * 3)
+    Image.frombytes("RGB", (1024, 1024), random_bytes).save(source_path, format="PNG")
+    assert source_path.stat().st_size > 2 * 1024 * 1024
+    monkeypatch.setattr(image_previews, "get_user_storage_path", lambda _: str(tmp_path))
+
+    artifact = asyncio.run(
+        ensure_image_preview(uuid.uuid4(), "source.png", "512x512", "fixture-hash")
+    )
+
+    assert artifact is not None
+    assert os.path.getsize(artifact.path) < source_path.stat().st_size
+
+
+def test_image_preview_reuses_exact_cache_and_invalidates_changed_source_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_path = tmp_path / "source.png"
+    _write_image(source_path)
+    monkeypatch.setattr(image_previews, "get_user_storage_path", lambda _: str(tmp_path))
+    user_id = uuid.uuid4()
+
+    first = asyncio.run(ensure_image_preview(user_id, "source.png", "160x160", "hash-a"))
+    assert first is not None
+    first_mtime_ns = os.stat(first.path).st_mtime_ns
+
+    def fail_render(*args, **kwargs):
+        raise AssertionError("exact cache hit must not render")
+
+    original_render = image_previews._render_preview_sync
+    monkeypatch.setattr(image_previews, "_render_preview_sync", fail_render)
+    cached = asyncio.run(ensure_image_preview(user_id, "source.png", "160x160", "hash-a"))
+    assert cached == first
+    assert os.stat(first.path).st_mtime_ns == first_mtime_ns
+
+    monkeypatch.setattr(image_previews, "_render_preview_sync", original_render)
+    changed_hash = asyncio.run(
+        ensure_image_preview(user_id, "source.png", "160x160", "hash-b")
+    )
+    assert changed_hash is not None
+    assert changed_hash.path != first.path
+
+    _write_image(source_path, size=(801, 600))
+    changed_stat = asyncio.run(
+        ensure_image_preview(user_id, "source.png", "160x160", "hash-b")
+    )
+    assert changed_stat is not None
+    assert changed_stat.path != changed_hash.path
+
+
+@pytest.mark.parametrize(
+    "changed_spec",
+    [
+        replace(ImagePreviewSpec(160, 160), width=48),
+        replace(ImagePreviewSpec(160, 160), height=48),
+        replace(ImagePreviewSpec(160, 160), output_format="PNG"),
+        replace(ImagePreviewSpec(160, 160), quality=81),
+        replace(ImagePreviewSpec(160, 160), transform_version=2),
+    ],
+)
+def test_image_preview_cache_key_includes_transform_identity(changed_spec) -> None:
+    original_spec = IMAGE_PREVIEW_PRESETS["160x160"]
+    identity = {
+        "relative_source_path": "images/source.png",
+        "content_hash": "hash-a",
+        "source_size": 123,
+        "source_mtime_ns": 456,
+    }
+
+    assert _build_cache_key(**identity, spec=changed_spec) != _build_cache_key(
+        **identity, spec=original_spec
+    )
+
+
+def test_image_preview_atomically_replaces_unique_temp_file(tmp_path: Path, monkeypatch) -> None:
+    source_path = tmp_path / "source.png"
+    _write_image(source_path)
+    monkeypatch.setattr(image_previews, "get_user_storage_path", lambda _: str(tmp_path))
+    replacements: list[tuple[str, str]] = []
+    original_replace = image_previews.os.replace
+
+    def record_replace(source: str, target: str) -> None:
+        replacements.append((source, target))
+        original_replace(source, target)
+
+    monkeypatch.setattr(image_previews.os, "replace", record_replace)
+
+    artifact = asyncio.run(
+        ensure_image_preview(uuid.uuid4(), "source.png", "48x48", "hash-a")
+    )
+
+    assert artifact is not None
+    assert len(replacements) == 1
+    assert replacements[0][1] == artifact.path
+    assert replacements[0][0] != artifact.path
+    assert not os.path.exists(replacements[0][0])

--- a/api/tests/test_inference.py
+++ b/api/tests/test_inference.py
@@ -1,11 +1,13 @@
 import asyncio
 import base64
 import json
+import os
+import signal
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import httpx
 import pytest
@@ -30,9 +32,18 @@ from services.github_copilot import (
     _is_model_unavailable_error,
     _list_sdk_models,
     _public_github_copilot_stream_error_message,
+    _run_copilot_session,
     list_github_copilot_models,
     make_github_copilot_request_non_streaming,
     stream_github_copilot_response,
+)
+from services.github_copilot_lifecycle import (
+    GITHUB_COPILOT_SCOPE_ENV,
+    CopilotProcessIdentity,
+    _find_scoped_processes,
+    _reap_process,
+    _signal_process,
+    _terminate_scoped_processes,
 )
 from services.inference import (
     CLAUDE_AGENT_SUPPORTED_TOOL_NAMES,
@@ -1967,68 +1978,247 @@ def test_github_copilot_model_listing_returns_only_sdk_models():
     assert listed_models == []
 
 
-def test_github_copilot_sdk_model_listing_falls_back_to_raw_models_on_billing_parse_error():
-    class FakeRpcClient:
-        async def request(self, method, payload):
-            assert method == "models.list"
-            assert payload == {}
-            return {
-                "models": [
-                    {
-                        "id": "gpt-5",
-                        "name": "GPT-5",
-                        "capabilities": {
-                            "supports": {"vision": True},
-                            "limits": {"max_context_window_tokens": 200000},
-                        },
-                        "billing": {},
-                    }
-                ]
-            }
+def test_github_copilot_failed_sdk_model_listing_preserves_error_and_cleans_up():
+    events = []
+    constructor_kwargs = {}
 
     class FakeCopilotClient:
-        def __init__(self, _config):
-            self._client = FakeRpcClient()
+        def __init__(self, **kwargs):
+            constructor_kwargs.update(kwargs)
+            events.append("client-created")
 
         async def start(self):
-            return None
+            events.append("client-started")
 
         async def list_models(self):
-            raise ValueError("Missing required field 'multiplier' in ModelBilling")
+            events.append("models-listed")
+            raise RuntimeError("Not authenticated")
+
+        async def stop(self):
+            events.append("client-stopped")
+            raise RuntimeError("runtime did not stop")
 
         async def force_stop(self):
-            return None
+            events.append("client-force-stopped")
 
     async def _stop_runtime_heartbeat(_heartbeat_task):
-        return None
+        events.append("heartbeat-stopped")
 
+    def _terminate_processes(_scope_id, _initial_identities):
+        events.append("processes-terminated")
+        return set()
+
+    runtime_root = Path("/tmp/meridian-copilot-test")
     with (
         patch("services.github_copilot.CopilotClient", FakeCopilotClient),
         patch(
-            "services.github_copilot.SubprocessConfig",
-            lambda **kwargs: SimpleNamespace(**kwargs),
-        ),
-        patch(
             "services.github_copilot._build_runtime_context",
-            return_value=SimpleNamespace(root_dir=Path("/tmp"), cwd=Path("/tmp"), env={}),
+            return_value=SimpleNamespace(
+                root_dir=runtime_root,
+                cwd=runtime_root / "cwd",
+                env={"HOME": "/tmp/home"},
+            ),
         ),
         patch("services.github_copilot.start_runtime_heartbeat", return_value=None),
         patch("services.github_copilot.stop_runtime_heartbeat", _stop_runtime_heartbeat),
-        patch("services.github_copilot._cleanup_runtime_context"),
+        patch(
+            "services.github_copilot._cleanup_runtime_context",
+            side_effect=lambda _context: events.append("runtime-cleaned"),
+        ),
+        patch("services.github_copilot_lifecycle._find_scoped_processes", return_value=set()),
+        patch(
+            "services.github_copilot_lifecycle._terminate_scoped_processes",
+            side_effect=_terminate_processes,
+        ),
     ):
-        raw_models = asyncio.run(_list_sdk_models("gho_test-token"))
+        with pytest.raises(ValueError, match="GitHub Copilot model listing failed: Not authenticated"):
+            asyncio.run(_list_sdk_models("gho_test-token"))
 
-    assert raw_models == [
-        {
-            "id": "gpt-5",
-            "name": "GPT-5",
-            "capabilities": {
-                "supports": {"vision": True},
-                "limits": {"max_context_window_tokens": 200000},
-            },
-            "billing": {},
-        }
+    assert constructor_kwargs == {
+        "working_directory": str(runtime_root / "cwd"),
+        "env": {
+            "HOME": "/tmp/home",
+            GITHUB_COPILOT_SCOPE_ENV: str(runtime_root),
+        },
+        "github_token": "gho_test-token",
+        "use_logged_in_user": False,
+    }
+    assert events == [
+        "client-created",
+        "client-started",
+        "models-listed",
+        "client-stopped",
+        "client-force-stopped",
+        "processes-terminated",
+        "heartbeat-stopped",
+        "runtime-cleaned",
     ]
+
+
+def test_github_copilot_failed_and_cancelled_chat_preserve_outcome_and_cleanup():
+    for send_error in (RuntimeError("chat failed"), asyncio.CancelledError()):
+        events = []
+        create_session_kwargs = {}
+
+        class FakeSession:
+            async def send_and_wait(self, _prompt, timeout):
+                assert timeout == 300.0
+                events.append("message-sent")
+                raise send_error
+
+            async def disconnect(self):
+                events.append("session-disconnected")
+
+        class FakeCopilotClient:
+            def __init__(self, **_kwargs):
+                events.append("client-created")
+
+            async def start(self):
+                events.append("client-started")
+
+            async def create_session(self, **kwargs):
+                create_session_kwargs.update(kwargs)
+                events.append("session-created")
+                return FakeSession()
+
+            async def stop(self):
+                events.append("client-stopped")
+
+            async def force_stop(self):  # pragma: no cover - graceful stop must win
+                raise AssertionError("force_stop should not run after successful stop")
+
+        def _terminate_processes(_scope_id, _initial_identities):
+            events.append("processes-terminated")
+            return set()
+
+        runtime_root = Path("/tmp/meridian-copilot-chat-test")
+        req = GitHubCopilotReqChat(
+            github_token="gho_test-token",
+            model="github-copilot/gpt-5",
+            messages=[{"role": "user", "content": "Hello"}],
+            config=SimpleNamespace(exclude_reasoning=False, reasoning_effort="low"),
+            user_id="user-1",
+            pg_engine=None,
+        )
+        with (
+            patch("services.github_copilot.CopilotClient", FakeCopilotClient),
+            patch("services.github_copilot._build_tools", return_value=[]),
+            patch(
+                "services.github_copilot._build_runtime_context",
+                return_value=SimpleNamespace(
+                    root_dir=runtime_root,
+                    cwd=runtime_root / "cwd",
+                    config_dir=runtime_root / "config",
+                    env={},
+                ),
+            ),
+            patch("services.github_copilot.start_runtime_heartbeat", return_value=None),
+            patch("services.github_copilot.stop_runtime_heartbeat", new=AsyncMock()),
+            patch("services.github_copilot._cleanup_runtime_context"),
+            patch(
+                "services.github_copilot_lifecycle._find_scoped_processes", return_value=set()
+            ),
+            patch(
+                "services.github_copilot_lifecycle._terminate_scoped_processes",
+                side_effect=_terminate_processes,
+            ),
+        ):
+            with pytest.raises(type(send_error)) as exc_info:
+                asyncio.run(
+                    _run_copilot_session(
+                        req,
+                        streaming=False,
+                        event_handler=lambda _event: None,
+                        feedback_callback=lambda _feedback: None,
+                    )
+                )
+
+        assert exc_info.value is send_error
+        assert "config_dir" not in create_session_kwargs
+        assert create_session_kwargs["config_directory"] == str(runtime_root / "config")
+        assert events == [
+            "client-created",
+            "client-started",
+            "session-created",
+            "message-sent",
+            "session-disconnected",
+            "client-stopped",
+            "processes-terminated",
+        ]
+
+
+def _write_fake_copilot_process(
+    proc_root: Path,
+    pid: int,
+    start_time: int,
+    environ_entries: list[str],
+) -> None:
+    process_dir = proc_root / str(pid)
+    process_dir.mkdir()
+    stat_fields = ["S", "1"] + ["0"] * 17 + [str(start_time)]
+    (process_dir / "stat").write_text(f"{pid} (copilot ) launcher) {' '.join(stat_fields)}")
+    (process_dir / "environ").write_bytes(
+        b"\0".join(entry.encode() for entry in environ_entries) + b"\0"
+    )
+
+
+def test_github_copilot_process_discovery_uses_exact_scope_and_start_identity(tmp_path):
+    scope_id = "/tmp/copilot-scope"
+    marker = f"{GITHUB_COPILOT_SCOPE_ENV}={scope_id}"
+    _write_fake_copilot_process(tmp_path, 41001, 101, [marker])
+    _write_fake_copilot_process(tmp_path, 41002, 102, [f"{marker}-other"])
+    _write_fake_copilot_process(tmp_path, 41003, 103, ["UNRELATED=value"])
+    _write_fake_copilot_process(tmp_path, os.getpid(), 104, [marker])
+
+    assert _find_scoped_processes(scope_id, tmp_path) == {
+        CopilotProcessIdentity(pid=41001, start_time_ticks=101)
+    }
+
+    reused_identity = CopilotProcessIdentity(pid=41001, start_time_ticks=101)
+    (tmp_path / "41001" / "stat").write_text(
+        "41001 (reused) " + " ".join(["S", "1"] + ["0"] * 17 + ["999"])
+    )
+    with (
+        patch("services.github_copilot_lifecycle.os.kill") as kill_process,
+        patch("services.github_copilot_lifecycle.os.waitpid") as wait_for_process,
+    ):
+        _signal_process(reused_identity, signal.SIGTERM, tmp_path)
+        _reap_process(reused_identity, tmp_path)
+
+    kill_process.assert_not_called()
+    wait_for_process.assert_not_called()
+
+
+def test_github_copilot_process_cleanup_escalates_and_reaps_only_tracked_pids():
+    first = CopilotProcessIdentity(pid=42001, start_time_ticks=201)
+    late = CopilotProcessIdentity(pid=42002, start_time_ticks=202)
+    discoveries = [{first}, {first}, {first}, {first, late}, {first, late}]
+
+    with (
+        patch(
+            "services.github_copilot_lifecycle._find_scoped_processes",
+            side_effect=discoveries,
+        ),
+        patch("services.github_copilot_lifecycle._identity_is_current", return_value=True),
+        patch(
+            "services.github_copilot_lifecycle.time.monotonic",
+            side_effect=[0.0, 1.0, 2.0, 2.0, 3.0],
+        ),
+        patch("services.github_copilot_lifecycle.time.sleep"),
+        patch("services.github_copilot_lifecycle.os.kill") as kill_process,
+        patch("services.github_copilot_lifecycle.os.waitpid", return_value=(0, 0)) as waitpid,
+    ):
+        survivors = _terminate_scoped_processes("scope-1")
+
+    assert kill_process.call_args_list == [
+        call(first.pid, signal.SIGTERM),
+        call(first.pid, signal.SIGKILL),
+        call(late.pid, signal.SIGKILL),
+    ]
+    assert survivors == {first, late}
+    assert waitpid.call_count > 0
+    assert all(call.args[0] in {first.pid, late.pid} for call in waitpid.call_args_list)
+    assert all(call.args[1] == os.WNOHANG for call in waitpid.call_args_list)
 
 
 def test_get_github_copilot_models_safe_returns_empty_on_failure():

--- a/api/tests/test_inference_cache.py
+++ b/api/tests/test_inference_cache.py
@@ -1,0 +1,359 @@
+import ast
+import asyncio
+import hashlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
+
+from models.inference import Architecture, ModelInfo, Pricing, ResponseModel
+from services import inference, inference_cache
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.set_calls: list[tuple[str, str, int | None]] = []
+        self.delete_calls: list[str] = []
+        self.fail_operations: set[str] = set()
+
+    async def get(self, key: str) -> str | None:
+        if "get" in self.fail_operations:
+            raise RuntimeError("redis get unavailable")
+        return self.values.get(key)
+
+    async def set(self, key: str, value: str, *, ex: int | None = None) -> None:
+        if "set" in self.fail_operations:
+            raise RuntimeError("redis set unavailable")
+        self.values[key] = value
+        self.set_calls.append((key, value, ex))
+
+    async def delete(self, key: str) -> None:
+        if "delete" in self.fail_operations:
+            raise RuntimeError("redis delete unavailable")
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def _manager(redis: FakeRedis) -> Any:
+    return SimpleNamespace(client=redis)
+
+
+def _model(model_id: str = "provider/model") -> ModelInfo:
+    return ModelInfo(
+        id=model_id,
+        name=model_id,
+        architecture=Architecture(
+            input_modalities=["text"],
+            modality="text->text",
+            output_modalities=["text"],
+            tokenizer="unknown",
+        ),
+        pricing=Pricing(prompt="0", completion="0"),
+    )
+
+
+def test_inference_redis_adapter_round_trips_values_with_exact_keys_and_ttls() -> None:
+    async def run() -> None:
+        redis = FakeRedis()
+        manager = _manager(redis)
+        credential = "credential-secret"
+        user_id = "user-sensitive-id"
+        credential_hash = hashlib.sha256(credential.encode()).hexdigest()
+        user_hash = hashlib.sha256(user_id.encode()).hexdigest()
+        provider_key = inference_cache.build_subscription_models_key("claude-agent", credential)
+        response = ResponseModel(data=[_model()])
+        available_snapshot = inference_cache.AlibabaOfficialVideoCatalogSnapshot(
+            model_ids=("happyhorse-t2v",),
+            available=True,
+            fingerprint="available-fingerprint",
+        )
+        unavailable_snapshot = inference_cache.AlibabaOfficialVideoCatalogSnapshot(
+            model_ids=(),
+            available=False,
+            fingerprint="unavailable-fingerprint",
+        )
+
+        assert provider_key == (
+            "inference:model-catalog:v1:provider:claude-agent:" f"{credential_hash}"
+        )
+        assert credential not in provider_key
+        await inference_cache.write_subscription_models(manager, provider_key, response.data)
+        assert (
+            await inference_cache.read_subscription_models(manager, provider_key) == response.data
+        )
+
+        await inference_cache.write_user_available_models(manager, user_id, response)
+        user_key = f"inference:model-catalog:v1:user:{user_hash}"
+        assert user_id not in user_key
+        assert await inference_cache.read_user_available_models(manager, user_id) == response
+
+        await inference_cache.write_alibaba_official_snapshot(manager, available_snapshot)
+        assert await inference_cache.read_alibaba_official_snapshot(manager) == available_snapshot
+        await inference_cache.write_alibaba_official_snapshot(manager, unavailable_snapshot)
+        assert await inference_cache.read_alibaba_official_snapshot(manager) == unavailable_snapshot
+
+        assert [(key, ex) for key, _, ex in redis.set_calls] == [
+            (provider_key, 600),
+            (user_key, 60),
+            (
+                "inference:model-catalog:v1:alibaba-official:official-video-v1",
+                600,
+            ),
+            (
+                "inference:model-catalog:v1:alibaba-official:official-video-v1",
+                60,
+            ),
+        ]
+        assert credential not in "".join(redis.values)
+        assert user_id not in "".join(redis.values)
+
+        await inference_cache.delete_user_available_models(manager, user_id)
+        assert redis.delete_calls == [user_key]
+        assert await inference_cache.read_user_available_models(manager, user_id) is None
+
+    asyncio.run(run())
+
+
+def test_inference_redis_alibaba_provider_key_is_hashed_and_versioned() -> None:
+    credential = "sk-sp-sensitive"
+    credential_hash = hashlib.sha256(credential.encode()).hexdigest()
+
+    key = inference_cache.build_alibaba_subscription_models_key(
+        credential,
+        "snapshot-fingerprint",
+    )
+
+    assert key == (
+        "inference:model-catalog:v1:provider:alibaba-token-plan:official-video-v1:"
+        f"{credential_hash}:snapshot-fingerprint"
+    )
+    assert credential not in key
+
+
+def test_inference_redis_adapter_malformed_and_unavailable_operations_fail_open(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def run() -> None:
+        redis = FakeRedis()
+        manager = _manager(redis)
+        subscription_key = inference_cache.build_subscription_models_key(
+            "provider",
+            "credential-secret",
+        )
+        user_key = (
+            "inference:model-catalog:v1:user:" + hashlib.sha256(b"user-sensitive-id").hexdigest()
+        )
+        snapshot_key = "inference:model-catalog:v1:alibaba-official:official-video-v1"
+        redis.values[subscription_key] = json.dumps({"not": "models"})
+        redis.values[user_key] = "not-json"
+        redis.values[snapshot_key] = json.dumps(
+            {"model_ids": [1], "available": "yes", "fingerprint": 4}
+        )
+
+        assert await inference_cache.read_subscription_models(manager, subscription_key) is None
+        assert (
+            await inference_cache.read_user_available_models(manager, "user-sensitive-id") is None
+        )
+        assert await inference_cache.read_alibaba_official_snapshot(manager) is None
+
+        redis.fail_operations = {"get", "set", "delete"}
+        assert await inference_cache.read_subscription_models(manager, subscription_key) is None
+        await inference_cache.write_subscription_models(manager, subscription_key, [_model()])
+        await inference_cache.delete_user_available_models(manager, "user-sensitive-id")
+
+        assert await inference_cache.read_subscription_models(None, subscription_key) is None
+        await inference_cache.write_subscription_models(None, subscription_key, [_model()])
+        await inference_cache.delete_user_available_models(None, "user-sensitive-id")
+
+    asyncio.run(run())
+    assert "credential-secret" not in caplog.text
+    assert "user-sensitive-id" not in caplog.text
+    assert "inference:model-catalog" not in caplog.text
+
+
+def test_inference_redis_subscription_values_are_shared_and_empty_policy_is_preserved() -> None:
+    async def run() -> None:
+        redis = FakeRedis()
+        first_app = FastAPI()
+        second_app = FastAPI()
+        first_app.state.redis_manager = _manager(redis)
+        second_app.state.redis_manager = _manager(redis)
+        cache_key = inference_cache.build_subscription_models_key(
+            "provider",
+            "credential-secret",
+        )
+        first_loader = AsyncMock(return_value=[_model("provider/shared")])
+        second_loader = AsyncMock(return_value=[_model("provider/unexpected")])
+
+        first = await inference._get_cached_subscription_models(
+            first_app,
+            cache_key=cache_key,
+            loader=first_loader,
+        )
+        first[0].name = "mutated"
+        second = await inference._get_cached_subscription_models(
+            second_app,
+            cache_key=cache_key,
+            loader=second_loader,
+        )
+
+        assert first_loader.await_count == 1
+        second_loader.assert_not_awaited()
+        assert second[0].id == "provider/shared"
+        assert second[0].name == "provider/shared"
+
+        empty_key = inference_cache.build_subscription_models_key("empty", "credential-secret")
+        empty_loader = AsyncMock(return_value=[])
+        await inference._get_cached_subscription_models(
+            first_app,
+            cache_key=empty_key,
+            loader=empty_loader,
+            cache_empty=False,
+        )
+        assert empty_key not in redis.values
+
+    asyncio.run(run())
+
+
+def test_inference_redis_user_values_share_across_apps_and_invalidation_rebuilds() -> None:
+    async def run() -> None:
+        redis = FakeRedis()
+        first_app = FastAPI()
+        second_app = FastAPI()
+        first_app.state.redis_manager = _manager(redis)
+        second_app.state.redis_manager = _manager(redis)
+        first_response = ResponseModel(data=[_model("provider/first")])
+        rebuilt_response = ResponseModel(data=[_model("provider/rebuilt")])
+        builder = AsyncMock(side_effect=[first_response, rebuilt_response])
+
+        with patch("services.inference._build_available_models_for_user", new=builder):
+            first = await inference.get_available_models_for_user(first_app, "user-sensitive-id")
+            shared = await inference.get_available_models_for_user(second_app, "user-sensitive-id")
+            await inference.invalidate_user_available_models_cache(
+                first_app,
+                "user-sensitive-id",
+            )
+            rebuilt = await inference.get_available_models_for_user(
+                second_app,
+                "user-sensitive-id",
+            )
+
+        assert first.data[0].id == "provider/first"
+        assert shared.data[0].id == "provider/first"
+        assert rebuilt.data[0].id == "provider/rebuilt"
+        assert builder.await_count == 2
+        assert not hasattr(first_app.state, "user_available_models_cache")
+        assert not hasattr(second_app.state, "user_available_models_cache")
+
+    asyncio.run(run())
+
+
+def test_inference_redis_malformed_or_unavailable_cache_still_runs_loader() -> None:
+    async def run() -> None:
+        redis = FakeRedis()
+        app = FastAPI()
+        app.state.redis_manager = _manager(redis)
+        cache_key = inference_cache.build_subscription_models_key(
+            "provider",
+            "credential-secret",
+        )
+        redis.values[cache_key] = "malformed"
+        redis.fail_operations.add("set")
+        loader = AsyncMock(return_value=[_model("provider/fresh")])
+
+        models = await inference._get_cached_subscription_models(
+            app,
+            cache_key=cache_key,
+            loader=loader,
+        )
+
+        assert [model.id for model in models] == ["provider/fresh"]
+        loader.assert_awaited_once()
+
+        redis.fail_operations = {"get", "set"}
+        second_loader = AsyncMock(return_value=[_model("provider/fallback")])
+        fallback = await inference._get_cached_subscription_models(
+            app,
+            cache_key=inference_cache.build_subscription_models_key(
+                "provider",
+                "second-credential",
+            ),
+            loader=second_loader,
+        )
+        assert [model.id for model in fallback] == ["provider/fallback"]
+
+    asyncio.run(run())
+
+
+def test_inference_redis_local_singleflight_shields_subscription_loader_from_cancellation() -> None:
+    async def run() -> None:
+        app = FastAPI()
+        app.state.redis_manager = _manager(FakeRedis())
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls = 0
+
+        async def loader() -> list[ModelInfo]:
+            nonlocal calls
+            calls += 1
+            started.set()
+            await release.wait()
+            return [_model("provider/shared")]
+
+        cache_key = inference_cache.build_subscription_models_key("provider", "credential")
+        cancelled_waiter = asyncio.create_task(
+            inference._get_cached_subscription_models(
+                app,
+                cache_key=cache_key,
+                loader=loader,
+            )
+        )
+        await started.wait()
+        surviving_waiter = asyncio.create_task(
+            inference._get_cached_subscription_models(
+                app,
+                cache_key=cache_key,
+                loader=loader,
+            )
+        )
+        await asyncio.sleep(0)
+        cancelled_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_waiter
+        release.set()
+        models = await surviving_waiter
+        await asyncio.sleep(0)
+
+        assert calls == 1
+        assert [model.id for model in models] == ["provider/shared"]
+        assert inference._get_subscription_model_inflight(app) == {}
+
+    asyncio.run(run())
+
+
+def test_inference_redis_all_provider_invalidation_callers_await() -> None:
+    router_path = Path(__file__).resolve().parents[1] / "app" / "routers" / "inference_providers.py"
+    tree = ast.parse(router_path.read_text())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "invalidate_user_available_models_cache"
+    ]
+    awaited_calls = {
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Await) and isinstance(node.value, ast.Call)
+    }
+
+    assert len(calls) == 14
+    assert all(id(call) in awaited_calls for call in calls)

--- a/api/tests/test_rate_limit.py
+++ b/api/tests/test_rate_limit.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+API_DIR = Path(__file__).resolve().parents[1]
+APP_DIR = API_DIR / "app"
+sys.path.append(str(APP_DIR))
+
+from services.rate_limit import build_redis_storage_uri  # noqa: E402
+
+
+def load_rate_limit_module(module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, APP_DIR / "services/rate_limit.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_redis_storage_uri_without_password():
+    assert build_redis_storage_uri("redis", 6379, None) == "redis://redis:6379"
+
+
+def test_build_redis_storage_uri_encodes_password():
+    storage_uri = build_redis_storage_uri("redis", 6380, "p@ss:/?#% word")
+
+    assert storage_uri == "redis://:p%40ss%3A%2F%3F%23%25%20word@redis:6380"
+    assert "p@ss:/?#% word" not in storage_uri
+
+
+def test_limiter_uses_environment_available_before_import(monkeypatch):
+    monkeypatch.setenv("REDIS_HOST", "configured-redis")
+    monkeypatch.setenv("REDIS_PORT", "6381")
+    monkeypatch.setenv("REDIS_PASSWORD", "configured/password")
+
+    rate_limit = load_rate_limit_module("rate_limit_with_configured_environment")
+
+    assert rate_limit.limiter._storage_uri == (
+        "redis://:configured%2Fpassword@configured-redis:6381"
+    )
+
+
+def test_host_development_loads_env_file_before_application_import():
+    run_dev_script = (API_DIR / "run-dev.sh").read_text()
+    env_file_option = '--env-file "${SCRIPT_DIR}/../docker/env/.env.local"'
+
+    assert env_file_option in run_dev_script
+    assert run_dev_script.index(env_file_option) < run_dev_script.index("main:app")

--- a/api/tests/test_repository_routes.py
+++ b/api/tests/test_repository_routes.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from limits.storage import MemoryStorage
+from limits.strategies import FixedWindowRateLimiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.extension import _rate_limit_exceeded_handler
 from slowapi.middleware import SlowAPIMiddleware
@@ -94,6 +96,13 @@ def test_repository_route_limit_threshold_plus_one(
         return service_response
 
     monkeypatch.setattr(repository, service_name, response)
+    memory_storage = MemoryStorage()
+    monkeypatch.setattr(repository.limiter, "_storage", memory_storage)
+    monkeypatch.setattr(
+        repository.limiter,
+        "_limiter",
+        FixedWindowRateLimiter(memory_storage),
+    )
     repository.limiter.reset()
     app = FastAPI()
     app.state.limiter = repository.limiter

--- a/docs/changelogs/Update-1.7.5-beta.md
+++ b/docs/changelogs/Update-1.7.5-beta.md
@@ -1,0 +1,59 @@
+# Meridian 1.7.5-beta
+
+Meridian `1.7.5-beta` brings repository context directly into chat, adds faster image previews, and records chat-generated media in the image playground. This release also improves multi-worker coordination, GitHub Copilot runtime cleanup, and beta release operations.
+
+## Highlights
+
+### Repository Context in Chat
+
+Chat prompts can now include selected repository files, issues, and pull requests without first configuring a GitHub node on the canvas.
+
+- Open repository context from the chat add menu, choose the files or issues and pull requests tab, and review the selected repository, branch, and item counts before sending.
+- Search available repositories and switch between connected GitHub and GitLab providers in the new repository picker.
+- Sending a prompt with repository context creates a populated context node alongside the prompt and any file-attachment nodes, preserving the selected branch and items in the graph.
+- Manual chat generation now opens the upcoming node settings before creating the next generator, so model and node options are available at the expected point in the workflow.
+
+### Attachment and Image Previews
+
+Images are easier to identify before sending and faster to browse in generated-media galleries.
+
+- Chat image attachments render as thumbnail tiles with accessible remove controls, while non-image files remain in a separate compact row.
+- Pasted images use keep-both upload handling, so sequential clipboard images with the same original filename remain attached as distinct files.
+- File previews are generated on demand as cached WebP images at fixed `48x48`, `160x160`, or `512x512` sizes; full downloads continue to use the original file.
+- Image playground galleries use responsive `160x160` and `512x512` previews, while compose, detail, and video-reference thumbnails use fixed `160x160` previews. Full downloads and original-media paths continue to request original files.
+
+### Completed Generation History
+
+Images and videos created through chat generation tools now carry the completed-job metadata used by the image playground.
+
+- Successful tool generations record prompt, resolved model, media type, requested aspect ratio and resolution, source-image references, and completion timestamps.
+- Image records also include measured dimensions and actual aspect ratio; video records retain requested duration and audio-generation choice.
+- Generated media can therefore appear in the existing playground gallery with metadata available for inspection and settings reuse.
+
+### Distributed API Coordination
+
+API instances now coordinate more runtime state through the existing Redis service.
+
+- Rate limits use shared Redis-backed storage instead of process-local memory, using the configured Redis host, port, and password.
+- Model discovery caches, including per-user available models and subscription-provider catalogs, are shared through Redis with bounded expiry and invalidated after provider credential changes.
+- WebSocket user events and generation-task cancellation requests fan out through Redis so connections and tasks owned by another API worker can receive the relevant update.
+- Redis cache failures fall back to fresh model loading, and WebSocket publishing still attempts local delivery while broker listeners reconnect after interruption.
+
+### GitHub Copilot Runtime Cleanup
+
+GitHub Copilot integration now uses the current SDK lifecycle and more deliberate process cleanup.
+
+- `github-copilot-sdk` is upgraded from `0.2.3` to `1.0.8`.
+- Model-list and chat sessions use scoped runtime environments, bounded session and client shutdown, force-stop fallback, and cleanup of remaining scoped Copilot processes.
+- Runtime heartbeat and temporary-directory cleanup now run even when session startup, execution, or cancellation fails.
+
+## Self-Hosting and Upgrade Notes
+
+Meridian `1.7.5-beta` requires no database migration and adds no application configuration keys. Existing Redis settings are reused for rate limits, model caches, and WebSocket fanout; these are expanded uses of the configured Redis service, not new Redis configuration.
+
+- Redeploy or restart matching API and UI versions to apply the chat context, preview, generation metadata, Redis coordination, and Copilot lifecycle changes.
+- Reinstall backend dependencies or rebuild the backend image to apply the `github-copilot-sdk` upgrade from `0.2.3` to `1.0.8`.
+- Host-development API startup now loads `docker/env/.env.local` before importing the application, ensuring existing Redis settings are available when the rate limiter is initialized.
+- Maintainers using the new release workflows must provision a repository Actions secret named `RELEASE_TOKEN` with repository contents and pull-request read/write access. This secret is only for release preparation and publishing; application deployments do not consume it.
+- Release preparation is now a manual workflow that validates the next changelog and creates or updates a `dev`-to-`main` release pull request. Merging that trusted release pull request creates the strict non-`v` beta tag and GitHub prerelease.
+- Docker image publication now runs from strict `X.Y.Z-beta` tags for frontend, backend, browser service, sandbox manager, and sandbox Python images. Release pull requests build the same matrix without pushing, ordinary pushes to `main` no longer publish images, and production deployment remains a separate manual step.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,42 @@
+# Releasing Meridian
+
+Meridian releases use a manually started preparation workflow, manual CI review and merge, then automatic tag, prerelease, and image publication. Production deployment remains manual.
+
+## Prerequisites
+
+Provision the `RELEASE_TOKEN` Actions secret externally. Use an unexpired GitHub App token or fine-grained personal access token for this repository with:
+
+- Contents: read and write
+- Pull requests: read and write
+
+Built-in `GITHUB_TOKEN` is not a supported fallback because events created with it do not reliably start the downstream PR and tag workflows. Automation does not create, rotate, or inspect this secret or alter repository settings and branch rules.
+
+At least one existing non-`v` tag matching strict `X.Y.Z-beta` syntax must exist. Bootstrap releases are not supported. Before starting preparation, commit the next changelog to `dev` at `docs/changelogs/Update-<version>.md`. File must be non-empty UTF-8 Markdown whose first line is exactly `# Meridian <version>`.
+
+## Prepare and merge
+
+1. Open **Actions → Prepare Release → Run workflow** from `main`.
+2. Select `patch`, `minor`, or `major`. Automation reads all strict beta tags, computes numeric successor, validates `dev` is ahead of `main`, and reads matching changelog from `dev`.
+3. Inspect created or updated `dev` to `main` PR. Title must be exactly `Release Meridian <version>` and body must exactly match changelog, including trailing newline.
+4. Wait for required CI to pass. Release PR image workflow runs shared lint and five parallel image builds without pushing packages. User remains responsible for CI review and manual merge.
+5. Merge PR manually. Publish workflow refetches merged PR and changelog from merge commit, validates title, body, branches, repository, successor version, and tag target before writing release artifacts.
+
+Finalization creates lightweight non-`v` `<version>` tag at merge commit and GitHub prerelease named `<version>` with exact changelog body. Tag starts five parallel publications for `frontend`, `backend`, `browser-service`, `sandbox-manager`, and `sandbox-python`. Observe all five matrix entries and verify exact beta image tags in GHCR. Ordinary pushes to `main` do not run image builds.
+
+## Failure and recovery
+
+Failures before tag creation are fail-closed. Correct changelog, PR, branch, token, or version issue, then rerun preparation or failed publish workflow. Repeated preparation updates one matching open PR; multiple matching open PRs stop automation without mutation.
+
+If tag already resolves to same merge commit, publish workflow can be rerun safely to create or reconcile prerelease. Partial tag-before-release failure is therefore recoverable. Existing release metadata is restored to canonical name, body, draft status, and prerelease status.
+
+Automation never moves or deletes tags. Tag resolving to another commit or newer strict beta tag requires operator investigation; do not retarget immutable release tag through this workflow. If image publication fails after tag creation, rerun failed image workflow for same tag rather than recreating release.
+
+## Production
+
+Production update is separate, manually authorized operation after all five images succeed. Use existing deployment command and exact beta tag:
+
+```bash
+./docker/run.sh prod <version>
+```
+
+Release automation never deploys or restarts production.

--- a/scripts/release_automation.py
+++ b/scripts/release_automation.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Prepare and publish Meridian releases through GitHub's REST API."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+
+VERSION_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta$")
+TITLE_RE = re.compile(r"^Release Meridian ((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-beta)$")
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+API_ROOT = "https://api.github.com"
+
+
+class ReleaseError(RuntimeError):
+    """Safe, operator-facing release automation failure."""
+
+
+class GitHubError(ReleaseError):
+    def __init__(self, method: str, path: str, status: int, detail: str = "") -> None:
+        suffix = f": {detail}" if detail else ""
+        super().__init__(f"GitHub {method} {path} failed with status {status}{suffix}")
+        self.status = status
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, value: str) -> "Version":
+        match = VERSION_RE.fullmatch(value)
+        if not match:
+            raise ReleaseError(f"invalid strict beta version: {value!r}")
+        return cls(*(int(part) for part in match.groups()))
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}-beta"
+
+    def bump(self, kind: str) -> "Version":
+        if kind == "patch":
+            return Version(self.major, self.minor, self.patch + 1)
+        if kind == "minor":
+            return Version(self.major, self.minor + 1, 0)
+        if kind == "major":
+            return Version(self.major + 1, 0, 0)
+        raise ReleaseError(f"unsupported bump: {kind!r}")
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    headers: Mapping[str, str]
+    body: bytes
+
+
+Transport = Callable[[str, str, Mapping[str, str], bytes | None, float], Response]
+
+
+def urllib_transport(
+    method: str, url: str, headers: Mapping[str, str], body: bytes | None, timeout: float
+) -> Response:
+    request = urllib.request.Request(url, data=body, headers=dict(headers), method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return Response(response.status, dict(response.headers), response.read())
+    except urllib.error.HTTPError as exc:
+        return Response(exc.code, dict(exc.headers), exc.read())
+
+
+class GitHubClient:
+    def __init__(
+        self,
+        repository: str,
+        token: str,
+        transport: Transport = urllib_transport,
+        timeout: float = 20,
+    ) -> None:
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+            raise ReleaseError("repository must use owner/name format")
+        if not token:
+            raise ReleaseError("RELEASE_TOKEN is required")
+        self.repository = repository
+        self.api_url = f"{API_ROOT}/repos/{repository}"
+        self.transport = transport
+        self.timeout = timeout
+
+        self.headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "meridian-release-automation",
+        }
+
+    def request(
+        self, method: str, path: str, payload: Mapping[str, Any] | None = None
+    ) -> tuple[Any, Mapping[str, str]]:
+        url = path if path.startswith("https://") else self.api_url + path
+        if not url.startswith(API_ROOT + "/"):
+            raise ReleaseError("GitHub pagination URL escaped GitHub API scope")
+        body = None
+        headers = dict(self.headers)
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        response = self.transport(method, url, headers, body, self.timeout)
+        if not 200 <= response.status < 300:
+            detail = ""
+            try:
+                parsed = json.loads(response.body)
+                if isinstance(parsed, dict) and isinstance(parsed.get("message"), str):
+                    detail = parsed["message"]
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                pass
+            raise GitHubError(method, urllib.parse.urlsplit(url).path, response.status, detail)
+        if not response.body:
+            return None, response.headers
+        try:
+            return json.loads(response.body), response.headers
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ReleaseError(f"GitHub {method} response was not valid JSON") from exc
+
+    def get_optional(self, path: str) -> Any | None:
+        try:
+            return self.request("GET", path)[0]
+        except GitHubError as exc:
+            if exc.status == 404:
+                return None
+            raise
+
+    def paginate(self, path: str) -> list[Any]:
+        items: list[Any] = []
+        next_url: str | None = path
+        seen: set[str] = set()
+        while next_url:
+            if next_url in seen:
+                raise ReleaseError("GitHub pagination loop detected")
+            seen.add(next_url)
+            page, headers = self.request("GET", next_url)
+            if not isinstance(page, list):
+                raise ReleaseError("GitHub paginated response was not a list")
+            items.extend(page)
+            next_url = _next_link(headers.get("Link") or headers.get("link"))
+        return items
+
+
+def _next_link(header: str | None) -> str | None:
+    if not header:
+        return None
+    for part in header.split(","):
+        match = re.fullmatch(r'\s*<([^>]+)>;\s*rel="([^"]+)"\s*', part)
+        if not match:
+            raise ReleaseError("malformed GitHub Link pagination header")
+        if match.group(2) == "next":
+            return match.group(1)
+    return None
+
+
+def latest_version(tags: list[Any], excluded: str | None = None) -> Version:
+    versions: list[Version] = []
+    for tag in tags:
+        if not isinstance(tag, dict) or not isinstance(tag.get("name"), str):
+            raise ReleaseError("GitHub tag response contained an invalid item")
+        name = tag["name"]
+        if name != excluded and VERSION_RE.fullmatch(name):
+            versions.append(Version.parse(name))
+    if not versions:
+        raise ReleaseError("no existing strict beta tag found")
+    return max(versions)
+
+
+def release_title(version: str) -> str:
+    Version.parse(version)
+    return f"Release Meridian {version}"
+
+
+def parse_release_title(title: Any) -> str:
+    if not isinstance(title, str):
+        raise ReleaseError("release PR title is missing")
+    match = TITLE_RE.fullmatch(title)
+    if not match:
+        raise ReleaseError("release PR title must be exactly 'Release Meridian <version>'")
+    return match.group(1)
+
+
+def changelog_path(version: str) -> str:
+    Version.parse(version)
+    return f"docs/changelogs/Update-{version}.md"
+
+
+def decode_changelog(content: Any, version: str) -> str:
+    if not isinstance(content, dict) or content.get("type") != "file":
+        raise ReleaseError("changelog content is not a regular file")
+    if content.get("encoding") != "base64" or not isinstance(content.get("content"), str):
+        raise ReleaseError("changelog content is not base64 encoded")
+    try:
+        encoded = "".join(content["content"].split())
+        raw = base64.b64decode(encoded, validate=True)
+        text = raw.decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ReleaseError("changelog content is not valid base64 UTF-8") from exc
+    if not text:
+        raise ReleaseError("changelog is empty")
+    if text.splitlines()[0] != f"# Meridian {version}":
+        raise ReleaseError(f"changelog first line must be exactly '# Meridian {version}'")
+    return text
+
+
+def _q(value: str) -> str:
+    return urllib.parse.quote(value, safe="")
+
+
+def _contents_path(version: str, ref: str) -> str:
+    path = urllib.parse.quote(changelog_path(version), safe="/")
+    return f"/contents/{path}?{urllib.parse.urlencode({'ref': ref})}"
+
+
+def prepare(client: GitHubClient, bump: str, base: str = "main", head: str = "dev") -> str:
+    tags = client.paginate("/tags?per_page=100")
+    version = str(latest_version(tags).bump(bump))
+    compare, _ = client.request("GET", f"/compare/{_q(base)}...{_q(head)}")
+    if not isinstance(compare, dict) or not isinstance(compare.get("ahead_by"), int):
+        raise ReleaseError("GitHub compare response is invalid")
+    if compare["ahead_by"] <= 0:
+        raise ReleaseError(f"{head} has no commits ahead of {base}")
+    changelog = decode_changelog(client.request("GET", _contents_path(version, head))[0], version)
+    owner = client.repository.split("/", 1)[0]
+    query = urllib.parse.urlencode(
+        {"state": "open", "base": base, "head": f"{owner}:{head}", "per_page": 100}
+    )
+    pulls = client.paginate(f"/pulls?{query}")
+    matching = [
+        pull for pull in pulls if _same_repository_pull(pull, client.repository, base, head)
+    ]
+    if len(matching) > 1:
+        raise ReleaseError("multiple open same-repository release PRs found")
+    payload = {"title": release_title(version), "body": changelog, "base": base, "head": head}
+    if not matching:
+        client.request("POST", "/pulls", payload)
+    else:
+        number = matching[0].get("number")
+        if not isinstance(number, int):
+            raise ReleaseError("existing release PR number is invalid")
+        client.request("PATCH", f"/pulls/{number}", {"title": payload["title"], "body": changelog})
+    return version
+
+
+def _same_repository_pull(pull: Any, repository: str, base: str, head: str) -> bool:
+    try:
+        return (
+            isinstance(pull, dict)
+            and pull["base"]["ref"] == base
+            and pull["head"]["ref"] == head
+            and pull["head"]["repo"]["full_name"].lower() == repository.lower()
+        )
+    except (KeyError, TypeError, AttributeError):
+        raise ReleaseError("GitHub pull request response is invalid")
+
+
+def _read_tag_target(client: GitHubClient, version: str) -> str | None:
+    ref = client.get_optional(f"/git/ref/tags/{_q(version)}")
+    if ref is None:
+        return None
+    try:
+        obj = ref["object"]
+        seen: set[str] = set()
+        while obj["type"] == "tag":
+            sha = obj["sha"]
+            if sha in seen or len(seen) >= 10:
+                raise ReleaseError("annotated tag dereference loop detected")
+            seen.add(sha)
+            tag, _ = client.request("GET", f"/git/tags/{_q(sha)}")
+            obj = tag["object"]
+        if obj["type"] != "commit" or not SHA_RE.fullmatch(obj["sha"]):
+            raise ReleaseError("tag does not resolve to a commit")
+        return obj["sha"].lower()
+    except (KeyError, TypeError) as exc:
+        raise ReleaseError("GitHub tag response is invalid") from exc
+
+
+def _ensure_tag(client: GitHubClient, version: str, merge_sha: str) -> None:
+    target = _read_tag_target(client, version)
+    if target is None:
+        try:
+            client.request("POST", "/git/refs", {"ref": f"refs/tags/{version}", "sha": merge_sha})
+        except GitHubError as exc:
+            if exc.status != 422:
+                raise
+        target = _read_tag_target(client, version)
+    if target != merge_sha.lower():
+        raise ReleaseError(f"tag {version} does not resolve to merge commit")
+
+
+def _canonical_release(version: str, changelog: str) -> dict[str, Any]:
+    return {
+        "tag_name": version,
+        "name": version,
+        "body": changelog,
+        "draft": False,
+        "prerelease": True,
+        "generate_release_notes": False,
+    }
+
+
+def _ensure_release(client: GitHubClient, version: str, changelog: str) -> None:
+    path = f"/releases/tags/{_q(version)}"
+    release = client.get_optional(path)
+    canonical = _canonical_release(version, changelog)
+    if release is None:
+        try:
+            client.request("POST", "/releases", canonical)
+            return
+        except GitHubError as exc:
+            if exc.status != 422:
+                raise
+        release = client.get_optional(path)
+    if not isinstance(release, dict) or not isinstance(release.get("id"), int):
+        raise ReleaseError("GitHub release response is invalid")
+    comparable = {key: release.get(key) for key in canonical if key != "generate_release_notes"}
+    desired = {key: value for key, value in canonical.items() if key != "generate_release_notes"}
+    if comparable != desired:
+        client.request("PATCH", f"/releases/{release['id']}", desired)
+
+
+def publish(
+    client: GitHubClient, pull_request_number: int, base: str = "main", head: str = "dev"
+) -> str:
+    pull, _ = client.request("GET", f"/pulls/{pull_request_number}")
+    if not _same_repository_pull(pull, client.repository, base, head):
+        raise ReleaseError("release PR does not match trusted repository branches")
+    if pull.get("merged") is not True or pull.get("state") != "closed":
+        raise ReleaseError("release PR is not merged")
+    merge_sha = pull.get("merge_commit_sha")
+    if not isinstance(merge_sha, str) or not SHA_RE.fullmatch(merge_sha):
+        raise ReleaseError("release PR merge commit SHA is invalid")
+    version = parse_release_title(pull.get("title"))
+    changelog = decode_changelog(
+        client.request("GET", _contents_path(version, merge_sha))[0], version
+    )
+    if pull.get("body") != changelog:
+        raise ReleaseError("release PR body does not equal merged changelog")
+    tags = client.paginate("/tags?per_page=100")
+    prior = latest_version(tags, excluded=version)
+    candidate = Version.parse(version)
+    if candidate not in {prior.bump(kind) for kind in ("patch", "minor", "major")}:
+        raise ReleaseError(f"release {version} is stale or is not a valid successor of {prior}")
+    _ensure_tag(client, version, merge_sha)
+    _ensure_release(client, version, changelog)
+    return version
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--repository", required=True)
+    prepare_parser.add_argument("--bump", required=True, choices=("patch", "minor", "major"))
+    prepare_parser.add_argument("--base", default="main")
+    prepare_parser.add_argument("--head", default="dev")
+    publish_parser = subparsers.add_parser("publish")
+    publish_parser.add_argument("--repository", required=True)
+    publish_parser.add_argument("--pull-request-number", required=True, type=int)
+    args = parser.parse_args(argv)
+    try:
+        client = GitHubClient(args.repository, os.environ.get("RELEASE_TOKEN", ""))
+        if args.command == "prepare":
+            version = prepare(client, args.bump, args.base, args.head)
+        else:
+            version = publish(client, args.pull_request_number)
+        print(version)
+        return 0
+    except ReleaseError as exc:
+        print(f"release automation failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -14,6 +14,7 @@ Usage: ./scripts/run-tests.sh [--e2e]
 
 Runs the repository test protocol:
   - Layered deployment configuration tests
+  - Release automation unit tests
   - Backend pytest suite
   - Backend lint/type checks
   - Frontend lint
@@ -60,6 +61,7 @@ else
 fi
 
 run_step "Layered deployment configuration tests" "$ROOT_DIR/docker/tests/test_config.sh"
+run_step "Release automation unit tests" "$API_PYTHON" -m unittest discover -s "$ROOT_DIR/scripts/tests" -p 'test_release_automation.py'
 run_step "Backend tests" bash -c "cd '$API_DIR' && '$API_PYTHON' -m pytest tests"
 run_step "Backend lint/type checks" bash -c "cd '$API_DIR' && ./run-linter.sh"
 run_step "Browser service tests and checks" "$BROWSER_SERVICE_DIR/run-checks.sh"

--- a/scripts/tests/test_release_automation.py
+++ b/scripts/tests/test_release_automation.py
@@ -1,0 +1,380 @@
+import base64
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+from urllib.parse import urlsplit
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import release_automation as release
+
+
+REPOSITORY = "meridian-project/Meridian"
+API = f"https://api.github.com/repos/{REPOSITORY}"
+SHA = "a" * 40
+CHANGELOG = "# Meridian 1.7.5-beta\n\nExact notes.\n"
+
+
+def encoded_changelog(text=CHANGELOG):
+    encoded = base64.b64encode(text.encode()).decode()
+    return {"type": "file", "encoding": "base64", "content": encoded}
+
+
+def pull(number=12, version="1.7.5-beta", body=CHANGELOG, merged=True, sha=SHA):
+    return {
+        "number": number,
+        "state": "closed" if merged else "open",
+        "merged": merged,
+        "merge_commit_sha": sha,
+        "title": f"Release Meridian {version}",
+        "body": body,
+        "base": {"ref": "main"},
+        "head": {"ref": "dev", "repo": {"full_name": REPOSITORY}},
+    }
+
+
+class FakeTransport:
+    def __init__(self):
+        self.responses = []
+        self.calls = []
+
+    def add(self, method, path, data=None, status=200, headers=None):
+        body = b"" if data is None else json.dumps(data).encode()
+        self.responses.append((method, path, release.Response(status, headers or {}, body)))
+
+    def __call__(self, method, url, headers, body, timeout):
+        self.calls.append(
+            {
+                "method": method,
+                "path": url.removeprefix(API),
+                "headers": headers,
+                "payload": json.loads(body) if body else None,
+                "timeout": timeout,
+            }
+        )
+        if not self.responses:
+            raise AssertionError(f"unexpected request: {method} {url}")
+        expected_method, expected_path, response = self.responses.pop(0)
+        self.assert_request(method, url, expected_method, expected_path)
+        return response
+
+    @staticmethod
+    def assert_request(method, url, expected_method, expected_path):
+        if method != expected_method or url != API + expected_path:
+            raise AssertionError(
+                f"expected {expected_method} {expected_path}, got {method} {url.removeprefix(API)}"
+            )
+
+    def assert_done(self):
+        if self.responses:
+            raise AssertionError(f"unused responses: {self.responses}")
+
+
+class VersionTests(unittest.TestCase):
+    def test_strict_version_and_numeric_latest(self):
+        tags = [
+            {"name": "1.9.9-beta"},
+            {"name": "1.10.0-beta"},
+            {"name": "v9.0.0-beta"},
+            {"name": "2.0.0"},
+            {"name": "1.11.0-rc"},
+            {"name": "01.12.0-beta"},
+        ]
+        self.assertEqual(str(release.latest_version(tags)), "1.10.0-beta")
+
+    def test_all_bumps_reset_expected_components(self):
+        version = release.Version.parse("1.7.9-beta")
+        self.assertEqual(str(version.bump("patch")), "1.7.10-beta")
+        self.assertEqual(str(version.bump("minor")), "1.8.0-beta")
+        self.assertEqual(str(version.bump("major")), "2.0.0-beta")
+
+    def test_invalid_and_missing_base_fail(self):
+        for value in ("v1.2.3-beta", "1.2.3", "01.2.3-beta", "1.2.3-BETA"):
+            with self.subTest(value=value), self.assertRaises(release.ReleaseError):
+                release.Version.parse(value)
+        with self.assertRaisesRegex(release.ReleaseError, "no existing"):
+            release.latest_version([{"name": "v1.0.0-beta"}])
+
+    def test_exact_title_generation_and_parsing(self):
+        self.assertEqual(release.release_title("1.2.3-beta"), "Release Meridian 1.2.3-beta")
+        self.assertEqual(release.parse_release_title("Release Meridian 1.2.3-beta"), "1.2.3-beta")
+        for title in (
+            "Release 1.2.3-beta",
+            "Release Meridian v1.2.3-beta",
+            "Release Meridian 1.2.3-beta ",
+        ):
+            with self.subTest(title=title), self.assertRaises(release.ReleaseError):
+                release.parse_release_title(title)
+
+    def test_changelog_validation_preserves_exact_text(self):
+        wrapped = encoded_changelog()
+        wrapped["content"] = "\n".join(
+            wrapped["content"][index : index + 8] for index in range(0, len(wrapped["content"]), 8)
+        )
+        self.assertEqual(release.decode_changelog(wrapped, "1.7.5-beta"), CHANGELOG)
+        invalid = [
+            {},
+            {"type": "dir", "encoding": "base64", "content": ""},
+            encoded_changelog(""),
+            encoded_changelog("# Meridian 1.7.4-beta\n"),
+            {"type": "file", "encoding": "base64", "content": base64.b64encode(b"\xff").decode()},
+        ]
+        for content in invalid:
+            with self.subTest(content=content), self.assertRaises(release.ReleaseError):
+                release.decode_changelog(content, "1.7.5-beta")
+
+
+class ClientTests(unittest.TestCase):
+    def setUp(self):
+        self.transport = FakeTransport()
+        self.client = release.GitHubClient(REPOSITORY, "secret", self.transport)
+
+    def test_pagination_follows_repository_scoped_next_link(self):
+        next_url = API + "/tags?per_page=100&page=2"
+        self.transport.add(
+            "GET",
+            "/tags?per_page=100",
+            [{"name": "1.0.0-beta"}],
+            headers={"Link": f'<{next_url}>; rel="next"'},
+        )
+        self.transport.add("GET", "/tags?per_page=100&page=2", [{"name": "1.1.0-beta"}])
+        self.assertEqual(len(self.client.paginate("/tags?per_page=100")), 2)
+        self.transport.assert_done()
+
+    def test_malformed_or_external_pagination_fails(self):
+        self.transport.add("GET", "/tags", [], headers={"Link": "not a link"})
+        with self.assertRaisesRegex(release.ReleaseError, "malformed"):
+            self.client.paginate("/tags")
+        self.transport.add(
+            "GET", "/tags", [], headers={"Link": '<https://evil.invalid/tags>; rel="next"'}
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "escaped"):
+            self.client.paginate("/tags")
+
+    def test_api_error_is_safe_and_status_aware(self):
+        self.transport.add("GET", "/tags", {"message": "denied"}, status=403)
+        with self.assertRaises(release.GitHubError) as raised:
+            self.client.request("GET", "/tags")
+        self.assertEqual(raised.exception.status, 403)
+        self.assertNotIn("secret", str(raised.exception))
+
+
+class PrepareTests(unittest.TestCase):
+    def setUp(self):
+        self.transport = FakeTransport()
+        self.client = release.GitHubClient(REPOSITORY, "secret", self.transport)
+
+    def queue_reads(self, pulls=None, ahead_by=1):
+        self.transport.add("GET", "/tags?per_page=100", [{"name": "1.7.4-beta"}])
+        self.transport.add("GET", "/compare/main...dev", {"ahead_by": ahead_by})
+        self.transport.add(
+            "GET", "/contents/docs/changelogs/Update-1.7.5-beta.md?ref=dev", encoded_changelog()
+        )
+        self.transport.add(
+            "GET",
+            "/pulls?state=open&base=main&head=meridian-project%3Adev&per_page=100",
+            pulls or [],
+        )
+
+    def test_create_exact_release_pr(self):
+        self.queue_reads()
+        self.transport.add("POST", "/pulls", {"number": 12}, status=201)
+        self.assertEqual(release.prepare(self.client, "patch"), "1.7.5-beta")
+        call = self.transport.calls[-1]
+        self.assertEqual(
+            call["payload"],
+            {
+                "title": "Release Meridian 1.7.5-beta",
+                "body": CHANGELOG,
+                "base": "main",
+                "head": "dev",
+            },
+        )
+        self.transport.assert_done()
+
+    def test_update_single_stale_release_pr(self):
+        existing = pull(merged=False)
+        existing["title"] = "old"
+        existing["body"] = "old"
+        self.queue_reads([existing])
+        self.transport.add("PATCH", "/pulls/12", {"number": 12})
+        release.prepare(self.client, "patch")
+        self.assertEqual(
+            self.transport.calls[-1]["payload"],
+            {"title": "Release Meridian 1.7.5-beta", "body": CHANGELOG},
+        )
+
+    def test_no_diff_refuses_before_changelog_or_mutation(self):
+        self.transport.add("GET", "/tags?per_page=100", [{"name": "1.7.4-beta"}])
+        self.transport.add("GET", "/compare/main...dev", {"ahead_by": 0})
+        with self.assertRaisesRegex(release.ReleaseError, "no commits ahead"):
+            release.prepare(self.client, "patch")
+        self.transport.assert_done()
+        self.assertEqual([call["method"] for call in self.transport.calls], ["GET", "GET"])
+
+    def test_duplicate_matching_prs_refuse_without_mutation(self):
+        self.queue_reads([pull(12, merged=False), pull(13, merged=False)])
+        with self.assertRaisesRegex(release.ReleaseError, "multiple"):
+            release.prepare(self.client, "patch")
+        self.assertTrue(all(call["method"] == "GET" for call in self.transport.calls))
+
+
+class PublishTests(unittest.TestCase):
+    def setUp(self):
+        self.transport = FakeTransport()
+        self.client = release.GitHubClient(REPOSITORY, "secret", self.transport)
+
+    def queue_publish_validation(self, pr=None, tags=None):
+        self.transport.add("GET", "/pulls/12", pr or pull())
+        self.transport.add(
+            "GET", f"/contents/docs/changelogs/Update-1.7.5-beta.md?ref={SHA}", encoded_changelog()
+        )
+        self.transport.add("GET", "/tags?per_page=100", tags or [{"name": "1.7.4-beta"}])
+
+    def test_create_lightweight_tag_then_release(self):
+        self.queue_publish_validation()
+        self.transport.add("GET", "/git/ref/tags/1.7.5-beta", {"message": "missing"}, status=404)
+        self.transport.add("POST", "/git/refs", {"ref": "refs/tags/1.7.5-beta"}, status=201)
+        self.transport.add(
+            "GET", "/git/ref/tags/1.7.5-beta", {"object": {"type": "commit", "sha": SHA}}
+        )
+        self.transport.add("GET", "/releases/tags/1.7.5-beta", {"message": "missing"}, status=404)
+        self.transport.add("POST", "/releases", {"id": 8}, status=201)
+        self.assertEqual(release.publish(self.client, 12), "1.7.5-beta")
+        writes = [call for call in self.transport.calls if call["method"] == "POST"]
+        self.assertEqual(writes[0]["payload"], {"ref": "refs/tags/1.7.5-beta", "sha": SHA})
+        self.assertEqual(
+            writes[1]["payload"],
+            {
+                "tag_name": "1.7.5-beta",
+                "name": "1.7.5-beta",
+                "body": CHANGELOG,
+                "draft": False,
+                "prerelease": True,
+                "generate_release_notes": False,
+            },
+        )
+
+    def test_existing_annotated_tag_and_release_are_reconciled(self):
+        self.queue_publish_validation(tags=[{"name": "1.7.4-beta"}, {"name": "1.7.5-beta"}])
+        tag_sha = "b" * 40
+        self.transport.add(
+            "GET", "/git/ref/tags/1.7.5-beta", {"object": {"type": "tag", "sha": tag_sha}}
+        )
+        self.transport.add(
+            "GET", f"/git/tags/{tag_sha}", {"object": {"type": "commit", "sha": SHA}}
+        )
+        self.transport.add(
+            "GET",
+            "/releases/tags/1.7.5-beta",
+            {
+                "id": 8,
+                "tag_name": "1.7.5-beta",
+                "name": "wrong",
+                "body": "wrong",
+                "draft": True,
+                "prerelease": False,
+            },
+        )
+        self.transport.add("PATCH", "/releases/8", {"id": 8})
+        release.publish(self.client, 12)
+        self.assertEqual(
+            self.transport.calls[-1]["payload"],
+            {
+                "tag_name": "1.7.5-beta",
+                "name": "1.7.5-beta",
+                "body": CHANGELOG,
+                "draft": False,
+                "prerelease": True,
+            },
+        )
+
+    def test_exact_existing_release_is_noop(self):
+        self.queue_publish_validation()
+        self.transport.add(
+            "GET", "/git/ref/tags/1.7.5-beta", {"object": {"type": "commit", "sha": SHA}}
+        )
+        existing = {"id": 8, **release._canonical_release("1.7.5-beta", CHANGELOG)}
+        self.transport.add("GET", "/releases/tags/1.7.5-beta", existing)
+        release.publish(self.client, 12)
+        self.assertTrue(all(call["method"] == "GET" for call in self.transport.calls))
+
+    def test_tag_create_race_is_reread(self):
+        self.queue_publish_validation()
+        self.transport.add("GET", "/git/ref/tags/1.7.5-beta", {"message": "missing"}, status=404)
+        self.transport.add("POST", "/git/refs", {"message": "already exists"}, status=422)
+        self.transport.add(
+            "GET", "/git/ref/tags/1.7.5-beta", {"object": {"type": "commit", "sha": SHA}}
+        )
+        self.transport.add("GET", "/releases/tags/1.7.5-beta", {"message": "missing"}, status=404)
+        self.transport.add("POST", "/releases", {"id": 8}, status=201)
+        release.publish(self.client, 12)
+
+    def test_mismatched_tag_refuses_before_release(self):
+        self.queue_publish_validation()
+        self.transport.add(
+            "GET", "/git/ref/tags/1.7.5-beta", {"object": {"type": "commit", "sha": "b" * 40}}
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "does not resolve"):
+            release.publish(self.client, 12)
+        self.assertFalse(any("/releases" in call["path"] for call in self.transport.calls))
+
+    def test_newer_tag_makes_finalizer_stale_before_mutation(self):
+        self.queue_publish_validation(tags=[{"name": "1.7.4-beta"}, {"name": "1.8.0-beta"}])
+        with self.assertRaisesRegex(release.ReleaseError, "stale"):
+            release.publish(self.client, 12)
+        self.assertTrue(all(call["method"] == "GET" for call in self.transport.calls))
+
+    def test_invalid_pr_title_or_body_refuses_before_mutation(self):
+        invalid_title = pull()
+        invalid_title["title"] = "Release 1.7.5-beta"
+        self.transport.add("GET", "/pulls/12", invalid_title)
+        with self.assertRaises(release.ReleaseError):
+            release.publish(self.client, 12)
+        invalid_body = pull(body="edited")
+        self.transport.add("GET", "/pulls/12", invalid_body)
+        self.transport.add(
+            "GET", f"/contents/docs/changelogs/Update-1.7.5-beta.md?ref={SHA}", encoded_changelog()
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "body"):
+            release.publish(self.client, 12)
+
+    def test_release_create_race_is_updated(self):
+        self.queue_publish_validation()
+        self.transport.add(
+            "GET", "/git/ref/tags/1.7.5-beta", {"object": {"type": "commit", "sha": SHA}}
+        )
+        self.transport.add("GET", "/releases/tags/1.7.5-beta", {"message": "missing"}, status=404)
+        self.transport.add("POST", "/releases", {"message": "race"}, status=422)
+        self.transport.add(
+            "GET",
+            "/releases/tags/1.7.5-beta",
+            {
+                "id": 8,
+                "tag_name": "1.7.5-beta",
+                "name": "old",
+                "body": "old",
+                "draft": True,
+                "prerelease": False,
+            },
+        )
+        self.transport.add("PATCH", "/releases/8", {"id": 8})
+        release.publish(self.client, 12)
+
+
+class CliTests(unittest.TestCase):
+    def test_missing_token_fails_without_transport(self):
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+            release, "urllib_transport", side_effect=AssertionError("network called")
+        ):
+            self.assertEqual(
+                release.main(["prepare", "--repository", REPOSITORY, "--bump", "patch"]), 1
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/app/app.vue
+++ b/ui/app/app.vue
@@ -144,6 +144,7 @@ watch(route, fetchEssentials);
         <ClientOnly>
             <UiLibraryPromptEditor />
             <UiLibraryPromptImprover />
+            <UiGraphNodeUtilsGithubFileSelectMountpoint />
         </ClientOnly>
     </div>
 </template>

--- a/ui/app/components/ui/chat/attachment/chipListItem.vue
+++ b/ui/app/components/ui/chat/attachment/chipListItem.vue
@@ -7,38 +7,94 @@ defineEmits<{
 }>();
 
 // --- Props ---
-defineProps<{
+const props = withDefaults(defineProps<{
     file: FileSystemObject;
     removeFiles: boolean;
-}>();
+    showImagePreview?: boolean;
+}>(), {
+    showImagePreview: false,
+});
 
 // --- Composables ---
 const { getFileType } = useFiles();
+
+const isImageFile = computed(() => {
+    if (props.file.type !== 'file') return false;
+
+    const contentType = props.file.content_type?.toLowerCase().split(';')[0]?.trim();
+    if (contentType?.startsWith('image/')) return true;
+
+    return /\.(?:avif|bmp|gif|jpe?g|png|svg|webp)$/i.test(props.file.name);
+});
+
+const imagePreviewUrl = computed(
+    () => `/api/auth/refresh/files/view/${props.file.id}?size=160x160`,
+);
+
+const isPreviewImage = computed(() => props.showImagePreview && isImageFile.value);
 </script>
 
 <template>
     <li
         v-if="file"
         :key="file.id"
-        class="text-soft-silk/70 border-stone-gray/30 relative flex items-center rounded-xl border py-1.5 pr-1.5
-            pl-3 text-sm font-bold transition-colors duration-200"
+        class="text-soft-silk/70 relative flex items-center text-sm font-bold transition-colors
+            duration-200"
+        :class="
+            isPreviewImage
+                ? 'group h-14 w-14 rounded-lg'
+                : 'border-stone-gray/30 rounded-xl border py-1.5 pr-1.5 pl-3'
+        "
     >
-        <template v-for="fileType in [getFileType(file.name)]" :key="fileType">
-            <UiIcon v-if="fileType === FileType.Other" class="h-5 w-5" name="BxBxsFileBlank" />
-            <UiIcon v-else-if="fileType === FileType.PDF" class="h-5 w-5" name="BxBxsFilePdf" />
-            <UiIcon
-                v-else-if="fileType === FileType.Image"
-                class="h-5 w-5"
-                name="MaterialSymbolsImageRounded"
-            />
+        <img
+            v-if="isPreviewImage"
+            :src="imagePreviewUrl"
+            alt=""
+            width="56"
+            height="56"
+            class="h-14 w-14 rounded-lg object-cover"
+        >
+        <template v-else>
+            <template v-for="fileType in [getFileType(file.name)]" :key="fileType">
+                <UiIcon
+                    v-if="fileType === FileType.Other"
+                    class="h-5 w-5"
+                    name="BxBxsFileBlank"
+                />
+                <UiIcon
+                    v-else-if="fileType === FileType.PDF"
+                    class="h-5 w-5"
+                    name="BxBxsFilePdf"
+                />
+                <UiIcon
+                    v-else-if="fileType === FileType.Image"
+                    class="h-5 w-5"
+                    name="MaterialSymbolsImageRounded"
+                />
+            </template>
         </template>
-        <span class="px-2">
+        <span v-if="!isPreviewImage" class="px-2">
             {{ file.name.length > 20 ? file.name.slice(0, 20) + '…' : file.name }}
         </span>
         <button
             v-if="removeFiles"
-            class="text-soft-silk/70 hover:text-soft-silk bg-stone-gray/10 hover:bg-stone-gray/10 flex h-5 w-5
-                cursor-pointer items-center justify-center rounded-lg transition-colors duration-200"
+            type="button"
+            :aria-label="`Remove ${file.name}`"
+            class="flex cursor-pointer items-center justify-center transition-all duration-200
+                focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-soft-silk/70"
+            :class="{
+                'text-soft-silk/70 hover:text-soft-silk bg-stone-gray/10 hover:bg-stone-gray/10 h-5 w-5 rounded-lg':
+                    !isPreviewImage,
+                'pointer-events-none absolute top-1 right-1 h-6 w-6 rounded-full border opacity-0 shadow-md':
+                    isPreviewImage,
+                'border-soft-silk/40 bg-obsidian/90 text-soft-silk': isPreviewImage,
+                'group-hover:pointer-events-auto group-hover:opacity-100 group-hover:shadow-lg':
+                    isPreviewImage,
+                'group-hover:border-soft-silk/60 group-hover:bg-obsidian': isPreviewImage,
+                'group-focus-within:pointer-events-auto group-focus-within:opacity-100':
+                    isPreviewImage,
+                'focus:pointer-events-auto focus:opacity-100 focus:shadow-lg': isPreviewImage,
+            }"
             @click="$emit('removeFile')"
         >
             <UiIcon class="h-4 w-4" name="MaterialSymbolsClose" />

--- a/ui/app/components/ui/chat/attachment/uploadButton.vue
+++ b/ui/app/components/ui/chat/attachment/uploadButton.vue
@@ -4,6 +4,7 @@ import { motion } from 'motion-v';
 const emit = defineEmits<{
     (e: 'open-cloud-select'): void;
     (e: 'add-files', files: FileList): void;
+    (e: 'add-git-context', tab: 'files' | 'issues'): void;
 }>();
 
 // --- Props ---
@@ -13,16 +14,25 @@ const props = defineProps<{
 
 // --- Local state ---
 const isMenuOpen = ref(false);
-const menuRef = ref(null);
+const menuRef = ref<HTMLElement | { $el?: HTMLElement } | null>(null);
 const buttonRef = ref<HTMLElement | null>(null);
 const menuPosition = ref({ top: 0, left: 0 });
 
 const updateMenuPosition = () => {
-    if (buttonRef.value) {
+    const menuElement =
+        menuRef.value instanceof HTMLElement ? menuRef.value : menuRef.value?.$el;
+    if (buttonRef.value && menuElement) {
         const rect = buttonRef.value.getBoundingClientRect();
+        // Layout dimensions ignore motion's initial scale transform.
+        const menuWidth = menuElement.offsetWidth;
+        const menuHeight = menuElement.offsetHeight;
+        const viewportPadding = 8;
         menuPosition.value = {
-            top: rect.top - 88,
-            left: rect.left,
+            top: Math.max(viewportPadding, rect.top - menuHeight - viewportPadding),
+            left: Math.max(
+                viewportPadding,
+                Math.min(rect.left, window.innerWidth - menuWidth - viewportPadding),
+            ),
         };
     }
 };
@@ -52,6 +62,11 @@ const handleCloudSelect = () => {
     closeMenu();
 };
 
+const handleGitSelect = (tab: 'files' | 'issues') => {
+    emit('add-git-context', tab);
+    closeMenu();
+};
+
 // Update position on window resize
 onMounted(() => {
     window.addEventListener('resize', updateMenuPosition);
@@ -63,7 +78,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-    <div ref="menuRef" class="relative">
+    <div class="relative">
         <!-- Button mode -->
         <button
             ref="buttonRef"
@@ -71,10 +86,12 @@ onUnmounted(() => {
                 rounded-2xl shadow transition duration-200 ease-in-out hover:cursor-pointer
                 disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="disabled"
+            type="button"
+            aria-label="Add context"
             @click="toggleMenu"
         >
             <slot name="icon">
-                <UiIcon name="MajesticonsAttachment" class="text-stone-gray h-6 w-6" />
+                <UiIcon name="Fa6SolidPlus" class="text-stone-gray h-5 w-5" />
             </slot>
         </button>
 
@@ -85,7 +102,9 @@ onUnmounted(() => {
             <AnimatePresence>
                 <motion.div
                     v-if="isMenuOpen"
+                    ref="menuRef"
                     key="attachment-menu"
+                    data-add-context-menu
                     :style="{
                         position: 'fixed',
                         top: `${menuPosition.top}px`,
@@ -119,13 +138,37 @@ onUnmounted(() => {
                         backdrop-blur-lg"
                 >
                     <ul class="flex flex-col gap-1">
+                        <li class="text-stone-gray/60 px-2 pt-1 text-xs font-semibold">Git</li>
+                        <li>
+                            <button
+                                type="button"
+                                class="hover:bg-stone-gray/20 flex w-full cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 text-sm
+                                    font-semibold transition-colors duration-200"
+                                @click="handleGitSelect('files')"
+                            >
+                                <UiIcon name="MdiFileDocumentOutline" class="h-5 w-5" />
+                                <span>Add files</span>
+                            </button>
+                        </li>
+                        <li>
+                            <button
+                                type="button"
+                                class="hover:bg-stone-gray/20 flex w-full cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 text-sm
+                                    font-semibold transition-colors duration-200"
+                                @click="handleGitSelect('issues')"
+                            >
+                                <UiIcon name="MdiSourcePull" class="h-5 w-5" />
+                                <span>Add PR/issue</span>
+                            </button>
+                        </li>
+                        <li class="text-stone-gray/60 px-2 pt-2 text-xs font-semibold">Files</li>
                         <li>
                             <label
                                 class="hover:bg-stone-gray/20 flex w-full cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 text-sm
                                     font-semibold transition-colors duration-200"
                             >
                                 <UiIcon name="UilUpload" class="h-5 w-5" />
-                                <span>Upload from device</span>
+                                <span>From device</span>
                                 <input
                                     type="file"
                                     multiple
@@ -138,10 +181,11 @@ onUnmounted(() => {
                             <button
                                 class="hover:bg-stone-gray/20 flex w-full cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 text-sm
                                     font-semibold transition-colors duration-200"
+                                type="button"
                                 @click="handleCloudSelect"
                             >
                                 <UiIcon name="MdiCloudUploadOutline" class="h-5 w-5" />
-                                <span>Upload from cloud</span>
+                                <span>From cloud</span>
                             </button>
                         </li>
                     </ul>

--- a/ui/app/components/ui/chat/chatBox.vue
+++ b/ui/app/components/ui/chat/chatBox.vue
@@ -3,6 +3,7 @@ import { NodeTypeEnum, MessageRoleEnum } from '@/types/enums';
 import { DEFAULT_NODE_ID } from '@/constants';
 import { useChatGenerator } from '@/composables/useChatGenerator';
 import { useMessageEditing } from '@/composables/useMessageEditing';
+import type { ChatInputSubmission } from '@/types/chat';
 
 const props = defineProps<{
     isTemporary?: boolean;
@@ -166,9 +167,9 @@ const handleHighlightNode = ({ nodeId }: { nodeId: string | null }) => {
     highlightedNodeId.value = nodeId;
 };
 
-const handleGenerateNew = (message: string, files: FileSystemObject[]) => {
+const handleGenerateNew = (submission: ChatInputSubmission) => {
     graphEvents.emit('open-upcoming-node-data', {});
-    generateNew(null, message, files);
+    generateNew(null, submission);
 };
 
 const chatPanelStyle = computed(() => {

--- a/ui/app/components/ui/chat/chatBox.vue
+++ b/ui/app/components/ui/chat/chatBox.vue
@@ -166,6 +166,11 @@ const handleHighlightNode = ({ nodeId }: { nodeId: string | null }) => {
     highlightedNodeId.value = nodeId;
 };
 
+const handleGenerateNew = (message: string, files: FileSystemObject[]) => {
+    graphEvents.emit('open-upcoming-node-data', {});
+    generateNew(null, message, files);
+};
+
 const chatPanelStyle = computed(() => {
     if (!openChatId.value || !isCompactCanvasWidth.value) return undefined;
 
@@ -490,11 +495,7 @@ onUnmounted(() => {
                 from="chat"
                 class="max-h-[600px]!"
                 @trigger-scroll="triggerScroll"
-                @generate="
-                    (message: string, files: FileSystemObject[]) => {
-                        generateNew(null, message, files);
-                    }
-                "
+                @generate="handleGenerateNew"
                 @go-back-to-bottom="goBackToBottom"
                 @cancel-stream="handleCancelStream"
                 @select-node-type="

--- a/ui/app/components/ui/chat/github/contextChip.vue
+++ b/ui/app/components/ui/chat/github/contextChip.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+import type { RepoContent } from '@/types/github';
+
+defineProps<{ context: RepoContent }>();
+defineEmits<{ (e: 'remove'): void }>();
+</script>
+
+<template>
+    <li
+        class="bg-stone-gray/10 border-stone-gray/10 text-soft-silk/80 flex max-w-full items-center
+            gap-2 rounded-xl border px-3 py-2 text-sm"
+    >
+        <UiIcon
+            :name="context.repo.provider.startsWith('gitlab') ? 'MdiGitlab' : 'MdiGithub'"
+            class="h-5 w-5 shrink-0"
+        />
+        <span class="truncate font-semibold">{{ context.repo.full_name }}</span>
+        <span class="text-stone-gray/60 shrink-0">{{ context.currentBranch }}</span>
+        <span class="text-stone-gray/60 shrink-0">
+            {{ context.selectedFiles.length }} file(s),
+            {{ context.selectedIssues?.length ?? 0 }} issue(s)
+        </span>
+        <button
+            type="button"
+            :aria-label="`Remove Git context for ${context.repo.full_name}`"
+            class="hover:bg-stone-gray/20 ml-auto flex h-6 w-6 shrink-0 cursor-pointer items-center
+                justify-center rounded-full"
+            @click="$emit('remove')"
+        >
+            <UiIcon name="MaterialSymbolsClose" class="h-4 w-4" />
+        </button>
+    </li>
+</template>

--- a/ui/app/components/ui/chat/textInput.vue
+++ b/ui/app/components/ui/chat/textInput.vue
@@ -126,11 +126,14 @@ const handlePaste = (event: ClipboardEvent) => {
     }
 
     if (imageFiles.length) {
-        void addFiles(imageFiles);
+        void addFiles(imageFiles, 'keep_both');
     }
 };
 
-const addFiles = async (newFiles: globalThis.FileList | File[]) => {
+const addFiles = async (
+    newFiles: globalThis.FileList | File[],
+    conflictPolicy?: FileConflictPolicy,
+) => {
     if (!newFiles) return;
 
     const currentUploads: Record<string, { status: UploadStatus }> = {};
@@ -166,7 +169,9 @@ const addFiles = async (newFiles: globalThis.FileList | File[]) => {
     const uploadPromises = fileList.map(async (file, index) => {
         const tempId = Object.keys(currentUploads)[index];
         try {
-            const newFile = await uploadFile(file, targetId);
+            const newFile = conflictPolicy
+                ? await uploadFile(file, targetId, conflictPolicy)
+                : await uploadFile(file, targetId);
             files.value.push(newFile);
             uploads.value[tempId].status = 'complete';
         } catch (err) {

--- a/ui/app/components/ui/chat/textInput.vue
+++ b/ui/app/components/ui/chat/textInput.vue
@@ -36,6 +36,18 @@ type UploadStatus = 'uploading' | 'complete' | 'error';
 const uploads = ref<Record<string, { status: UploadStatus }>>({});
 const isUploading = computed(() => Object.keys(uploads.value).length > 0);
 
+const isImageAttachment = (file: FileSystemObject) => {
+    if (file.type !== 'file') return false;
+
+    const contentType = file.content_type?.toLowerCase().split(';')[0]?.trim();
+    if (contentType?.startsWith('image/')) return true;
+
+    return /\.(?:avif|bmp|gif|jpe?g|png|svg|webp)$/i.test(file.name);
+};
+
+const imageAttachments = computed(() => files.value.filter(isImageAttachment));
+const nonImageAttachments = computed(() => files.value.filter((file) => !isImageAttachment(file)));
+
 // --- Core Logic Functions ---
 const handleInputWheel = (event: WheelEvent) => {
     const el = textareaRef.value;
@@ -70,6 +82,11 @@ const sendMessage = async () => {
     const el = textareaRef.value;
     if (!el) return;
     el.innerText = '';
+};
+
+const removeFile = (file: FileSystemObject) => {
+    const index = files.value.indexOf(file);
+    if (index >= 0) files.value.splice(index, 1);
 };
 
 const handleDrop = async (event: DragEvent) => {
@@ -224,20 +241,40 @@ onMounted(() => {
         </button>
 
         <!-- File attachments -->
-        <ul
+        <div
             v-if="files.length > 0"
-            class="decoration-none bg-obsidian shadow-soft-silk/5 mx-10 flex h-fit
-                w-[calc(80%-3rem)] max-w-268 flex-wrap items-center justify-start gap-2
-                rounded-t-3xl px-2 py-2 shadow-[0_-5px_15px]"
+            data-attachment-grid
+            class="bg-obsidian shadow-soft-silk/5 mx-10 grid h-fit w-[calc(80%-3rem)] max-w-268
+                grid-cols-1 gap-2 rounded-t-3xl px-2 py-2 shadow-[0_-5px_15px]"
         >
-            <UiChatAttachmentChipListItem
-                v-for="(file, index) in files"
-                :key="file.id"
-                :file="file"
-                :remove-files="true"
-                @remove-file="files.splice(index, 1)"
-            />
-        </ul>
+            <ul
+                v-if="imageAttachments.length > 0"
+                data-attachment-row="images"
+                class="col-span-1 flex w-full list-none flex-wrap items-center justify-start gap-2"
+            >
+                <UiChatAttachmentChipListItem
+                    v-for="file in imageAttachments"
+                    :key="file.id"
+                    :file="file"
+                    :remove-files="true"
+                    :show-image-preview="true"
+                    @remove-file="removeFile(file)"
+                />
+            </ul>
+            <ul
+                v-if="nonImageAttachments.length > 0"
+                data-attachment-row="files"
+                class="col-span-1 flex w-full list-none flex-wrap items-center justify-start gap-2"
+            >
+                <UiChatAttachmentChipListItem
+                    v-for="file in nonImageAttachments"
+                    :key="file.id"
+                    :file="file"
+                    :remove-files="true"
+                    @remove-file="removeFile(file)"
+                />
+            </ul>
+        </div>
 
         <!-- Main input text bar -->
         <div

--- a/ui/app/components/ui/chat/textInput.vue
+++ b/ui/app/components/ui/chat/textInput.vue
@@ -1,13 +1,15 @@
 <script lang="ts" setup>
 import type { NodeTypeEnum } from '@/types/enums';
+import type { ChatInputSubmission } from '@/types/chat';
+import type { BlockDefinition } from '@/types/graph';
 
-const emit = defineEmits([
-    'triggerScroll',
-    'generate',
-    'goBackToBottom',
-    'cancelStream',
-    'selectNodeType',
-]);
+const emit = defineEmits<{
+    (e: 'triggerScroll'): void;
+    (e: 'generate', submission: ChatInputSubmission): void;
+    (e: 'goBackToBottom'): void;
+    (e: 'cancelStream'): void;
+    (e: 'selectNodeType', nodeType: BlockDefinition): void;
+}>();
 
 defineProps<{
     isLockedToBottom: boolean;
@@ -24,6 +26,7 @@ const usageStore = useUsageStore();
 const { uploadFile, getRootFolder, getFolderContents, createFolder } = useAPI();
 const { error } = useToast();
 const graphEvents = useGraphEvents();
+const { githubContext, openGithubContext, removeGithubContext } = useChatGithubContext();
 
 // --- Local State ---
 const textareaRef = ref<HTMLDivElement | null>(null);
@@ -74,10 +77,15 @@ const onInput = () => {
 };
 
 const sendMessage = async () => {
-    emit('generate', message.value, files.value);
+    emit('generate', {
+        message: message.value,
+        files: files.value,
+        githubContext: githubContext.value,
+    });
 
     message.value = '';
     files.value = [];
+    githubContext.value = null;
     isEmpty.value = true;
     const el = textareaRef.value;
     if (!el) return;
@@ -247,11 +255,21 @@ onMounted(() => {
 
         <!-- File attachments -->
         <div
-            v-if="files.length > 0"
+            v-if="files.length > 0 || githubContext"
             data-attachment-grid
             class="bg-obsidian shadow-soft-silk/5 mx-10 grid h-fit w-[calc(80%-3rem)] max-w-268
                 grid-cols-1 gap-2 rounded-t-3xl px-2 py-2 shadow-[0_-5px_15px]"
         >
+            <ul
+                v-if="githubContext"
+                data-attachment-row="github"
+                class="col-span-1 flex w-full list-none flex-wrap items-center justify-start gap-2"
+            >
+                <UiChatGithubContextChip
+                    :context="githubContext"
+                    @remove="removeGithubContext"
+                />
+            </ul>
             <ul
                 v-if="imageAttachments.length > 0"
                 data-attachment-row="images"
@@ -286,7 +304,7 @@ onMounted(() => {
             class="border-stone-gray/10 flex h-fit max-h-full w-[80%] max-w-280 items-end
                 justify-center rounded-3xl border-2 px-2 py-2 backdrop-blur-lg"
             :class="{
-                'shadow-soft-silk/5 shadow-[0_-5px_25px]': files.length === 0,
+                'shadow-soft-silk/5 shadow-[0_-5px_25px]': files.length === 0 && !githubContext,
                 'bg-anthracite/25': from === 'home',
                 'bg-obsidian/75': from === 'chat',
             }"
@@ -295,6 +313,7 @@ onMounted(() => {
                 :disabled="isUploading"
                 @add-files="addFiles"
                 @open-cloud-select="openCloudSelect"
+                @add-git-context="openGithubContext"
             >
                 <template #icon>
                     <UiChatUtilsUploadProgressCircle
@@ -302,7 +321,7 @@ onMounted(() => {
                         :uploads="uploads"
                         class="animate-pulse"
                     />
-                    <UiIcon v-else name="MajesticonsAttachment" class="text-stone-gray h-6 w-6" />
+                    <UiIcon v-else name="Fa6SolidPlus" class="text-stone-gray h-5 w-5" />
                 </template>
             </UiChatAttachmentUploadButton>
 

--- a/ui/app/components/ui/chat/textInput.vue
+++ b/ui/app/components/ui/chat/textInput.vue
@@ -84,24 +84,36 @@ const handleDrop = async (event: DragEvent) => {
 const handlePaste = (event: ClipboardEvent) => {
     event.preventDefault();
 
+    const clipboardData = event.clipboardData;
+    if (!clipboardData) return;
+
+    const imageFiles = Array.from(clipboardData.items)
+        .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+        .map((item) => item.getAsFile())
+        .filter((file): file is File => file !== null);
+
     // Remove formatting from pasted text
-    const text = event.clipboardData?.getData('text/plain');
-    if (!text) return;
+    const text = clipboardData.getData('text/plain');
+    if (text) {
+        document.execCommand('insertText', false, text);
 
-    document.execCommand('insertText', false, text);
+        onInput();
 
-    onInput();
+        // After the DOM updates from the paste, scroll the input field to the bottom
+        const el = textareaRef.value;
+        if (el) {
+            nextTick(() => {
+                el.scrollTop = el.scrollHeight;
+            });
+        }
+    }
 
-    // After the DOM updates from the paste, scroll the input field to the bottom
-    const el = textareaRef.value;
-    if (el) {
-        nextTick(() => {
-            el.scrollTop = el.scrollHeight;
-        });
+    if (imageFiles.length) {
+        void addFiles(imageFiles);
     }
 };
 
-const addFiles = async (newFiles: globalThis.FileList) => {
+const addFiles = async (newFiles: globalThis.FileList | File[]) => {
     if (!newFiles) return;
 
     const currentUploads: Record<string, { status: UploadStatus }> = {};

--- a/ui/app/components/ui/graph/node/github.vue
+++ b/ui/app/components/ui/graph/node/github.vue
@@ -4,6 +4,7 @@ import { NodeResizer } from '@vue-flow/node-resizer';
 
 import type { DataGithub } from '@/types/graph';
 import type { RepositoryInfo } from '@/types/github';
+import { SavingStatus } from '@/types/enums';
 
 const emit = defineEmits([
     'updateNodeInternals',
@@ -25,6 +26,7 @@ const graphId = computed(() => (route.params.id as string) ?? '');
 const githubStore = useGithubStore();
 const gitlabStore = useGitlabStore();
 const repositoryStore = useRepositoryStore();
+const canvasSaveStore = useCanvasSaveStore();
 
 // --- State from Stores ---
 const { isGithubConnected } = storeToRefs(githubStore);
@@ -39,6 +41,7 @@ const { nodeRef, isVisible } = useNodeVisibility();
 
 // --- Actions ---
 const { fetchRepositories } = repositoryStore;
+const { setNeedSave } = canvasSaveStore;
 
 // --- Constants ---
 const blockDefinition = getBlockById('primary-github-context');
@@ -46,6 +49,7 @@ const blockDefinition = getBlockById('primary-github-context');
 watch(
     () => props.data.repo,
     (newRepo) => {
+        setNeedSave(SavingStatus.NOT_SAVED);
         if (newRepo) {
             props.data.files = [];
             props.data.branch = undefined;

--- a/ui/app/components/ui/graph/node/utils/github/fileList.vue
+++ b/ui/app/components/ui/graph/node/utils/github/fileList.vue
@@ -44,13 +44,14 @@ const fetchRepoTree = async () => {
     const initialBranch = props.branch || props.repo.default_branch || 'main';
 
     graphEvents.emit('open-github-file-select', {
+        target: { kind: 'node', nodeId: props.nodeId },
         repoContent: {
             repo: props.repo,
             selectedFiles: selectedFiles.value,
             selectedIssues: selectedIssues.value,
             currentBranch: initialBranch,
         },
-        nodeId: props.nodeId,
+        initialTab: 'files',
     });
 };
 
@@ -74,14 +75,14 @@ watch(
 onMounted(() => {
     const unsubscribe = graphEvents.on(
         'close-github-file-select',
-        ({ selectedFilePaths, selectedIssues: newSelectedIssues, nodeId, branch }) => {
-            if (nodeId === props.nodeId) {
-                selectedFiles.value = selectedFilePaths;
-                if (newSelectedIssues) {
-                    selectedIssues.value = newSelectedIssues;
+        ({ target, repoContent }) => {
+            if (target.kind === 'node' && target.nodeId === props.nodeId && repoContent) {
+                selectedFiles.value = repoContent.selectedFiles;
+                if (repoContent.selectedIssues) {
+                    selectedIssues.value = repoContent.selectedIssues;
                 }
-                if (branch) {
-                    props.setBranch(branch);
+                if (repoContent.currentBranch) {
+                    props.setBranch(repoContent.currentBranch);
                 }
             }
         },

--- a/ui/app/components/ui/graph/node/utils/github/fileSelectMountpoint.vue
+++ b/ui/app/components/ui/graph/node/utils/github/fileSelectMountpoint.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
 import { motion } from 'motion-v';
-import type { RepoContent, FileTreeNode, GithubIssue } from '@/types/github';
+import type { RepoContent, FileTreeNode, GithubIssue, RepositoryInfo } from '@/types/github';
+import type { GithubSelectorTab, GithubSelectorTarget } from '@/composables/useGraphEvents';
 
 // --- Stores ---
 const settingsStore = useSettingsStore();
+const repositoryStore = useRepositoryStore();
 
 // --- State from Stores ---
 const { blockGithubSettings } = storeToRefs(settingsStore);
@@ -12,20 +14,31 @@ const { blockGithubSettings } = storeToRefs(settingsStore);
 const { getGenericRepoTree, getGenericRepoBranches, cloneRepository, pullGenericRepo } = useAPI();
 const graphEvents = useGraphEvents();
 const { error } = useToast();
+const { fetchRepositories } = repositoryStore;
 
 // --- Local State ---
 const isOpen = ref(false);
 const repoContent = ref<RepoContent | null>(null);
+const initialRepoContent = ref<RepoContent | null>(null);
+const selectedRepo = ref<RepositoryInfo>();
 const selectedFiles = ref<FileTreeNode[]>([]);
-const initialSelectedFiles = ref<FileTreeNode[]>([]);
 const selectedIssues = ref<GithubIssue[]>([]);
-const initialSelectedIssues = ref<GithubIssue[]>([]);
-const activeNodeId = ref<string | null>(null);
+const activeTarget = ref<GithubSelectorTarget | null>(null);
 const fileTree = ref<FileTreeNode>();
 const branches = ref<string[]>([]);
 const loadingState = ref(0); // 0: idle, 1: cloning, 2: fetching tree
 const errorState = ref<string | null>(null);
-const activeTab = ref<'files' | 'issues'>('files');
+const activeTab = ref<GithubSelectorTab>('files');
+
+const cloneRepoContent = (content: RepoContent | null): RepoContent | null => {
+    if (!content) return null;
+    return {
+        repo: { ...content.repo },
+        selectedFiles: content.selectedFiles.map((file) => ({ ...file })),
+        selectedIssues: (content.selectedIssues ?? []).map((issue) => ({ ...issue })),
+        currentBranch: content.currentBranch,
+    };
+};
 
 // --- Core Logic Functions ---
 const fetchGithubData = async () => {
@@ -103,22 +116,48 @@ const closeFullscreen = (payload?: {
     branch: string;
     issues: GithubIssue[];
 }) => {
+    if (!activeTarget.value) return;
+    const result = payload && repoContent.value
+        ? {
+              repo: { ...repoContent.value.repo },
+              selectedFiles: payload.files.map((file) => ({ ...file })),
+              selectedIssues: payload.issues.map((issue) => ({ ...issue })),
+              currentBranch: payload.branch,
+          }
+        : cloneRepoContent(initialRepoContent.value);
+
     graphEvents.emit('close-github-file-select', {
-        selectedFilePaths: payload ? payload.files : initialSelectedFiles.value,
-        selectedIssues: payload ? payload.issues : initialSelectedIssues.value,
-        nodeId: activeNodeId.value || '',
-        branch: payload ? payload.branch : repoContent.value?.currentBranch,
+        target: activeTarget.value,
+        repoContent: result,
     });
 
-    repoContent.value = null;
     isOpen.value = false;
+    repoContent.value = null;
+    initialRepoContent.value = null;
+    selectedRepo.value = undefined;
     selectedFiles.value = [];
     selectedIssues.value = [];
-    activeNodeId.value = null;
+    activeTarget.value = null;
     fileTree.value = undefined;
     branches.value = [];
     activeTab.value = 'files';
 };
+
+watch(selectedRepo, async (repo) => {
+    if (!isOpen.value || !repo) return;
+    if (repoContent.value?.repo.full_name === repo.full_name) return;
+
+    repoContent.value = {
+        repo: { ...repo },
+        selectedFiles: [],
+        selectedIssues: [],
+        currentBranch: repo.default_branch || 'main',
+    };
+    selectedFiles.value = [];
+    selectedIssues.value = [];
+    errorState.value = null;
+    await fetchGithubData();
+});
 
 const handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Escape' && isOpen.value) {
@@ -130,13 +169,23 @@ const handleKeyDown = (event: KeyboardEvent) => {
 onMounted(() => {
     const unsubscribe = graphEvents.on('open-github-file-select', async (payload) => {
         isOpen.value = true;
-        repoContent.value = payload.repoContent;
-        selectedFiles.value = payload.repoContent.selectedFiles || [];
-        selectedIssues.value = payload.repoContent.selectedIssues || [];
-        activeNodeId.value = payload.nodeId;
-        initialSelectedFiles.value = [...selectedFiles.value];
-        initialSelectedIssues.value = [...selectedIssues.value];
+        activeTarget.value = payload.target;
+        activeTab.value = payload.initialTab;
+        initialRepoContent.value = cloneRepoContent(payload.repoContent);
+        repoContent.value = cloneRepoContent(payload.repoContent);
+        selectedRepo.value = repoContent.value?.repo;
+        selectedFiles.value = repoContent.value?.selectedFiles ?? [];
+        selectedIssues.value = repoContent.value?.selectedIssues ?? [];
         errorState.value = null;
+
+        if (!repoContent.value) {
+            try {
+                await fetchRepositories();
+            } catch {
+                error('Failed to fetch repositories');
+            }
+            return;
+        }
 
         // Gitlab migration support
         if (!repoContent.value.repo.provider) {
@@ -146,7 +195,7 @@ onMounted(() => {
             repoContent.value.repo.encoded_provider = btoa(unescape(encodeURIComponent('github')));
         }
 
-        fetchGithubData();
+        await fetchGithubData();
     });
 
     document.addEventListener('keydown', handleKeyDown);
@@ -168,7 +217,7 @@ onUnmounted(() => {
             :initial="{ opacity: 0, scale: 0.85 }"
             :animate="{ opacity: 1, scale: 1, transition: { duration: 0.2, ease: 'easeOut' } }"
             :exit="{ opacity: 0, scale: 0.85, transition: { duration: 0.15, ease: 'easeIn' } }"
-            class="bg-obsidian/90 border-stone-gray/10 absolute top-1/2 left-1/2 z-50 mx-auto flex
+            class="bg-obsidian/90 border-stone-gray/10 fixed top-1/2 left-1/2 z-50 mx-auto flex
                 h-[95%] w-[95%] -translate-x-1/2 -translate-y-1/2 cursor-grab flex-col
                 overflow-hidden rounded-2xl border-2 shadow-lg backdrop-blur-md"
         >
@@ -180,17 +229,7 @@ onUnmounted(() => {
                     hover:cursor-pointer"
                 aria-label="Close Fullscreen"
                 title="Close Fullscreen"
-                @click="
-                    closeFullscreen(
-                        repoContent
-                            ? {
-                                  files: selectedFiles,
-                                  branch: repoContent.currentBranch,
-                                  issues: selectedIssues,
-                              }
-                            : undefined,
-                    )
-                "
+                @click="closeFullscreen()"
             >
                 <UiIcon name="MaterialSymbolsClose" class="text-stone-gray h-6 w-6" />
             </button>
@@ -237,6 +276,10 @@ onUnmounted(() => {
 
                 <!-- Main Content -->
                 <div class="flex grow overflow-hidden p-8">
+                    <div v-if="!repoContent" class="m-auto w-full max-w-xl">
+                        <UiGraphNodeUtilsGithubRepoSelect v-model:current-repo="selectedRepo" />
+                    </div>
+
                     <template v-if="repoContent && fileTree && activeTab === 'files'">
                         <UiGraphNodeUtilsGithubFileTreeSelector
                             :tree-data="fileTree"
@@ -273,17 +316,20 @@ onUnmounted(() => {
                             :initial-selected-issues="selectedIssues"
                             @update:selected-issues="selectedIssues = $event"
                             @close="
-                                closeFullscreen({
-                                    files: selectedFiles,
-                                    branch: repoContent.currentBranch,
-                                    issues: selectedIssues,
-                                })
+                                (issues) =>
+                                    issues
+                                        ? closeFullscreen({
+                                              files: selectedFiles,
+                                              branch: repoContent.currentBranch,
+                                              issues,
+                                          })
+                                        : closeFullscreen()
                             "
                         />
                     </template>
 
                     <div
-                        v-else-if="!repoContent || !fileTree"
+                        v-else-if="repoContent && !fileTree"
                         class="text-stone-gray/50 m-auto flex flex-col items-center gap-4
                             text-center text-sm"
                     >

--- a/ui/app/components/ui/graph/node/utils/github/fileSelectMountpoint.vue
+++ b/ui/app/components/ui/graph/node/utils/github/fileSelectMountpoint.vue
@@ -5,7 +5,6 @@ import type { GithubSelectorTab, GithubSelectorTarget } from '@/composables/useG
 
 // --- Stores ---
 const settingsStore = useSettingsStore();
-const repositoryStore = useRepositoryStore();
 
 // --- State from Stores ---
 const { blockGithubSettings } = storeToRefs(settingsStore);
@@ -14,7 +13,6 @@ const { blockGithubSettings } = storeToRefs(settingsStore);
 const { getGenericRepoTree, getGenericRepoBranches, cloneRepository, pullGenericRepo } = useAPI();
 const graphEvents = useGraphEvents();
 const { error } = useToast();
-const { fetchRepositories } = repositoryStore;
 
 // --- Local State ---
 const isOpen = ref(false);
@@ -178,14 +176,7 @@ onMounted(() => {
         selectedIssues.value = repoContent.value?.selectedIssues ?? [];
         errorState.value = null;
 
-        if (!repoContent.value) {
-            try {
-                await fetchRepositories();
-            } catch {
-                error('Failed to fetch repositories');
-            }
-            return;
-        }
+        if (!repoContent.value) return;
 
         // Gitlab migration support
         if (!repoContent.value.repo.provider) {
@@ -238,6 +229,8 @@ onUnmounted(() => {
             <div class="flex h-full w-full">
                 <!-- Tab Navigation (Left Side) -->
                 <div
+                    v-if="repoContent"
+                    data-github-tab-navigation
                     class="bg-obsidian/50 border-stone-gray/10 flex w-16 flex-col items-center gap-4
                         border-r py-8"
                 >
@@ -276,9 +269,10 @@ onUnmounted(() => {
 
                 <!-- Main Content -->
                 <div class="flex grow overflow-hidden p-8">
-                    <div v-if="!repoContent" class="m-auto w-full max-w-xl">
-                        <UiGraphNodeUtilsGithubRepoSelect v-model:current-repo="selectedRepo" />
-                    </div>
+                    <UiGraphNodeUtilsGithubRepositoryPicker
+                        v-if="isOpen && !repoContent"
+                        @select="selectedRepo = $event"
+                    />
 
                     <template v-if="repoContent && fileTree && activeTab === 'files'">
                         <UiGraphNodeUtilsGithubFileTreeSelector

--- a/ui/app/components/ui/graph/node/utils/github/issuePrSelector.vue
+++ b/ui/app/components/ui/graph/node/utils/github/issuePrSelector.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 // --- Emits ---
 const emit = defineEmits<{
     (e: 'update:selectedIssues', issues: GithubIssue[]): void;
-    (e: 'close'): void;
+    (e: 'close', issues?: GithubIssue[]): void;
 }>();
 
 // --- Composables ---
@@ -107,7 +107,7 @@ const toggleIssue = (issue: GithubIssue) => {
 };
 
 const confirmSelection = () => {
-    emit('close');
+    emit('close', selectedIssuesList.value);
 };
 
 // --- Watchers ---

--- a/ui/app/components/ui/graph/node/utils/github/repoSelect.vue
+++ b/ui/app/components/ui/graph/node/utils/github/repoSelect.vue
@@ -2,20 +2,15 @@
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
 import { RecycleScroller } from 'vue-virtual-scroller';
 
-import { SavingStatus } from '@/types/enums';
 import type { RepositoryInfo, SourceProvider } from '@/types/github';
 
 const currentRepo = defineModel<RepositoryInfo>('currentRepo');
 
 // --- Stores ---
 const repositoryStore = useRepositoryStore();
-const canvasSaveStore = useCanvasSaveStore();
 
 // --- State from Stores ---
 const { repositories, isLoading } = storeToRefs(repositoryStore);
-
-// --- Actions/Methods from Stores ---
-const { setNeedSave } = canvasSaveStore;
 
 // --- Local State ---
 const comboboxInput = ref<HTMLInputElement>();
@@ -51,8 +46,6 @@ const clearSelection = async (event: MouseEvent) => {
 
 watch(selected, (newSelected) => {
     currentRepo.value = newSelected ?? undefined;
-
-    setNeedSave(SavingStatus.NOT_SAVED);
 });
 
 // Sync model with local selected & set source tab

--- a/ui/app/components/ui/graph/node/utils/github/repositoryPicker.vue
+++ b/ui/app/components/ui/graph/node/utils/github/repositoryPicker.vue
@@ -1,0 +1,209 @@
+<script lang="ts" setup>
+import type { RepositoryInfo, SourceProvider } from '@/types/github';
+
+const emit = defineEmits<{
+    (e: 'select', repository: RepositoryInfo): void;
+}>();
+
+const repositoryStore = useRepositoryStore();
+const { repositories, isLoading } = storeToRefs(repositoryStore);
+const { fetchRepositories } = repositoryStore;
+const { error } = useToast();
+
+const searchInput = ref<HTMLInputElement | null>(null);
+const query = ref('');
+const selectedProvider = ref<SourceProvider>('github');
+const fetchFailed = ref(false);
+
+const isGitlab = (repository: RepositoryInfo) => repository.provider.startsWith('gitlab');
+
+const providerRepositories = computed(() =>
+    repositories.value.filter((repository) =>
+        selectedProvider.value === 'gitlab' ? isGitlab(repository) : !isGitlab(repository),
+    ),
+);
+
+const normalizedQuery = computed(() => query.value.trim().toLowerCase());
+const filteredRepositories = computed(() => {
+    if (!normalizedQuery.value) return providerRepositories.value;
+    return providerRepositories.value.filter((repository) => {
+        const description = repository.description?.toLowerCase() ?? '';
+        return (
+            repository.full_name.toLowerCase().includes(normalizedQuery.value) ||
+            description.includes(normalizedQuery.value)
+        );
+    });
+});
+
+const loadRepositories = async () => {
+    fetchFailed.value = false;
+    try {
+        await fetchRepositories();
+    } catch {
+        fetchFailed.value = true;
+        error('Failed to fetch repositories');
+    }
+};
+
+onMounted(async () => {
+    await nextTick();
+    searchInput.value?.focus();
+    await loadRepositories();
+});
+</script>
+
+<template>
+    <section class="flex h-full min-h-0 w-full flex-col" aria-labelledby="repository-picker-title">
+        <header class="mb-6 shrink-0 pr-14">
+            <h1 id="repository-picker-title" class="text-soft-silk text-2xl font-bold">
+                Select a repository
+            </h1>
+        </header>
+
+        <div class="mb-6 flex shrink-0 flex-col gap-3 md:flex-row md:items-center">
+            <label class="relative min-w-0 grow">
+                <span class="sr-only">Search repositories…</span>
+                <UiIcon
+                    name="MdiMagnify"
+                    class="text-stone-gray/60 pointer-events-none absolute top-1/2 left-4 h-5 w-5
+                        -translate-y-1/2"
+                />
+                <input
+                    ref="searchInput"
+                    v-model="query"
+                    type="search"
+                    aria-label="Search repositories…"
+                    placeholder="Search repositories…"
+                    class="bg-stone-gray/5 border-stone-gray/20 text-soft-silk placeholder:text-stone-gray/40
+                        focus:border-ember-glow focus:ring-ember-glow/30 h-12 w-full rounded-xl border
+                        pr-4 pl-12 text-base outline-none focus:ring-2"
+                />
+            </label>
+
+            <div
+                role="group"
+                aria-label="Repository provider"
+                class="bg-stone-gray/5 border-stone-gray/15 flex shrink-0 rounded-xl border p-1"
+            >
+                <button
+                    v-for="provider in ['github', 'gitlab'] as const"
+                    :key="provider"
+                    type="button"
+                    :aria-pressed="selectedProvider === provider"
+                    class="focus-visible:ring-ember-glow flex min-h-10 flex-1 cursor-pointer items-center
+                        justify-center gap-2 rounded-lg px-5 text-sm font-semibold outline-none
+                        transition-colors focus-visible:ring-2 md:flex-none"
+                    :class="
+                        selectedProvider === provider
+                            ? 'bg-stone-gray/20 text-soft-silk'
+                            : 'text-stone-gray/60 hover:bg-stone-gray/10 hover:text-soft-silk'
+                    "
+                    @click="selectedProvider = provider"
+                >
+                    <UiIcon
+                        :name="provider === 'gitlab' ? 'MdiGitlab' : 'MdiGithub'"
+                        class="h-5 w-5"
+                    />
+                    {{ provider === 'gitlab' ? 'GitLab' : 'GitHub' }}
+                </button>
+            </div>
+        </div>
+
+        <div class="min-h-0 grow overflow-y-auto pr-1">
+            <div
+                v-if="isLoading"
+                role="status"
+                class="text-stone-gray/60 flex h-full min-h-48 items-center justify-center gap-3"
+            >
+                <UiIcon name="MingcuteLoading3Fill" class="h-6 w-6 animate-spin" />
+                <span>Loading repositories…</span>
+            </div>
+
+            <div
+                v-else-if="fetchFailed"
+                role="alert"
+                class="text-stone-gray/60 flex h-full min-h-48 flex-col items-center justify-center gap-4"
+            >
+                <span>Unable to load repositories.</span>
+                <button
+                    type="button"
+                    class="bg-ember-glow/15 text-ember-glow hover:bg-ember-glow/25 focus-visible:ring-ember-glow
+                        cursor-pointer rounded-lg px-4 py-2 font-semibold outline-none focus-visible:ring-2"
+                    @click="loadRepositories"
+                >
+                    Try again
+                </button>
+            </div>
+
+            <p
+                v-else-if="repositories.length === 0"
+                class="text-stone-gray/50 flex h-full min-h-48 items-center justify-center text-center"
+            >
+                No repositories available.
+            </p>
+
+            <p
+                v-else-if="normalizedQuery && filteredRepositories.length === 0"
+                class="text-stone-gray/50 flex h-full min-h-48 items-center justify-center text-center"
+            >
+                No repositories match your search.
+            </p>
+
+            <p
+                v-else-if="providerRepositories.length === 0"
+                class="text-stone-gray/50 flex h-full min-h-48 items-center justify-center text-center"
+            >
+                No repositories available for
+                {{ selectedProvider === 'gitlab' ? 'GitLab' : 'GitHub' }}.
+            </p>
+
+            <ul
+                v-else
+                data-repository-grid
+                class="grid grid-cols-1 gap-3 pb-2 lg:grid-cols-2 2xl:grid-cols-3"
+            >
+                <li v-for="repository in filteredRepositories" :key="repository.full_name">
+                    <button
+                        type="button"
+                        class="bg-stone-gray/5 border-stone-gray/15 hover:bg-stone-gray/10
+                            hover:border-stone-gray/30 focus-visible:border-ember-glow
+                            focus-visible:ring-ember-glow/40 flex h-full min-h-36 w-full cursor-pointer
+                            flex-col items-start rounded-xl border p-4 text-left outline-none transition-colors
+                            focus-visible:ring-2"
+                        @click="emit('select', repository)"
+                    >
+                        <span class="text-stone-gray/60 mb-3 flex items-center gap-2 text-xs font-semibold">
+                            <UiIcon
+                                :name="isGitlab(repository) ? 'MdiGitlab' : 'MdiGithub'"
+                                class="h-4 w-4"
+                            />
+                            {{ isGitlab(repository) ? 'GitLab' : 'GitHub' }}
+                        </span>
+                        <span class="text-soft-silk w-full break-words font-semibold">
+                            {{ repository.full_name }}
+                        </span>
+                        <span
+                            v-if="repository.description?.trim()"
+                            class="text-stone-gray/60 mt-2 line-clamp-2 text-sm"
+                        >
+                            {{ repository.description }}
+                        </span>
+                        <span class="text-stone-gray/50 mt-auto flex w-full items-center gap-4 pt-4 text-xs">
+                            <span class="flex min-w-0 items-center gap-1">
+                                <UiIcon name="MdiSourceBranch" class="h-4 w-4 shrink-0" />
+                                <span class="truncate">{{ repository.default_branch || 'main' }}</span>
+                            </span>
+                            <span
+                                v-if="typeof repository.stargazers_count === 'number'"
+                                class="ml-auto flex shrink-0 items-center gap-1"
+                            >
+                                <UiIcon name="MaterialSymbolsStarOutlineRounded" class="h-4 w-4" />
+                                {{ repository.stargazers_count }}
+                            </span>
+                        </span>
+                    </button>
+                </li>
+            </ul>
+        </div>
+    </section>
+</template>

--- a/ui/app/components/ui/images/playground/composePane.vue
+++ b/ui/app/components/ui/images/playground/composePane.vue
@@ -940,7 +940,7 @@ defineExpose({
                                     v-if="preset.imageId || IMAGE_PLAYGROUND_STYLE_VISUALS[key]?.image"
                                     :src="
                                         preset.imageId
-                                            ? imagePlaygroundImageUrl(preset.imageId, true)
+                                            ? imagePlaygroundImageUrl(preset.imageId, '160x160')
                                             : IMAGE_PLAYGROUND_STYLE_VISUALS[key]?.image
                                     "
                                     :alt="`${preset.label} illustration`"
@@ -1150,7 +1150,7 @@ defineExpose({
                         @dragend.stop="onReferenceDragEnd"
                     >
                         <img
-                            :src="imagePlaygroundImageUrl(image.id, true)"
+                            :src="imagePlaygroundImageUrl(image.id, '160x160')"
                             :alt="image.name"
                             class="h-full w-full object-cover"
                         />
@@ -1268,7 +1268,7 @@ defineExpose({
                         >
                             <img
                                 v-if="newTonePreviewImageId"
-                                :src="imagePlaygroundImageUrl(newTonePreviewImageId, true)"
+                                :src="imagePlaygroundImageUrl(newTonePreviewImageId, '160x160')"
                                 alt="Generated tone preview"
                                 class="h-full w-full object-cover"
                             >

--- a/ui/app/components/ui/images/playground/galleryTile.vue
+++ b/ui/app/components/ui/images/playground/galleryTile.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
 import type { GeneratedImageGalleryItem } from '@/types/imagePlayground';
 import {
+    IMAGE_PLAYGROUND_GALLERY_SIZES,
     IMAGE_PLAYGROUND_GENERATED_IMAGE_DRAG_TYPE,
     imagePlaygroundAspectClass,
     imagePlaygroundAspectStyle,
     imagePlaygroundDownloadName,
     imagePlaygroundDownloadUrl,
     imagePlaygroundDisplayAspectRatio,
+    imagePlaygroundGallerySrcset,
     imagePlaygroundImageUrl,
 } from '@/utils/imagePlayground';
 
@@ -45,7 +47,9 @@ const onDragStart = (event: DragEvent) => {
         @dragstart.stop="onDragStart"
     >
         <img
-            :src="imagePlaygroundImageUrl(image.id, true)"
+            :src="imagePlaygroundImageUrl(image.id, '160x160')"
+            :srcset="imagePlaygroundGallerySrcset(image.id)"
+            :sizes="IMAGE_PLAYGROUND_GALLERY_SIZES"
             alt=""
             aria-hidden="true"
             loading="lazy"
@@ -61,7 +65,9 @@ const onDragStart = (event: DragEvent) => {
                 :style="imagePlaygroundAspectStyle(image)"
             >
                 <img
-                    :src="imagePlaygroundImageUrl(image.id, true)"
+                    :src="imagePlaygroundImageUrl(image.id, '160x160')"
+                    :srcset="imagePlaygroundGallerySrcset(image.id)"
+                    :sizes="IMAGE_PLAYGROUND_GALLERY_SIZES"
                     :alt="image.name"
                     loading="lazy"
                     class="h-full w-full object-cover transition duration-500 group-hover:scale-[1.04]"

--- a/ui/app/components/ui/images/playground/imageDetailModal.vue
+++ b/ui/app/components/ui/images/playground/imageDetailModal.vue
@@ -432,7 +432,7 @@ const tooltip =
                                 @click.prevent="openReferenceInNewTab(referenceId)"
                             >
                                 <img
-                                    :src="imagePlaygroundImageUrl(referenceId, true)"
+                                    :src="imagePlaygroundImageUrl(referenceId, '160x160')"
                                     alt="Reference image used for this generation"
                                     loading="lazy"
                                     class="h-full w-full object-cover transition duration-300

--- a/ui/app/components/ui/images/playground/videoPane.vue
+++ b/ui/app/components/ui/images/playground/videoPane.vue
@@ -896,7 +896,7 @@ defineExpose({
                             @dragend.stop="onReferenceDragEnd"
                         >
                             <img
-                                :src="imagePlaygroundImageUrl(image.id, true)"
+                                :src="imagePlaygroundImageUrl(image.id, '160x160')"
                                 :alt="image.name"
                                 class="h-full w-full object-cover"
                             />

--- a/ui/app/composables/useChatGenerator.ts
+++ b/ui/app/composables/useChatGenerator.ts
@@ -1,7 +1,6 @@
 import { NodeTypeEnum, MessageRoleEnum, MessageContentTypeEnum } from '@/types/enums';
 import type { MessageContent, BlockDefinition } from '@/types/graph';
-import type { ChatSession } from '@/types/chat';
-import { DEFAULT_NODE_ID } from '@/constants';
+import type { ChatInputSubmission, ChatSession } from '@/types/chat';
 import type { ShallowRef } from 'vue';
 import { useVueFlow } from '@vue-flow/core';
 
@@ -39,7 +38,7 @@ export const useChatGenerator = (
     } = streamStore;
 
     // --- Composables ---
-    const { addFilesPromptInputNodes, createNodeFromVariant, waitForRender } = useGraphChat();
+    const { createNodeFromVariant, waitForRender } = useGraphChat();
     const { teleportViewportToNode } = useGraphActions();
     const { getBlockByNodeType } = useBlocks();
     const { getNodes } = useVueFlow('main-graph-' + graphId.value);
@@ -188,8 +187,7 @@ export const useChatGenerator = (
 
     const generateNew = async (
         forcedNodeId: string | null = null,
-        message: string | null = null,
-        files: FileSystemObject[] | null = null,
+        submission: ChatInputSubmission | null = null,
     ) => {
         let generatorNodeId: string | undefined;
         syncUpcomingModelDefaults();
@@ -201,37 +199,30 @@ export const useChatGenerator = (
                 return;
             }
 
-            const createdNodes = createNodeFromVariant(
-                lastestMessage.type,
-                openChatId.value as string,
-                [NodeTypeEnum.PROMPT],
-                getTextFromMessage(lastestMessage),
+            const storedSubmission: ChatInputSubmission = {
+                message: getTextFromMessage(lastestMessage),
+                files: lastestMessage.data?.files ?? [],
+                githubContext: lastestMessage.data?.githubContext ?? null,
+            };
+            const createdNodes = createNodeFromVariant(lastestMessage.type, openChatId.value as string, {
+                submission: storedSubmission,
                 forcedNodeId,
-            );
+            });
             generatorNodeId = createdNodes.generatorNodeId;
             if (createdNodes.promptNodeId) {
                 lastestMessage.prompt_node_id = createdNodes.promptNodeId;
             }
-
-            if (lastestMessage.data.files && lastestMessage.data.files.length > 0) {
-                addFilesPromptInputNodes(
-                    lastestMessage.data.files || [],
-                    forcedNodeId || DEFAULT_NODE_ID,
-                );
-            }
-        } else if (message && selectedNodeType.value) {
+        } else if (submission && selectedNodeType.value) {
             const createdNodes = createNodeFromVariant(
                 selectedNodeType.value.nodeType,
                 openChatId.value as string,
-                [NodeTypeEnum.PROMPT],
-                message,
+                { submission },
             );
             generatorNodeId = createdNodes.generatorNodeId;
 
             let filesContent: MessageContent[] = [];
-            if (files && files.length > 0) {
-                addFilesPromptInputNodes(files, generatorNodeId || DEFAULT_NODE_ID);
-                filesContent = files.map((file) => fileToMessageContent(file));
+            if (submission.files.length > 0) {
+                filesContent = submission.files.map((file) => fileToMessageContent(file));
             }
 
             addMessage({
@@ -239,7 +230,7 @@ export const useChatGenerator = (
                 content: [
                     {
                         type: MessageContentTypeEnum.TEXT,
-                        text: message,
+                        text: submission.message,
                     },
                     ...filesContent,
                 ],
@@ -304,7 +295,11 @@ export const useChatGenerator = (
             return;
         }
 
-        await generateNew(null, normalizedMessage, files);
+        await generateNew(null, {
+            message: normalizedMessage,
+            files: files ?? [],
+            githubContext: null,
+        });
     };
 
     const regenerate = async (index: number) => {

--- a/ui/app/composables/useChatGithubContext.ts
+++ b/ui/app/composables/useChatGithubContext.ts
@@ -1,0 +1,37 @@
+import type { GithubSelectorTab } from '@/composables/useGraphEvents';
+import type { RepoContent } from '@/types/github';
+
+export const useChatGithubContext = () => {
+    const graphEvents = useGraphEvents();
+    const githubContext = ref<RepoContent | null>(null);
+
+    const normalizeContext = (context: RepoContent | null) => {
+        if (!context) return null;
+        if (context.selectedFiles.length === 0 && (context.selectedIssues?.length ?? 0) === 0) {
+            return null;
+        }
+        return context;
+    };
+
+    const openGithubContext = (initialTab: GithubSelectorTab) => {
+        graphEvents.emit('open-github-file-select', {
+            target: { kind: 'chat-input' },
+            repoContent: githubContext.value,
+            initialTab,
+        });
+    };
+
+    const removeGithubContext = () => {
+        githubContext.value = null;
+    };
+
+    onMounted(() => {
+        const unsubscribe = graphEvents.on('close-github-file-select', ({ target, repoContent }) => {
+            if (target.kind !== 'chat-input') return;
+            githubContext.value = normalizeContext(repoContent);
+        });
+        onUnmounted(unsubscribe);
+    });
+
+    return { githubContext, openGithubContext, removeGithubContext };
+};

--- a/ui/app/composables/useGraphChat.ts
+++ b/ui/app/composables/useGraphChat.ts
@@ -3,6 +3,8 @@ import { useVueFlow } from '@vue-flow/core';
 import { DEFAULT_NODE_ID } from '@/constants';
 import { AUTO_PLACEMENT_GAP } from '@/composables/useGraphOverlaps';
 import { NodeTypeEnum } from '@/types/enums';
+import type { ChatInputSubmission } from '@/types/chat';
+import type { RepoContent } from '@/types/github';
 
 type CreatedChatNodes = {
     generatorNodeId: string | undefined;
@@ -134,7 +136,7 @@ export const useGraphChat = () => {
         return newPromptNode?.id;
     };
 
-    const addGithubInputNodes = (fromNodeId: string) => {
+    const addGithubInputNodes = (context: RepoContent, fromNodeId: string) => {
         const { x: inputNodeBaseX, y: inputNodeBaseY, height: _ } = getNodeRect(fromNodeId);
 
         const newGithubNode = placeBlock({
@@ -143,6 +145,12 @@ export const useGraphChat = () => {
             fromNodeId: fromNodeId,
             positionFrom: { x: inputNodeBaseX, y: inputNodeBaseY },
             positionOffset: { x: -600, y: 0 },
+            data: {
+                repo: context.repo,
+                files: context.selectedFiles,
+                selectedIssues: context.selectedIssues ?? [],
+                branch: context.currentBranch,
+            },
         });
 
         placeEdge(graphId.value, newGithubNode?.id, fromNodeId, null, 'attachment_' + fromNodeId);
@@ -305,42 +313,45 @@ export const useGraphChat = () => {
     const createNodeFromVariant = (
         generatorNode: NodeTypeEnum,
         fromNodeId: string,
-        options: NodeTypeEnum[] | undefined = undefined,
-        inputText: string = '',
-        forcedNodeId: string | null = null,
+        options: { submission: ChatInputSubmission; forcedNodeId?: string | null },
     ): CreatedChatNodes => {
         let newNodeId: string | undefined;
         let promptNodeId: string | undefined;
         const optionIds: string[] = [];
+        const { submission, forcedNodeId = null } = options;
 
         switch (generatorNode) {
             case NodeTypeEnum.TEXT_TO_TEXT:
-                newNodeId = addTextToTextInputNodes(inputText, fromNodeId, forcedNodeId);
+                newNodeId = addTextToTextInputNodes(submission.message, fromNodeId, forcedNodeId);
                 break;
             case NodeTypeEnum.PARALLELIZATION:
-                newNodeId = addParallelizationInputNode(inputText, fromNodeId, forcedNodeId);
+                newNodeId = addParallelizationInputNode(submission.message, fromNodeId, forcedNodeId);
                 break;
             case NodeTypeEnum.ROUTING:
-                newNodeId = addRoutingInputNode(inputText, fromNodeId, forcedNodeId);
+                newNodeId = addRoutingInputNode(submission.message, fromNodeId, forcedNodeId);
                 break;
             default:
                 console.warn(`Unknown node variant: ${generatorNode}`);
                 break;
         }
 
-        for (const option of options ?? []) {
-            if (option === NodeTypeEnum.FILE_PROMPT && newNodeId) {
-                const optionId = addFilesPromptInputNodes([], newNodeId);
-                if (optionId) optionIds.push(optionId);
-            } else if (option === NodeTypeEnum.PROMPT && newNodeId) {
-                const optionId = addPromptFromNodeId(inputText, newNodeId);
-                if (optionId) {
-                    optionIds.push(optionId);
-                    promptNodeId = optionId;
-                }
-            } else if (option === NodeTypeEnum.GITHUB && newNodeId) {
-                const optionId = addGithubInputNodes(newNodeId);
-                if (optionId) optionIds.push(optionId);
+        if (newNodeId) {
+            promptNodeId = addPromptFromNodeId(submission.message, newNodeId);
+            if (promptNodeId) optionIds.push(promptNodeId);
+
+            if (submission.files.length > 0) {
+                const fileNodeId = addFilesPromptInputNodes(submission.files, newNodeId);
+                if (fileNodeId) optionIds.push(fileNodeId);
+            }
+
+            const githubContext = submission.githubContext;
+            if (
+                githubContext &&
+                (githubContext.selectedFiles.length > 0 ||
+                    (githubContext.selectedIssues?.length ?? 0) > 0)
+            ) {
+                const githubNodeId = addGithubInputNodes(githubContext, newNodeId);
+                if (githubNodeId) optionIds.push(githubNodeId);
             }
         }
 
@@ -374,6 +385,7 @@ export const useGraphChat = () => {
     return {
         addTextToTextInputNodes,
         addFilesPromptInputNodes,
+        addGithubInputNodes,
         addParallelizationInputNode,
         updatePromptNodeText,
         isCanvasEmpty,

--- a/ui/app/composables/useGraphEvents.ts
+++ b/ui/app/composables/useGraphEvents.ts
@@ -1,7 +1,7 @@
 import type { NodeCategoryEnum } from '@/types/enums';
 import type { ExecutionPlanResponse } from '@/types/chat';
 import type { DragZoneHoverEvent } from '@/types/graph';
-import type { RepoContent, FileTreeNode, GithubIssue } from '@/types/github';
+import type { RepoContent } from '@/types/github';
 import type { PromptImproverReviewChangeInput } from '@/types/promptImprover';
 import type { PromptTemplate, WheelSlot } from '@/types/settings';
 import type { QuickWorkflowDirection } from '@/utils/quickWorkflow';
@@ -21,12 +21,14 @@ type BusEvents = {
     'open-fullscreen': { open: boolean; rawElement?: string };
     'drag-zone-hover': DragZoneHoverEvent | null;
 
-    'open-github-file-select': { repoContent: RepoContent; nodeId: string };
+    'open-github-file-select': {
+        target: GithubSelectorTarget;
+        repoContent: RepoContent | null;
+        initialTab: GithubSelectorTab;
+    };
     'close-github-file-select': {
-        selectedFilePaths: FileTreeNode[];
-        selectedIssues?: GithubIssue[];
-        nodeId: string;
-        branch?: string;
+        target: GithubSelectorTarget;
+        repoContent: RepoContent | null;
     };
 
     'open-attachment-select': { nodeId: string | null; selectedFiles: FileSystemObject[] };
@@ -64,6 +66,11 @@ type BusEvents = {
         error?: string;
     };
 };
+
+export type GithubSelectorTab = 'files' | 'issues';
+export type GithubSelectorTarget =
+    | { kind: 'node'; nodeId: string }
+    | { kind: 'chat-input' };
 
 const listeners: { [key in keyof BusEvents]?: Array<(arg: BusEvents[key]) => void> } = {};
 

--- a/ui/app/layouts/canvas.vue
+++ b/ui/app/layouts/canvas.vue
@@ -21,8 +21,6 @@ onMounted(() => {
 
         <UiUtilsFullscreenMountpoint />
 
-        <UiGraphNodeUtilsGithubFileSelectMountpoint />
-
         <UiGraphNodeUtilsFilePromptMountpoint />
     </div>
 </template>

--- a/ui/app/pages/index.vue
+++ b/ui/app/pages/index.vue
@@ -3,6 +3,7 @@ import { DEFAULT_NODE_ID } from '@/constants';
 import { NodeTypeEnum, MessageRoleEnum, MessageContentTypeEnum } from '@/types/enums';
 import type { MessageContent, BlockDefinition } from '@/types/graph';
 import type { User } from '@/types/user';
+import type { ChatInputSubmission } from '@/types/chat';
 import type HomeRecentCanvasSection from '~/components/ui/home/recentCanvasSection.vue';
 import { PLAN_LIMITS } from '@/constants/limits';
 
@@ -130,7 +131,7 @@ const loadMoreGraphs = async () => {
     }
 };
 
-const openNewFromInput = async (message: string, files: FileSystemObject[]) => {
+const openNewFromInput = async (submission: ChatInputSubmission) => {
     if ((user.value as User)?.plan_type === 'free') {
         const nonTemporaryGraphs = graphs.value.filter((g) => !g.temporary);
         if (nonTemporaryGraphs.length >= PLAN_LIMITS.FREE.MAX_GRAPHS) {
@@ -164,8 +165,8 @@ const openNewFromInput = async (message: string, files: FileSystemObject[]) => {
     openChatId.value = textToTextNodeId;
 
     let filesContent: MessageContent[] = [];
-    if (files && files.length > 0) {
-        filesContent = files.map((file) => fileToMessageContent(file));
+    if (submission.files.length > 0) {
+        filesContent = submission.files.map((file) => fileToMessageContent(file));
     }
 
     addMessage(
@@ -174,7 +175,7 @@ const openNewFromInput = async (message: string, files: FileSystemObject[]) => {
             content: [
                 {
                     type: MessageContentTypeEnum.TEXT,
-                    text: message,
+                    text: submission.message,
                 },
                 ...filesContent,
             ],
@@ -184,7 +185,8 @@ const openNewFromInput = async (message: string, files: FileSystemObject[]) => {
             data: {
                 reply: '',
                 model: upcomingModelData.value.data.model as string,
-                files: files,
+                files: submission.files,
+                githubContext: submission.githubContext,
             },
             usageData: null,
         },

--- a/ui/app/types/chat.d.ts
+++ b/ui/app/types/chat.d.ts
@@ -1,5 +1,12 @@
 import type { NodeTypeEnum } from '@/types/enums';
 import type { Message } from '@/types/graph';
+import type { RepoContent } from '@/types/github';
+
+export interface ChatInputSubmission {
+    message: string;
+    files: FileSystemObject[];
+    githubContext: RepoContent | null;
+}
 
 export interface GenerateRequest {
     graph_id: string;

--- a/ui/app/utils/imagePlayground.ts
+++ b/ui/app/utils/imagePlayground.ts
@@ -21,6 +21,11 @@ export const IMAGE_PLAYGROUND_RESOLUTIONS: Array<{ id: string; pixels: string }>
 export const IMAGE_PLAYGROUND_GENERATED_IMAGE_DRAG_TYPE =
     'application/x-meridian-image-playground-generated-image';
 
+export type ImagePreviewSize = '48x48' | '160x160' | '512x512';
+
+export const IMAGE_PLAYGROUND_GALLERY_SIZES =
+    '(min-width: 1536px) 20vw, (min-width: 1280px) 25vw, (min-width: 768px) 33vw, 50vw';
+
 const ASPECT_RATIO_TOLERANCE = 0.02;
 
 type StyleVisual = {
@@ -61,10 +66,13 @@ export const IMAGE_PLAYGROUND_STYLE_VISUALS: Record<string, StyleVisual> = {
     },
 };
 
-export const imagePlaygroundImageUrl = (id: string, thumbnail = false) =>
-    thumbnail
-        ? `/api/auth/refresh/files/view/${id}?size=512x512`
+export const imagePlaygroundImageUrl = (id: string, previewSize?: ImagePreviewSize) =>
+    previewSize
+        ? `/api/auth/refresh/files/view/${id}?size=${previewSize}`
         : `/api/auth/refresh/files/view/${id}`;
+
+export const imagePlaygroundGallerySrcset = (id: string) =>
+    `${imagePlaygroundImageUrl(id, '160x160')} 160w, ${imagePlaygroundImageUrl(id, '512x512')} 512w`;
 
 export const imagePlaygroundDownloadUrl = (id: string) =>
     `/api/auth/refresh/files/view/${id}?download=1`;

--- a/ui/tests/nuxt/alibabaTokenPlanMediaPlayground.spec.ts
+++ b/ui/tests/nuxt/alibabaTokenPlanMediaPlayground.spec.ts
@@ -277,8 +277,8 @@ describe('Alibaba Token Plan Image Playground behavior', () => {
         }
     });
 
-    it('labels persisted Alibaba video audio as provider-managed rather than silent', async () => {
-        settingsRefs.toolsImageGenerationSettings.value.defaultVideoModel = fixtures.t2v.id;
+    it('displays and reuses persisted Alibaba video metadata', async () => {
+        settingsRefs.toolsImageGenerationSettings.value.defaultVideoModel = fixtures.openRouterVideo.id;
         generatedVideos.value = [{
             id: 'generated-video-1',
             name: 'Generated video',
@@ -286,16 +286,50 @@ describe('Alibaba Token Plan Image Playground behavior', () => {
             content_type: 'video/mp4',
             created_at: '2026-07-23T00:00:00Z',
             updated_at: '2026-07-23T00:00:00Z',
-            model: fixtures.t2v.id,
+            prompt: 'Persisted motion directive',
+            model: fixtures.r2v.id,
+            aspect_ratio: '9:16',
+            resolution: '1080p',
+            duration: 10,
             generate_audio: false,
-            source_image_ids: [],
+            source_image_ids: ['reference-1', 'reference-2'],
         }];
         const wrapper = await mountSuspended(VideoPane, mountOptions);
         await nextTick();
 
         try {
-            expect(wrapper.text()).toContain('provider-managed audio');
-            expect(wrapper.text()).not.toContain('· silent ·');
+            const persistedVideo = wrapper.get('article');
+            expect(persistedVideo.text()).toContain('Persisted motion directive');
+            expect(persistedVideo.text()).toContain(fixtures.r2v.id);
+            expect(persistedVideo.text()).toContain('9:16');
+            expect(persistedVideo.text()).toContain('1080p');
+            expect(persistedVideo.text()).toContain('provider-managed audio');
+            expect(persistedVideo.text()).not.toContain('· silent ·');
+
+            await wrapper.get('button[title="Reuse settings"]').trigger('click');
+            await nextTick();
+
+            expect(wrapper.get('textarea').element.value).toBe('Persisted motion directive');
+            expect(playgroundRefs.sourceImages.value.map((reference) => reference.id)).toEqual([
+                'reference-1',
+                'reference-2',
+            ]);
+
+            const buttons = wrapper.findAll('button');
+            const selectedModel = buttons.find((button) => button.text().includes('HappyHorse R2V'));
+            const selectedAspectRatio = buttons.find((button) => button.text().trim() === '9:16');
+            const selectedResolution = buttons.find((button) => button.text().includes('1080p'));
+            const selectedDuration = buttons.find((button) => button.text().trim() === '10s');
+            const audioButton = buttons.find((button) =>
+                button.text().includes('Audio managed by HappyHorse'),
+            );
+
+            expect(selectedModel?.classes()).toContain('border-ember-glow');
+            expect(selectedAspectRatio?.classes()).toContain('border-ember-glow');
+            expect(selectedResolution?.classes()).toContain('border-ember-glow');
+            expect(selectedDuration?.classes()).toContain('border-ember-glow');
+            expect(audioButton?.attributes('disabled')).toBeDefined();
+            expect(audioButton?.classes()).not.toContain('bg-ember-glow/8');
         } finally {
             wrapper.unmount();
         }

--- a/ui/tests/nuxt/chatAddMenu.spec.ts
+++ b/ui/tests/nuxt/chatAddMenu.spec.ts
@@ -1,0 +1,130 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { defineComponent, h } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import UploadButton from '@/components/ui/chat/attachment/uploadButton.vue';
+
+const SlotStub = defineComponent({
+    setup(_, { slots }) {
+        return () => h('div', slots.default?.());
+    },
+});
+
+const mountMenu = () =>
+    mountSuspended(UploadButton, {
+        global: {
+            stubs: {
+                Teleport: true,
+                AnimatePresence: SlotStub,
+                UiIcon: true,
+            },
+        },
+    });
+
+describe('chat add menu', () => {
+    it('renders exact flat headings and actions in order', async () => {
+        const wrapper = await mountMenu();
+        await wrapper.get('button[aria-label="Add context"]').trigger('click');
+
+        const labels = wrapper
+            .findAll('li')
+            .map((item) => item.text().trim())
+            .filter(Boolean);
+        expect(labels).toEqual([
+            'Git',
+            'Add files',
+            'Add PR/issue',
+            'Files',
+            'From device',
+            'From cloud',
+        ]);
+
+        expect(wrapper.findAll('ul')).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    it('emits each Git and file action and closes after selection', async () => {
+        const wrapper = await mountMenu();
+        const addButton = wrapper.get('button[aria-label="Add context"]');
+
+        await addButton.trigger('click');
+        await wrapper.findAll('ul button')[0]!.trigger('click');
+        expect(wrapper.emitted('add-git-context')).toEqual([['files']]);
+
+        await addButton.trigger('click');
+        const actionButtons = wrapper.findAll('ul button');
+        await actionButtons[1]!.trigger('click');
+        expect(wrapper.emitted('add-git-context')).toEqual([['files'], ['issues']]);
+
+        await addButton.trigger('click');
+        await wrapper.findAll('ul button').at(-1)!.trigger('click');
+        expect(wrapper.emitted('open-cloud-select')).toHaveLength(1);
+
+        await addButton.trigger('click');
+        const input = wrapper.get('input[type="file"]');
+        const fileList = { 0: new File(['test'], 'test.txt'), length: 1, item: () => null };
+        Object.defineProperty(input.element, 'files', { value: fileList, configurable: true });
+        await input.trigger('change');
+        expect(wrapper.emitted('add-files')).toEqual([[fileList]]);
+        wrapper.unmount();
+    });
+
+    it('does not open while disabled', async () => {
+        const wrapper = await mountSuspended(UploadButton, {
+            props: { disabled: true },
+            global: { stubs: { Teleport: true, AnimatePresence: SlotStub, UiIcon: true } },
+        });
+
+        await wrapper.get('button[aria-label="Add context"]').trigger('click');
+        expect(wrapper.find('ul').exists()).toBe(false);
+        wrapper.unmount();
+    });
+
+    it('positions with untransformed dimensions fully above the button and clamps horizontally', async () => {
+        const wrapper = await mountMenu();
+        const addButton = wrapper.get('button[aria-label="Add context"]');
+        vi.spyOn(addButton.element, 'getBoundingClientRect').mockReturnValue({
+            top: 400,
+            left: 900,
+            right: 948,
+            bottom: 448,
+            width: 48,
+            height: 48,
+            x: 900,
+            y: 400,
+            toJSON: () => ({}),
+        });
+        const widthDescriptor = Object.getOwnPropertyDescriptor(
+            HTMLElement.prototype,
+            'offsetWidth',
+        );
+        const heightDescriptor = Object.getOwnPropertyDescriptor(
+            HTMLElement.prototype,
+            'offsetHeight',
+        );
+        Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+            configurable: true,
+            get: () => 208,
+        });
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+            configurable: true,
+            get: () => 240,
+        });
+
+        try {
+            await addButton.trigger('click');
+            await wrapper.vm.$nextTick();
+
+            const menu = wrapper.get('[data-add-context-menu]');
+            expect(menu.attributes('style')).toContain('top: 152px');
+            expect(menu.attributes('style')).toContain('left: 808px');
+        } finally {
+            if (widthDescriptor) {
+                Object.defineProperty(HTMLElement.prototype, 'offsetWidth', widthDescriptor);
+            }
+            if (heightDescriptor) {
+                Object.defineProperty(HTMLElement.prototype, 'offsetHeight', heightDescriptor);
+            }
+            wrapper.unmount();
+        }
+    });
+});

--- a/ui/tests/nuxt/chatBox.spec.ts
+++ b/ui/tests/nuxt/chatBox.spec.ts
@@ -1,0 +1,145 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { defineComponent, h, ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ChatBox from '@/components/ui/chat/chatBox.vue';
+import { NodeTypeEnum } from '@/types/enums';
+
+const stubs = vi.hoisted(() => ({
+    callOrder: [] as string[],
+    generateNew: vi.fn(),
+    graphEmit: vi.fn(),
+}));
+
+vi.mock('@/composables/useChatGenerator', async () => {
+    const { ref: vueRef } = await import('vue');
+
+    return {
+        useChatGenerator: () => ({
+            isStreaming: vueRef(false),
+            streamingSession: vueRef(null),
+            generationError: vueRef(null),
+            selectedNodeType: vueRef(NodeTypeEnum.STREAMING),
+            generateNew: stubs.generateNew,
+            generateFollowUp: vi.fn(),
+            regenerate: vi.fn(),
+            handleCancelStream: vi.fn(),
+            restoreStreamingState: vi.fn(),
+        }),
+    };
+});
+
+vi.mock('@/composables/useMessageEditing', async () => {
+    const { ref: vueRef } = await import('vue');
+
+    return {
+        useMessageEditing: () => ({
+            currentEditModeIdx: vueRef(null),
+            handleEditDone: vi.fn(),
+        }),
+    };
+});
+
+mockNuxtImport('storeToRefs', () => (store: object) => store);
+mockNuxtImport('useChatStore', () => () => ({
+    openChatId: ref('chat-id'),
+    isFetching: ref(false),
+    isCanvasReady: ref(false),
+    lastOpenedChatId: ref('chat-id'),
+    closeChat: vi.fn(),
+    loadAndOpenChat: vi.fn(),
+    getSession: vi.fn(() => ({ fromNodeId: null, messages: [] })),
+}));
+mockNuxtImport('useSidebarCanvasStore', () => () => ({
+    isRightOpen: ref(false),
+    isLeftOpen: ref(false),
+}));
+mockNuxtImport('useCanvasSaveStore', () => () => ({ ensureGraphSaved: vi.fn() }));
+mockNuxtImport('useStreamStore', () => () => ({
+    isNodeStreaming: ref(() => false),
+    regenerateTitle: vi.fn(),
+    removeChatCallback: vi.fn(),
+}));
+mockNuxtImport('useSettingsStore', () => () => ({
+    generalSettings: ref({
+        openChatViewOnNewCanvas: false,
+        enableMessageCollapsing: false,
+    }),
+}));
+mockNuxtImport('useWebSocket', () => () => ({
+    isConnected: ref(true),
+    isReconnecting: ref(false),
+    connect: vi.fn(),
+}));
+mockNuxtImport('useGraphChat', () => () => ({ isCanvasEmpty: vi.fn(() => false) }));
+mockNuxtImport('useChatScroll', () => () => ({
+    goBackToBottom: vi.fn(),
+    scrollToBottom: vi.fn(),
+    triggerScroll: vi.fn(),
+    handleScroll: vi.fn(),
+    isLockedToBottom: ref(true),
+}));
+mockNuxtImport('useAPI', () => () => ({ persistGraph: vi.fn() }));
+mockNuxtImport('useGraphEvents', () => () => ({
+    emit: stubs.graphEmit,
+    on: vi.fn(() => () => undefined),
+}));
+mockNuxtImport('useToast', () => () => ({ success: vi.fn(), error: vi.fn() }));
+mockNuxtImport('useMessage', () => () => ({
+    getTextFromMessage: vi.fn(() => ''),
+    getTextFromMessageFast: vi.fn(() => ''),
+}));
+mockNuxtImport('useHydratedMediaQuery', () => () => ref(false));
+
+const TextInputStub = defineComponent({
+    name: 'UiChatTextInput',
+    emits: ['generate'],
+    setup() {
+        return () => h('div');
+    },
+});
+
+describe('chatBox manual message generation', () => {
+    beforeEach(() => {
+        stubs.callOrder.length = 0;
+        stubs.graphEmit.mockReset().mockImplementation(() => {
+            stubs.callOrder.push('open-upcoming-node-data');
+        });
+        stubs.generateNew.mockReset().mockImplementation(() => {
+            stubs.callOrder.push('generate-new');
+        });
+    });
+
+    it('opens upcoming node data before generating with unchanged arguments', async () => {
+        const wrapper = await mountSuspended(ChatBox, {
+            shallow: true,
+            global: {
+                stubs: {
+                    UiChatTextInput: TextInputStub,
+                },
+            },
+        });
+        const message = 'Generate this';
+        const files: FileSystemObject[] = [
+            {
+                id: 'file-id',
+                name: 'reference.png',
+                type: 'file',
+                created_at: '2026-08-04T00:00:00Z',
+                updated_at: '2026-08-04T00:00:00Z',
+                cached: true,
+            },
+        ];
+
+        try {
+            wrapper.findComponent(TextInputStub).vm.$emit('generate', message, files);
+
+            expect(stubs.graphEmit).toHaveBeenCalledOnce();
+            expect(stubs.graphEmit).toHaveBeenCalledWith('open-upcoming-node-data', {});
+            expect(stubs.generateNew).toHaveBeenCalledOnce();
+            expect(stubs.generateNew).toHaveBeenCalledWith(null, message, files);
+            expect(stubs.callOrder).toEqual(['open-upcoming-node-data', 'generate-new']);
+        } finally {
+            wrapper.unmount();
+        }
+    });
+});

--- a/ui/tests/nuxt/chatBox.spec.ts
+++ b/ui/tests/nuxt/chatBox.spec.ts
@@ -3,6 +3,7 @@ import { defineComponent, h, ref } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ChatBox from '@/components/ui/chat/chatBox.vue';
 import { NodeTypeEnum } from '@/types/enums';
+import type { ChatInputSubmission } from '@/types/chat';
 
 const stubs = vi.hoisted(() => ({
     callOrder: [] as string[],
@@ -109,7 +110,7 @@ describe('chatBox manual message generation', () => {
         });
     });
 
-    it('opens upcoming node data before generating with unchanged arguments', async () => {
+    it('opens upcoming node data before forwarding the typed submission', async () => {
         const wrapper = await mountSuspended(ChatBox, {
             shallow: true,
             global: {
@@ -118,25 +119,26 @@ describe('chatBox manual message generation', () => {
                 },
             },
         });
-        const message = 'Generate this';
-        const files: FileSystemObject[] = [
-            {
+        const submission: ChatInputSubmission = {
+            message: 'Generate this',
+            files: [{
                 id: 'file-id',
                 name: 'reference.png',
                 type: 'file',
                 created_at: '2026-08-04T00:00:00Z',
                 updated_at: '2026-08-04T00:00:00Z',
                 cached: true,
-            },
-        ];
+            }],
+            githubContext: null,
+        };
 
         try {
-            wrapper.findComponent(TextInputStub).vm.$emit('generate', message, files);
+            wrapper.findComponent(TextInputStub).vm.$emit('generate', submission);
 
             expect(stubs.graphEmit).toHaveBeenCalledOnce();
             expect(stubs.graphEmit).toHaveBeenCalledWith('open-upcoming-node-data', {});
             expect(stubs.generateNew).toHaveBeenCalledOnce();
-            expect(stubs.generateNew).toHaveBeenCalledWith(null, message, files);
+            expect(stubs.generateNew).toHaveBeenCalledWith(null, submission);
             expect(stubs.callOrder).toEqual(['open-upcoming-node-data', 'generate-new']);
         } finally {
             wrapper.unmount();

--- a/ui/tests/nuxt/chatTextInput.spec.ts
+++ b/ui/tests/nuxt/chatTextInput.spec.ts
@@ -1,0 +1,122 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import TextInput from '@/components/ui/chat/textInput.vue';
+import { NodeTypeEnum } from '@/types/enums';
+
+const stubs = vi.hoisted(() => ({
+    uploadFile: vi.fn(),
+    getRootFolder: vi.fn(),
+    getFolderContents: vi.fn(),
+    createFolder: vi.fn(),
+    fetchUsage: vi.fn(),
+    error: vi.fn(),
+}));
+
+mockNuxtImport('useAPI', () => () => ({
+    uploadFile: stubs.uploadFile,
+    getRootFolder: stubs.getRootFolder,
+    getFolderContents: stubs.getFolderContents,
+    createFolder: stubs.createFolder,
+}));
+
+mockNuxtImport('useSettingsStore', () => () => ({
+    blockAttachmentSettings: { default_upload_folder: null },
+}));
+
+mockNuxtImport('useUsageStore', () => () => ({
+    fetchUsage: stubs.fetchUsage,
+}));
+
+mockNuxtImport('useToast', () => () => ({ error: stubs.error }));
+mockNuxtImport('useGraphEvents', () => () => ({
+    emit: vi.fn(),
+    on: vi.fn(() => () => undefined),
+}));
+
+const mountInput = () =>
+    mountSuspended(TextInput, {
+        props: {
+            isLockedToBottom: true,
+            isStreaming: false,
+            nodeType: NodeTypeEnum.PROMPT,
+            from: 'chat',
+        },
+        global: {
+            stubs: {
+                UiChatAttachmentChipListItem: true,
+                UiChatAttachmentUploadButton: true,
+                UiChatUtilsSendChatButton: true,
+                UiChatUtilsUploadProgressCircle: true,
+                UiIcon: true,
+            },
+        },
+    });
+
+const dispatchPaste = (element: Element, text: string, files: File[]) => {
+    const event = new Event('paste', { bubbles: true, cancelable: true });
+    const items = [
+        {
+            kind: 'string',
+            type: 'text/plain',
+            getAsFile: () => null,
+        },
+        ...files.map((file) => ({
+            kind: 'file',
+            type: file.type,
+            getAsFile: () => file,
+        })),
+    ];
+
+    Object.defineProperty(event, 'clipboardData', {
+        value: {
+            items,
+            getData: (type: string) => (type === 'text/plain' ? text : ''),
+        },
+    });
+    element.dispatchEvent(event);
+};
+
+describe('chat text input clipboard paste', () => {
+    beforeEach(() => {
+        stubs.uploadFile.mockReset().mockResolvedValue({
+            id: 'uploaded-image',
+            name: 'clipboard.png',
+        });
+        stubs.getRootFolder.mockReset().mockResolvedValue({ id: 'root' });
+        stubs.getFolderContents.mockReset().mockResolvedValue([]);
+        stubs.createFolder.mockReset();
+        stubs.fetchUsage.mockReset();
+        stubs.error.mockReset();
+        Object.defineProperty(document, 'execCommand', {
+            value: vi.fn(() => true),
+            configurable: true,
+        });
+    });
+
+    it('uploads clipboard images once while preserving mixed plain text paste', async () => {
+        const wrapper = await mountInput();
+        const image = new File(['image'], 'clipboard.png', { type: 'image/png' });
+        const nonImage = new File(['document'], 'notes.txt', { type: 'text/plain' });
+
+        try {
+            dispatchPaste(wrapper.get('[contenteditable]').element, 'Pasted caption', [
+                image,
+                nonImage,
+            ]);
+            await flushPromises();
+
+            expect(document.execCommand).toHaveBeenCalledOnce();
+            expect(document.execCommand).toHaveBeenCalledWith(
+                'insertText',
+                false,
+                'Pasted caption',
+            );
+            expect(stubs.uploadFile).toHaveBeenCalledOnce();
+            expect(stubs.uploadFile).toHaveBeenCalledWith(image, 'root');
+            expect(stubs.fetchUsage).toHaveBeenCalledOnce();
+        } finally {
+            wrapper.unmount();
+        }
+    });
+});

--- a/ui/tests/nuxt/chatTextInput.spec.ts
+++ b/ui/tests/nuxt/chatTextInput.spec.ts
@@ -1,6 +1,7 @@
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AttachmentChipListItem from '@/components/ui/chat/attachment/chipListItem.vue';
 import TextInput from '@/components/ui/chat/textInput.vue';
 import { NodeTypeEnum } from '@/types/enums';
 
@@ -11,6 +12,8 @@ const stubs = vi.hoisted(() => ({
     createFolder: vi.fn(),
     fetchUsage: vi.fn(),
     error: vi.fn(),
+    graphEmit: vi.fn(),
+    graphOn: vi.fn(),
 }));
 
 mockNuxtImport('useAPI', () => () => ({
@@ -30,21 +33,24 @@ mockNuxtImport('useUsageStore', () => () => ({
 
 mockNuxtImport('useToast', () => () => ({ error: stubs.error }));
 mockNuxtImport('useGraphEvents', () => () => ({
-    emit: vi.fn(),
-    on: vi.fn(() => () => undefined),
+    emit: stubs.graphEmit,
+    on: stubs.graphOn,
 }));
 
-const mountInput = () =>
+const mountInput = (
+    from: 'home' | 'chat' = 'chat',
+    stubAttachmentChip = true,
+) =>
     mountSuspended(TextInput, {
         props: {
             isLockedToBottom: true,
             isStreaming: false,
             nodeType: NodeTypeEnum.PROMPT,
-            from: 'chat',
+            from,
         },
         global: {
             stubs: {
-                UiChatAttachmentChipListItem: true,
+                UiChatAttachmentChipListItem: stubAttachmentChip,
                 UiChatAttachmentUploadButton: true,
                 UiChatUtilsSendChatButton: true,
                 UiChatUtilsUploadProgressCircle: true,
@@ -77,17 +83,36 @@ const dispatchPaste = (element: Element, text: string, files: File[]) => {
     element.dispatchEvent(event);
 };
 
+const selectCloudAttachments = (files: FileSystemObject[]) => {
+    const registration = stubs.graphOn.mock.calls.find(
+        (call) => call[0] === 'close-attachment-select',
+    );
+    const handler = registration?.[1] as
+        | ((payload: { selectedFiles: FileSystemObject[] }) => void)
+        | undefined;
+
+    if (!handler) throw new Error('Attachment selection handler was not registered');
+    handler({ selectedFiles: files });
+};
+
 describe('chat text input clipboard paste', () => {
     beforeEach(() => {
         stubs.uploadFile.mockReset().mockResolvedValue({
             id: 'uploaded-image',
             name: 'clipboard.png',
+            type: 'file',
+            content_type: 'image/png',
+            created_at: '',
+            updated_at: '',
+            cached: false,
         });
         stubs.getRootFolder.mockReset().mockResolvedValue({ id: 'root' });
         stubs.getFolderContents.mockReset().mockResolvedValue([]);
         stubs.createFolder.mockReset();
         stubs.fetchUsage.mockReset();
         stubs.error.mockReset();
+        stubs.graphEmit.mockReset();
+        stubs.graphOn.mockReset().mockReturnValue(() => undefined);
         Object.defineProperty(document, 'execCommand', {
             value: vi.fn(() => true),
             configurable: true,
@@ -117,6 +142,173 @@ describe('chat text input clipboard paste', () => {
             expect(stubs.fetchUsage).toHaveBeenCalledOnce();
         } finally {
             wrapper.unmount();
+        }
+    });
+
+    it.each(['home', 'chat'] as const)(
+        'renders a sharp 56px authenticated image preview from the %s input',
+        async (from) => {
+            const wrapper = await mountInput(from, false);
+            const image = new File(['image'], 'clipboard.png', { type: 'image/png' });
+
+            try {
+                dispatchPaste(wrapper.get('[contenteditable]').element, '', [image]);
+                await flushPromises();
+
+                const preview = wrapper.get('img');
+                expect(preview.attributes('src')).toBe(
+                    '/api/auth/refresh/files/view/uploaded-image?size=160x160',
+                );
+                expect(preview.attributes('alt')).toBe('');
+                expect(preview.attributes('width')).toBe('56');
+                expect(preview.attributes('height')).toBe('56');
+                expect(preview.classes()).toContain('h-14');
+                expect(preview.classes()).toContain('w-14');
+                expect(wrapper.text()).not.toContain('clipboard.png');
+            } finally {
+                wrapper.unmount();
+            }
+        },
+    );
+
+    it('separates mixed images and files into wrapping rows and removes the selected image', async () => {
+        const wrapper = await mountInput('chat', false);
+        const image: FileSystemObject = {
+            id: 'cloud-image',
+            name: 'selected.webp',
+            type: 'file',
+            content_type: 'image/webp',
+            created_at: '',
+            updated_at: '',
+            cached: false,
+        };
+        const document: FileSystemObject = {
+            ...image,
+            id: 'cloud-document',
+            name: 'notes.txt',
+            content_type: 'text/plain',
+        };
+
+        try {
+            selectCloudAttachments([image, document]);
+            await flushPromises();
+
+            const attachmentGrid = wrapper.get('[data-attachment-grid]');
+            const imageRow = wrapper.get('[data-attachment-row="images"]');
+            const fileRow = wrapper.get('[data-attachment-row="files"]');
+            expect(attachmentGrid.classes()).toContain('grid');
+            expect(attachmentGrid.classes()).toContain('grid-cols-1');
+            expect(imageRow.element.parentElement).toBe(attachmentGrid.element);
+            expect(fileRow.element.parentElement).toBe(attachmentGrid.element);
+            expect(imageRow.classes()).toContain('col-span-1');
+            expect(fileRow.classes()).toContain('col-span-1');
+            expect(imageRow.classes()).toContain('w-full');
+            expect(fileRow.classes()).toContain('w-full');
+            expect(imageRow.classes()).toContain('flex-wrap');
+            expect(fileRow.classes()).toContain('flex-wrap');
+            expect(imageRow.find('img').exists()).toBe(true);
+            expect(imageRow.text()).not.toContain('selected.webp');
+            expect(fileRow.text()).toContain('notes.txt');
+
+            await imageRow.get('button[aria-label="Remove selected.webp"]').trigger('click');
+
+            expect(wrapper.find('[data-attachment-row="images"]').exists()).toBe(false);
+            expect(wrapper.get('[data-attachment-row="files"]').text()).toContain('notes.txt');
+        } finally {
+            wrapper.unmount();
+        }
+    });
+});
+
+describe('chat attachment chip image previews', () => {
+    const imageFile: FileSystemObject = {
+        id: 'cloud-image',
+        name: 'selected.WEBP',
+        type: 'file',
+        created_at: '',
+        updated_at: '',
+        cached: false,
+    };
+
+    it('renders only the square preview with an accessible hover and focus remove control', async () => {
+        const wrapper = await mountSuspended(AttachmentChipListItem, {
+            props: {
+                file: imageFile,
+                removeFiles: true,
+                showImagePreview: true,
+            },
+            global: {
+                stubs: {
+                    UiIcon: true,
+                },
+            },
+        });
+
+        try {
+            const chip = wrapper.get('li');
+            const removeButton = wrapper.get('button');
+            expect(wrapper.get('img').attributes('src')).toBe(
+                '/api/auth/refresh/files/view/cloud-image?size=160x160',
+            );
+            expect(wrapper.text()).not.toContain('selected.WEBP');
+            expect(chip.classes()).not.toContain('border');
+            expect(chip.classes()).not.toContain('py-1.5');
+            expect(chip.classes()).not.toContain('pr-1.5');
+            expect(chip.classes()).not.toContain('pl-3');
+            expect(removeButton.attributes('aria-label')).toBe('Remove selected.WEBP');
+            expect(removeButton.classes()).toContain('absolute');
+            expect(removeButton.classes()).toContain('rounded-full');
+            expect(removeButton.classes()).toContain('border');
+            expect(removeButton.classes()).toContain('border-soft-silk/40');
+            expect(removeButton.classes()).toContain('bg-obsidian/90');
+            expect(removeButton.classes()).toContain('text-soft-silk');
+            expect(removeButton.classes()).toContain('shadow-md');
+            expect(removeButton.classes()).toContain('opacity-0');
+            expect(removeButton.classes()).toContain('group-hover:opacity-100');
+            expect(removeButton.classes()).toContain('group-hover:border-soft-silk/60');
+            expect(removeButton.classes()).toContain('group-hover:bg-obsidian');
+            expect(removeButton.classes()).toContain('group-hover:shadow-lg');
+            expect(removeButton.classes()).toContain('group-focus-within:opacity-100');
+            expect(removeButton.classes()).toContain('focus:opacity-100');
+            expect(removeButton.classes()).toContain('focus-visible:outline-2');
+        } finally {
+            wrapper.unmount();
+        }
+    });
+
+    it('preserves the default icon behavior and never previews non-images', async () => {
+        const defaultImageChip = await mountSuspended(AttachmentChipListItem, {
+            props: {
+                file: imageFile,
+                removeFiles: false,
+            },
+            global: {
+                stubs: {
+                    UiIcon: true,
+                },
+            },
+        });
+        const documentChip = await mountSuspended(AttachmentChipListItem, {
+            props: {
+                file: { ...imageFile, id: 'document', name: 'notes.txt' },
+                removeFiles: false,
+                showImagePreview: true,
+            },
+            global: {
+                stubs: {
+                    UiIcon: true,
+                },
+            },
+        });
+
+        try {
+            expect(defaultImageChip.find('img').exists()).toBe(false);
+            expect(defaultImageChip.findComponent({ name: 'UiIcon' }).exists()).toBe(true);
+            expect(documentChip.find('img').exists()).toBe(false);
+            expect(documentChip.findComponent({ name: 'UiIcon' }).exists()).toBe(true);
+        } finally {
+            defaultImageChip.unmount();
+            documentChip.unmount();
         }
     });
 });

--- a/ui/tests/nuxt/chatTextInput.spec.ts
+++ b/ui/tests/nuxt/chatTextInput.spec.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AttachmentChipListItem from '@/components/ui/chat/attachment/chipListItem.vue';
 import TextInput from '@/components/ui/chat/textInput.vue';
 import { NodeTypeEnum } from '@/types/enums';
+import type { RepoContent } from '@/types/github';
 
 const stubs = vi.hoisted(() => ({
     uploadFile: vi.fn(),
@@ -101,6 +102,17 @@ const selectCloudAttachments = (files: FileSystemObject[]) => {
 
     if (!handler) throw new Error('Attachment selection handler was not registered');
     handler({ selectedFiles: files });
+};
+
+const closeGithubSelector = (repoContent: RepoContent | null) => {
+    const registration = stubs.graphOn.mock.calls.find(
+        (call) => call[0] === 'close-github-file-select',
+    );
+    const handler = registration?.[1] as
+        | ((payload: { target: { kind: 'chat-input' }; repoContent: RepoContent | null }) => void)
+        | undefined;
+    if (!handler) throw new Error('Git context selection handler was not registered');
+    handler({ target: { kind: 'chat-input' }, repoContent });
 };
 
 describe('chat text input clipboard paste', () => {
@@ -384,5 +396,91 @@ describe('chat attachment chip image previews', () => {
             defaultImageChip.unmount();
             documentChip.unmount();
         }
+    });
+});
+
+describe('chat Git context', () => {
+    beforeEach(() => {
+        stubs.uploadFile.mockReset();
+        stubs.getRootFolder.mockReset();
+        stubs.getFolderContents.mockReset();
+        stubs.createFolder.mockReset();
+        stubs.fetchUsage.mockReset();
+        stubs.error.mockReset();
+        stubs.graphEmit.mockReset();
+        stubs.graphOn.mockReset().mockReturnValue(() => undefined);
+    });
+
+    it('opens targeted tabs, shows removable context, and submits then clears it', async () => {
+        const wrapper = await mountInput();
+        const context: RepoContent = {
+            repo: {
+                provider: 'github',
+                encoded_provider: 'github',
+                full_name: 'meridian/test',
+                description: null,
+                clone_url_ssh: 'git@example.test:meridian/test.git',
+                clone_url_https: 'https://example.test/meridian/test.git',
+                default_branch: 'main',
+            },
+            selectedFiles: [
+                { name: 'README.md', type: 'file', path: 'README.md', children: [] },
+            ],
+            selectedIssues: [],
+            currentBranch: 'main',
+        };
+
+        const addButton = wrapper.getComponent({ name: 'UiChatAttachmentUploadButton' });
+        addButton.vm.$emit('add-git-context', 'issues');
+        expect(stubs.graphEmit).toHaveBeenCalledWith('open-github-file-select', {
+            target: { kind: 'chat-input' },
+            repoContent: null,
+            initialTab: 'issues',
+        });
+
+        closeGithubSelector(context);
+        await flushPromises();
+        expect(wrapper.text()).toContain('meridian/test');
+        expect(wrapper.text()).toContain('1 file(s), 0 issue(s)');
+
+        await wrapper.get('button[aria-label="Remove Git context for meridian/test"]').trigger('click');
+        expect(wrapper.text()).not.toContain('meridian/test');
+
+        closeGithubSelector(context);
+        await flushPromises();
+
+        const input = wrapper.get('[contenteditable]');
+        input.element.textContent = 'Use this context';
+        await input.trigger('input');
+        wrapper.getComponent({ name: 'UiChatUtilsSendChatButton' }).vm.$emit('send');
+
+        expect(wrapper.emitted('generate')).toEqual([
+            [{ message: 'Use this context', files: [], githubContext: context }],
+        ]);
+        await flushPromises();
+        expect(wrapper.text()).not.toContain('meridian/test');
+
+        wrapper.unmount();
+    });
+
+    it('normalizes an empty confirmed repository to no pending context', async () => {
+        const wrapper = await mountInput();
+        closeGithubSelector({
+            repo: {
+                provider: 'github',
+                encoded_provider: 'github',
+                full_name: 'meridian/empty',
+                description: null,
+                clone_url_ssh: '',
+                clone_url_https: '',
+                default_branch: 'main',
+            },
+            selectedFiles: [],
+            selectedIssues: [],
+            currentBranch: 'main',
+        });
+        await flushPromises();
+        expect(wrapper.text()).not.toContain('meridian/empty');
+        wrapper.unmount();
     });
 });

--- a/ui/tests/nuxt/chatTextInput.spec.ts
+++ b/ui/tests/nuxt/chatTextInput.spec.ts
@@ -83,6 +83,14 @@ const dispatchPaste = (element: Element, text: string, files: File[]) => {
     element.dispatchEvent(event);
 };
 
+const dispatchDrop = (element: Element, files: File[]) => {
+    const event = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'dataTransfer', {
+        value: { files },
+    });
+    element.dispatchEvent(event);
+};
+
 const selectCloudAttachments = (files: FileSystemObject[]) => {
     const registration = stubs.graphOn.mock.calls.find(
         (call) => call[0] === 'close-attachment-select',
@@ -138,8 +146,74 @@ describe('chat text input clipboard paste', () => {
                 'Pasted caption',
             );
             expect(stubs.uploadFile).toHaveBeenCalledOnce();
-            expect(stubs.uploadFile).toHaveBeenCalledWith(image, 'root');
+            expect(stubs.uploadFile).toHaveBeenCalledWith(image, 'root', 'keep_both');
             expect(stubs.fetchUsage).toHaveBeenCalledOnce();
+        } finally {
+            wrapper.unmount();
+        }
+    });
+
+    it('attaches distinct server results from sequential same-name clipboard images', async () => {
+        stubs.uploadFile
+            .mockResolvedValueOnce({
+                id: 'first-image',
+                name: 'image.png',
+                type: 'file',
+                content_type: 'image/png',
+                created_at: '',
+                updated_at: '',
+                cached: false,
+            })
+            .mockResolvedValueOnce({
+                id: 'second-image',
+                name: 'image (1).png',
+                type: 'file',
+                content_type: 'image/png',
+                created_at: '',
+                updated_at: '',
+                cached: false,
+            });
+        const wrapper = await mountInput('chat', false);
+        const firstImage = new File(['first'], 'image.png', { type: 'image/png' });
+        const secondImage = new File(['second'], 'image.png', { type: 'image/png' });
+
+        try {
+            dispatchPaste(wrapper.get('[contenteditable]').element, '', [firstImage]);
+            await flushPromises();
+            dispatchPaste(wrapper.get('[contenteditable]').element, '', [secondImage]);
+            await flushPromises();
+
+            expect(stubs.uploadFile).toHaveBeenNthCalledWith(
+                1,
+                firstImage,
+                'root',
+                'keep_both',
+            );
+            expect(stubs.uploadFile).toHaveBeenNthCalledWith(
+                2,
+                secondImage,
+                'root',
+                'keep_both',
+            );
+            expect(wrapper.findAll('img').map((preview) => preview.attributes('src'))).toEqual([
+                '/api/auth/refresh/files/view/first-image?size=160x160',
+                '/api/auth/refresh/files/view/second-image?size=160x160',
+            ]);
+        } finally {
+            wrapper.unmount();
+        }
+    });
+
+    it('keeps drag-and-drop uploads policy-free', async () => {
+        const wrapper = await mountInput();
+        const image = new File(['image'], 'dropped.png', { type: 'image/png' });
+
+        try {
+            dispatchDrop(wrapper.get('[contenteditable]').element, [image]);
+            await flushPromises();
+
+            expect(stubs.uploadFile).toHaveBeenCalledOnce();
+            expect(stubs.uploadFile).toHaveBeenCalledWith(image, 'root');
         } finally {
             wrapper.unmount();
         }

--- a/ui/tests/nuxt/githubFileSelectMountpoint.spec.ts
+++ b/ui/tests/nuxt/githubFileSelectMountpoint.spec.ts
@@ -8,7 +8,6 @@ import type { RepoContent, RepositoryInfo } from '@/types/github';
 const stubs = vi.hoisted(() => ({
     graphOn: vi.fn(),
     graphEmit: vi.fn(),
-    fetchRepositories: vi.fn().mockResolvedValue([]),
     getGenericRepoTree: vi.fn(),
     getGenericRepoBranches: vi.fn(),
     cloneRepository: vi.fn(),
@@ -17,9 +16,6 @@ const stubs = vi.hoisted(() => ({
 }));
 
 mockNuxtImport('useSettingsStore', () => () => ({ storeKind: 'settings' }));
-mockNuxtImport('useRepositoryStore', () => () => ({
-    fetchRepositories: stubs.fetchRepositories,
-}));
 mockNuxtImport('storeToRefs', () => () => ({
     blockGithubSettings: { value: { autoPull: false } },
 }));
@@ -32,11 +28,10 @@ mockNuxtImport('useAPI', () => () => ({
 mockNuxtImport('useGraphEvents', () => () => ({ on: stubs.graphOn, emit: stubs.graphEmit }));
 mockNuxtImport('useToast', () => () => ({ error: stubs.error }));
 
-const RepoSelectStub = defineComponent({
-    name: 'UiGraphNodeUtilsGithubRepoSelect',
-    props: ['currentRepo'],
-    emits: ['update:currentRepo'],
-    setup: () => () => h('div', { 'data-repo-select': '' }),
+const RepositoryPickerStub = defineComponent({
+    name: 'UiGraphNodeUtilsGithubRepositoryPicker',
+    emits: ['select'],
+    setup: () => () => h('div', { 'data-repository-picker': '' }),
 });
 
 const IssueSelectorStub = defineComponent({
@@ -76,7 +71,7 @@ const mountSelector = () =>
             stubs: {
                 AnimatePresence: SlotStub,
                 UiIcon: true,
-                UiGraphNodeUtilsGithubRepoSelect: RepoSelectStub,
+                UiGraphNodeUtilsGithubRepositoryPicker: RepositoryPickerStub,
                 UiGraphNodeUtilsGithubIssuePrSelector: IssueSelectorStub,
                 UiGraphNodeUtilsGithubFileTreeSelector: true,
             },
@@ -87,7 +82,6 @@ describe('Git file selector mountpoint', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         stubs.graphOn.mockReturnValue(() => undefined);
-        stubs.fetchRepositories.mockResolvedValue([]);
         stubs.getGenericRepoTree.mockResolvedValue({
             name: '.',
             type: 'directory',
@@ -106,11 +100,15 @@ describe('Git file selector mountpoint', () => {
         });
         await flushPromises();
 
-        expect(stubs.fetchRepositories).toHaveBeenCalledOnce();
-        const repoSelector = wrapper.getComponent(RepoSelectStub);
-        repoSelector.vm.$emit('update:currentRepo', repo);
+        expect(wrapper.find('[data-repository-picker]').exists()).toBe(true);
+        expect(wrapper.find('[data-github-tab-navigation]').exists()).toBe(false);
+        expect(wrapper.findComponent({ name: 'UiGraphNodeUtilsGithubRepoSelect' }).exists()).toBe(
+            false,
+        );
+        wrapper.getComponent(RepositoryPickerStub).vm.$emit('select', repo);
         await flushPromises();
 
+        expect(wrapper.find('[data-github-tab-navigation]').exists()).toBe(true);
         expect(wrapper.find('[data-issue-selector]').exists()).toBe(true);
         expect(stubs.getGenericRepoTree).toHaveBeenCalledWith('github', 'meridian/test', 'develop');
 

--- a/ui/tests/nuxt/githubFileSelectMountpoint.spec.ts
+++ b/ui/tests/nuxt/githubFileSelectMountpoint.spec.ts
@@ -1,0 +1,154 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { defineComponent, h } from 'vue';
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FileSelectMountpoint from '@/components/ui/graph/node/utils/github/fileSelectMountpoint.vue';
+import type { RepoContent, RepositoryInfo } from '@/types/github';
+
+const stubs = vi.hoisted(() => ({
+    graphOn: vi.fn(),
+    graphEmit: vi.fn(),
+    fetchRepositories: vi.fn().mockResolvedValue([]),
+    getGenericRepoTree: vi.fn(),
+    getGenericRepoBranches: vi.fn(),
+    cloneRepository: vi.fn(),
+    pullGenericRepo: vi.fn(),
+    error: vi.fn(),
+}));
+
+mockNuxtImport('useSettingsStore', () => () => ({ storeKind: 'settings' }));
+mockNuxtImport('useRepositoryStore', () => () => ({
+    fetchRepositories: stubs.fetchRepositories,
+}));
+mockNuxtImport('storeToRefs', () => () => ({
+    blockGithubSettings: { value: { autoPull: false } },
+}));
+mockNuxtImport('useAPI', () => () => ({
+    getGenericRepoTree: stubs.getGenericRepoTree,
+    getGenericRepoBranches: stubs.getGenericRepoBranches,
+    cloneRepository: stubs.cloneRepository,
+    pullGenericRepo: stubs.pullGenericRepo,
+}));
+mockNuxtImport('useGraphEvents', () => () => ({ on: stubs.graphOn, emit: stubs.graphEmit }));
+mockNuxtImport('useToast', () => () => ({ error: stubs.error }));
+
+const RepoSelectStub = defineComponent({
+    name: 'UiGraphNodeUtilsGithubRepoSelect',
+    props: ['currentRepo'],
+    emits: ['update:currentRepo'],
+    setup: () => () => h('div', { 'data-repo-select': '' }),
+});
+
+const IssueSelectorStub = defineComponent({
+    name: 'UiGraphNodeUtilsGithubIssuePrSelector',
+    props: ['repo', 'initialSelectedIssues'],
+    emits: ['update:selectedIssues', 'close'],
+    setup: () => () => h('div', { 'data-issue-selector': '' }),
+});
+
+const SlotStub = defineComponent({
+    setup(_, { slots }) {
+        return () => h('div', slots.default?.());
+    },
+});
+
+const repo: RepositoryInfo = {
+    provider: 'github',
+    encoded_provider: 'github',
+    full_name: 'meridian/test',
+    description: null,
+    clone_url_ssh: 'git@example.test:meridian/test.git',
+    clone_url_https: 'https://example.test/meridian/test.git',
+    default_branch: 'develop',
+};
+
+const openHandler = () => {
+    const registration = stubs.graphOn.mock.calls.find(
+        (call) => call[0] === 'open-github-file-select',
+    );
+    if (!registration) throw new Error('Open handler was not registered');
+    return registration[1];
+};
+
+const mountSelector = () =>
+    mountSuspended(FileSelectMountpoint, {
+        global: {
+            stubs: {
+                AnimatePresence: SlotStub,
+                UiIcon: true,
+                UiGraphNodeUtilsGithubRepoSelect: RepoSelectStub,
+                UiGraphNodeUtilsGithubIssuePrSelector: IssueSelectorStub,
+                UiGraphNodeUtilsGithubFileTreeSelector: true,
+            },
+        },
+    });
+
+describe('Git file selector mountpoint', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        stubs.graphOn.mockReturnValue(() => undefined);
+        stubs.fetchRepositories.mockResolvedValue([]);
+        stubs.getGenericRepoTree.mockResolvedValue({
+            name: '.',
+            type: 'directory',
+            path: '.',
+            children: [],
+        });
+        stubs.getGenericRepoBranches.mockResolvedValue(['develop']);
+    });
+
+    it('starts with repository selection and opens requested issues tab with default branch', async () => {
+        const wrapper = await mountSelector();
+        await openHandler()({
+            target: { kind: 'chat-input' },
+            repoContent: null,
+            initialTab: 'issues',
+        });
+        await flushPromises();
+
+        expect(stubs.fetchRepositories).toHaveBeenCalledOnce();
+        const repoSelector = wrapper.getComponent(RepoSelectStub);
+        repoSelector.vm.$emit('update:currentRepo', repo);
+        await flushPromises();
+
+        expect(wrapper.find('[data-issue-selector]').exists()).toBe(true);
+        expect(stubs.getGenericRepoTree).toHaveBeenCalledWith('github', 'meridian/test', 'develop');
+
+        wrapper.getComponent(IssueSelectorStub).vm.$emit('close', []);
+        expect(stubs.graphEmit).toHaveBeenCalledWith('close-github-file-select', {
+            target: { kind: 'chat-input' },
+            repoContent: {
+                repo,
+                selectedFiles: [],
+                selectedIssues: [],
+                currentBranch: 'develop',
+            },
+        });
+        wrapper.unmount();
+    });
+
+    it('returns the initial snapshot on close and preserves node target isolation', async () => {
+        const wrapper = await mountSelector();
+        const initial: RepoContent = {
+            repo,
+            selectedFiles: [
+                { name: 'README.md', type: 'file', path: 'README.md', children: [] },
+            ],
+            selectedIssues: [],
+            currentBranch: 'develop',
+        };
+        await openHandler()({
+            target: { kind: 'node', nodeId: 'github-node' },
+            repoContent: initial,
+            initialTab: 'issues',
+        });
+        await flushPromises();
+
+        await wrapper.get('button[aria-label="Close Fullscreen"]').trigger('click');
+        expect(stubs.graphEmit).toHaveBeenCalledWith('close-github-file-select', {
+            target: { kind: 'node', nodeId: 'github-node' },
+            repoContent: initial,
+        });
+        wrapper.unmount();
+    });
+});

--- a/ui/tests/nuxt/githubRepositoryPicker.spec.ts
+++ b/ui/tests/nuxt/githubRepositoryPicker.spec.ts
@@ -1,0 +1,157 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { ref } from 'vue';
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RepositoryPicker from '@/components/ui/graph/node/utils/github/repositoryPicker.vue';
+import type { RepositoryInfo } from '@/types/github';
+
+const stubs = vi.hoisted(() => ({
+    repositoryValues: [] as RepositoryInfo[],
+    loading: false,
+    fetchRepositories: vi.fn(),
+    error: vi.fn(),
+}));
+
+mockNuxtImport('useRepositoryStore', () => () => ({
+    storeKind: 'repository',
+    fetchRepositories: stubs.fetchRepositories,
+}));
+mockNuxtImport('storeToRefs', () => () => ({
+    repositories: ref(stubs.repositoryValues),
+    isLoading: ref(stubs.loading),
+}));
+mockNuxtImport('useToast', () => () => ({ error: stubs.error }));
+
+const githubRepo: RepositoryInfo = {
+    provider: 'github',
+    encoded_provider: 'github',
+    full_name: 'meridian/frontend',
+    description: 'Frontend tools',
+    clone_url_ssh: '',
+    clone_url_https: '',
+    default_branch: 'develop',
+    stargazers_count: 0,
+};
+
+const githubRepoWithoutOptionalMetadata: RepositoryInfo = {
+    ...githubRepo,
+    full_name: 'meridian/api',
+    description: null,
+    default_branch: '',
+    stargazers_count: undefined,
+};
+
+const gitlabRepo: RepositoryInfo = {
+    ...githubRepo,
+    provider: 'gitlab-self-hosted',
+    encoded_provider: 'gitlab',
+    full_name: 'meridian/deployment',
+    description: 'Deployment automation',
+    default_branch: 'main',
+    stargazers_count: 5,
+};
+
+const mountPicker = () =>
+    mountSuspended(RepositoryPicker, {
+        attachTo: document.body,
+        global: { stubs: { UiIcon: true } },
+    });
+
+describe('Git repository picker', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        stubs.repositoryValues = [
+            githubRepo,
+            githubRepoWithoutOptionalMetadata,
+            gitlabRepo,
+        ];
+        stubs.loading = false;
+        stubs.fetchRepositories.mockResolvedValue(stubs.repositoryValues);
+    });
+
+    it('focuses search, filters by provider and text, renders metadata, and emits selection', async () => {
+        const wrapper = await mountPicker();
+        await flushPromises();
+
+        const search = wrapper.get('input[aria-label="Search repositories…"]');
+        expect(document.activeElement).toBe(search.element);
+        expect(wrapper.text()).toContain('Select a repository');
+        expect(wrapper.text()).toContain('meridian/frontend');
+        expect(wrapper.text()).toContain('Frontend tools');
+        expect(wrapper.text()).toContain('develop');
+        expect(wrapper.text()).toContain('0');
+        expect(wrapper.text()).toContain('meridian/api');
+        expect(wrapper.text()).toContain('main');
+        expect(wrapper.text()).not.toContain('meridian/deployment');
+
+        const frontendButton = wrapper
+            .findAll('button')
+            .find((button) => button.text().includes('meridian/frontend'));
+        const apiButton = wrapper
+            .findAll('button')
+            .find((button) => button.text().includes('meridian/api'));
+        expect(frontendButton?.text()).toContain('0');
+        expect(apiButton?.text()).not.toContain('Frontend tools');
+
+        await search.setValue(' frontend tools ');
+        expect(wrapper.text()).toContain('meridian/frontend');
+        expect(wrapper.text()).not.toContain('meridian/api');
+
+        await search.setValue('deployment automation');
+        await wrapper.get('button[aria-pressed="false"]').trigger('click');
+        expect(wrapper.text()).toContain('meridian/deployment');
+        expect(wrapper.text()).toContain('Deployment automation');
+        expect(wrapper.text()).toContain('5');
+        expect(wrapper.text()).not.toContain('meridian/frontend');
+
+        const repositoryButton = wrapper
+            .findAll('button')
+            .find((button) => button.text().includes('meridian/deployment'));
+        if (!repositoryButton) throw new Error('Repository button not found');
+        await repositoryButton.trigger('click');
+        expect(wrapper.emitted('select')).toEqual([[gitlabRepo]]);
+        wrapper.unmount();
+    });
+
+    it('distinguishes loading, empty, provider-empty, and search-empty states', async () => {
+        stubs.loading = true;
+        const loadingWrapper = await mountPicker();
+        expect(loadingWrapper.get('[role="status"]').text()).toBe('Loading repositories…');
+        loadingWrapper.unmount();
+
+        stubs.loading = false;
+        stubs.repositoryValues = [];
+        const emptyWrapper = await mountPicker();
+        await flushPromises();
+        expect(emptyWrapper.text()).toContain('No repositories available.');
+        emptyWrapper.unmount();
+
+        stubs.repositoryValues = [githubRepo];
+        const filteredWrapper = await mountPicker();
+        await flushPromises();
+        await filteredWrapper.get('button[aria-pressed="false"]').trigger('click');
+        expect(filteredWrapper.text()).toContain('No repositories available for GitLab.');
+        await filteredWrapper.get('input[aria-label="Search repositories…"]').setValue('missing');
+        expect(filteredWrapper.text()).toContain('No repositories match your search.');
+        filteredWrapper.unmount();
+    });
+
+    it('shows fetch errors above empty states and retries through the repository store', async () => {
+        stubs.repositoryValues = [];
+        stubs.fetchRepositories.mockRejectedValueOnce(new Error('unavailable'));
+        const wrapper = await mountPicker();
+        await flushPromises();
+
+        expect(wrapper.get('[role="alert"]').text()).toContain('Unable to load repositories.');
+        expect(wrapper.text()).not.toContain('No repositories available.');
+        expect(stubs.error).toHaveBeenCalledWith('Failed to fetch repositories');
+
+        stubs.fetchRepositories.mockResolvedValueOnce([]);
+        await wrapper.get('[role="alert"] button').trigger('click');
+        await flushPromises();
+        expect(stubs.fetchRepositories).toHaveBeenCalledTimes(2);
+        expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+        expect(wrapper.text()).toContain('No repositories available.');
+        wrapper.unmount();
+    });
+});

--- a/ui/tests/nuxt/homeChatInput.spec.ts
+++ b/ui/tests/nuxt/homeChatInput.spec.ts
@@ -1,0 +1,126 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { defineComponent, h, ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import HomePage from '@/pages/index.vue';
+import type { ChatInputSubmission } from '@/types/chat';
+
+const stubs = vi.hoisted(() => ({
+    addMessage: vi.fn(),
+    createGraph: vi.fn(),
+    fetchData: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('motion-v', () => ({
+    useSpring: (initial: number) => {
+        let value = initial;
+        return {
+            on: vi.fn(),
+            get: () => value,
+            set: (next: number) => {
+                value = next;
+            },
+        };
+    },
+}));
+
+mockNuxtImport('useChatStore', () => () => ({
+    storeKind: 'chat',
+    resetChatState: vi.fn(),
+    addMessage: stubs.addMessage,
+    syncUpcomingModelDefaults: vi.fn(),
+}));
+mockNuxtImport('useSettingsStore', () => () => ({ storeKind: 'settings' }));
+mockNuxtImport('storeToRefs', () => (store: { storeKind: string }) =>
+    store.storeKind === 'chat'
+        ? {
+              openChatId: ref(null),
+              upcomingModelData: ref({ data: {} }),
+          }
+        : {
+              modelsSettings: ref({ defaultModel: 'test-model' }),
+              toolsSettings: ref({ defaultAutoSelectTools: false, defaultSelectedTools: [] }),
+              accountSettings: ref({ openRouterApiKey: 'key' }),
+              isReady: ref(false),
+          },
+);
+mockNuxtImport('useFiles', () => () => ({ fileToMessageContent: vi.fn() }));
+mockNuxtImport('useAPI', () => () => ({
+    createGraph: stubs.createGraph,
+    moveGraph: vi.fn(),
+}));
+mockNuxtImport('useHistoryData', () => () => ({
+    graphs: ref([]),
+    folders: ref([]),
+    workspaces: ref([]),
+    hasMoreGraphs: ref(false),
+    hasLoadedHistory: ref(true),
+    fetchData: stubs.fetchData,
+    fetchNextGraphsPage: vi.fn(),
+}));
+mockNuxtImport('useUniqueId', () => () => ({ generateId: () => 'generator-id' }));
+mockNuxtImport('useUserSession', () => () => ({
+    user: ref({ plan_type: 'pro', name: 'Test', has_seen_welcome: true }),
+    loggedIn: ref(true),
+    ready: ref(true),
+    clear: vi.fn(),
+    fetch: vi.fn(),
+}));
+mockNuxtImport('useToast', () => () => ({ error: vi.fn() }));
+mockNuxtImport('useGraphDeletion', () => () => ({ handleDeleteGraph: vi.fn() }));
+
+const TextInputStub = defineComponent({
+    name: 'UiChatTextInput',
+    emits: ['generate'],
+    setup: () => () => h('div'),
+});
+
+describe('home chat input', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        stubs.fetchData.mockResolvedValue(undefined);
+        stubs.createGraph.mockResolvedValue({
+            id: 'graph-id',
+            temporary: false,
+            folder_id: null,
+            workspace_id: null,
+        });
+    });
+
+    it('persists Git context in initial message data before navigation', async () => {
+        const wrapper = await mountSuspended(HomePage, {
+            shallow: true,
+            global: { stubs: { UiChatTextInput: TextInputStub } },
+        });
+        const submission: ChatInputSubmission = {
+            message: 'Inspect repository',
+            files: [],
+            githubContext: {
+                repo: {
+                    provider: 'github',
+                    encoded_provider: 'github',
+                    full_name: 'meridian/test',
+                    description: null,
+                    clone_url_ssh: '',
+                    clone_url_https: '',
+                    default_branch: 'main',
+                },
+                selectedFiles: [
+                    { name: 'README.md', type: 'file', path: 'README.md', children: [] },
+                ],
+                selectedIssues: [],
+                currentBranch: 'main',
+            },
+        };
+
+        wrapper.findComponent(TextInputStub).vm.$emit('generate', submission);
+        await vi.waitFor(() => expect(stubs.addMessage).toHaveBeenCalledOnce());
+
+        expect(stubs.addMessage.mock.calls[0]?.[0]).toMatchObject({
+            data: {
+                files: [],
+                githubContext: submission.githubContext,
+            },
+        });
+        wrapper.unmount();
+    });
+});

--- a/ui/tests/nuxt/imagePlaygroundPreviews.spec.ts
+++ b/ui/tests/nuxt/imagePlaygroundPreviews.spec.ts
@@ -1,0 +1,52 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { describe, expect, it } from 'vitest';
+import GalleryTile from '@/components/ui/images/playground/galleryTile.vue';
+import type { GeneratedImageGalleryItem } from '@/types/imagePlayground';
+import { IMAGE_PLAYGROUND_GALLERY_SIZES } from '@/utils/imagePlayground';
+
+const image: GeneratedImageGalleryItem = {
+    id: 'gallery-image-1',
+    name: 'Gallery image',
+    path: '/Images/gallery-image-1.png',
+    content_type: 'image/png',
+    created_at: '2026-08-04T00:00:00Z',
+    updated_at: '2026-08-04T00:00:00Z',
+    prompt: 'Gallery fixture',
+    model: 'fixture-model',
+    source_image_ids: [],
+};
+
+describe('Image Playground gallery previews', () => {
+    it('renders responsive preview contracts for backdrop and foreground images', async () => {
+        const wrapper = await mountSuspended(GalleryTile, {
+            props: {
+                image,
+                index: 0,
+                modelDisplayName: (modelId?: string | null) => modelId || 'Unknown model',
+            },
+            global: {
+                stubs: {
+                    UiIcon: true,
+                },
+            },
+        });
+
+        try {
+            const images = wrapper.findAll('img');
+            expect(images).toHaveLength(2);
+
+            for (const renderedImage of images) {
+                expect(renderedImage.attributes('src')).toBe(
+                    '/api/auth/refresh/files/view/gallery-image-1?size=160x160',
+                );
+                expect(renderedImage.attributes('srcset')).toBe(
+                    '/api/auth/refresh/files/view/gallery-image-1?size=160x160 160w, '
+                    + '/api/auth/refresh/files/view/gallery-image-1?size=512x512 512w',
+                );
+                expect(renderedImage.attributes('sizes')).toBe(IMAGE_PLAYGROUND_GALLERY_SIZES);
+            }
+        } finally {
+            wrapper.unmount();
+        }
+    });
+});

--- a/ui/tests/nuxt/imagePlaygroundPreviews.spec.ts
+++ b/ui/tests/nuxt/imagePlaygroundPreviews.spec.ts
@@ -13,6 +13,8 @@ const image: GeneratedImageGalleryItem = {
     updated_at: '2026-08-04T00:00:00Z',
     prompt: 'Gallery fixture',
     model: 'fixture-model',
+    aspect_ratio: '4:3',
+    resolution: '1K',
     source_image_ids: [],
 };
 
@@ -45,6 +47,11 @@ describe('Image Playground gallery previews', () => {
                 );
                 expect(renderedImage.attributes('sizes')).toBe(IMAGE_PLAYGROUND_GALLERY_SIZES);
             }
+
+            expect(wrapper.text()).toContain('Gallery fixture');
+            expect(wrapper.text()).toContain('fixture-model');
+            expect(wrapper.text()).toContain('4:3');
+            expect(wrapper.text()).toContain('1K');
         } finally {
             wrapper.unmount();
         }

--- a/ui/tests/nuxt/useChatGenerator.spec.ts
+++ b/ui/tests/nuxt/useChatGenerator.spec.ts
@@ -23,7 +23,6 @@ const stubs = vi.hoisted(() => ({
     retrieveCurrentSession: vi.fn(),
     isNodeStreaming: vi.fn(() => false),
     createNodeFromVariant: vi.fn(),
-    addFilesPromptInputNodes: vi.fn(),
     waitForRender: vi.fn().mockResolvedValue(undefined),
     teleportViewportToNode: vi.fn(),
     execute: vi.fn().mockResolvedValue(undefined),
@@ -65,7 +64,6 @@ mockNuxtImport('storeToRefs', () => (store: { storeKind: string }) =>
         : { isNodeStreaming: { value: stubs.isNodeStreaming } },
 );
 mockNuxtImport('useGraphChat', () => () => ({
-    addFilesPromptInputNodes: stubs.addFilesPromptInputNodes,
     createNodeFromVariant: stubs.createNodeFromVariant,
     waitForRender: stubs.waitForRender,
 }));
@@ -126,7 +124,11 @@ describe('useChatGenerator prompt identity', () => {
         const { session, generator } = setupGenerator([]);
         generator.selectedNodeType.value = { nodeType: NodeTypeEnum.TEXT_TO_TEXT } as never;
 
-        await generator.generateNew(null, 'Fresh prompt');
+        await generator.generateNew(null, {
+            message: 'Fresh prompt',
+            files: [],
+            githubContext: null,
+        });
 
         const createdUserMessage = session.value.messages.find(
             (message) => message.role === MessageRoleEnum.user,
@@ -161,9 +163,14 @@ describe('useChatGenerator prompt identity', () => {
         expect(stubs.createNodeFromVariant).toHaveBeenCalledWith(
             NodeTypeEnum.TEXT_TO_TEXT,
             'existing-chat-id',
-            [NodeTypeEnum.PROMPT],
-            'Initial prompt',
-            'generator-node-id',
+            {
+                submission: {
+                    message: 'Initial prompt',
+                    files: [],
+                    githubContext: null,
+                },
+                forcedNodeId: 'generator-node-id',
+            },
         );
         expect(stubs.execute).toHaveBeenCalledWith('generator-node-id');
     });

--- a/ui/tests/nuxt/useGraphChat.spec.ts
+++ b/ui/tests/nuxt/useGraphChat.spec.ts
@@ -9,7 +9,14 @@ const stubs = vi.hoisted(() => ({
         position: { x: 100, y: 200 },
     })),
     placeBlock: vi.fn((options: { blocId: string }) => ({
-        id: options.blocId === 'primary-prompt-text' ? 'attached-prompt-id' : 'chat-main-id',
+        id:
+            options.blocId === 'primary-prompt-text'
+                ? 'attached-prompt-id'
+                : options.blocId === 'primary-prompt-file'
+                  ? 'attached-file-id'
+                  : options.blocId === 'primary-github-context'
+                    ? 'attached-github-id'
+                    : 'chat-main-id',
     })),
     placeEdge: vi.fn(),
     resolveOverlaps: vi.fn(),
@@ -35,6 +42,7 @@ mockNuxtImport('useGraphOverlaps', () => () => ({
 
 describe('useGraphChat createNodeFromVariant', () => {
     beforeEach(() => {
+        vi.clearAllMocks();
         vi.useFakeTimers();
     });
 
@@ -45,12 +53,9 @@ describe('useGraphChat createNodeFromVariant', () => {
     it('resolves the main node and attached prompt below collisions after the placement delay', async () => {
         const { createNodeFromVariant } = useGraphChat();
 
-        const createdNodes = createNodeFromVariant(
-            NodeTypeEnum.TEXT_TO_TEXT,
-            'source-node-id',
-            [NodeTypeEnum.PROMPT],
-            'Prompt text',
-        );
+        const createdNodes = createNodeFromVariant(NodeTypeEnum.TEXT_TO_TEXT, 'source-node-id', {
+            submission: { message: 'Prompt text', files: [], githubContext: null },
+        });
 
         expect(createdNodes).toEqual({
             generatorNodeId: 'chat-main-id',
@@ -64,6 +69,60 @@ describe('useGraphChat createNodeFromVariant', () => {
         expect(stubs.resolveOverlaps).toHaveBeenCalledWith(
             'chat-main-id',
             ['attached-prompt-id'],
+            { direction: 'below' },
+        );
+    });
+
+    it('creates populated file and Git inputs in the same overlap group', async () => {
+        const { createNodeFromVariant } = useGraphChat();
+        const file = {
+            id: 'file-id',
+            name: 'notes.txt',
+            type: 'file' as const,
+            created_at: '',
+            updated_at: '',
+            cached: false,
+        };
+        const repoFile = { name: 'README.md', type: 'file' as const, path: 'README.md', children: [] };
+        const repo = {
+            provider: 'github',
+            encoded_provider: 'github',
+            full_name: 'meridian/test',
+            description: null,
+            clone_url_ssh: 'git@example.test:meridian/test.git',
+            clone_url_https: 'https://example.test/meridian/test.git',
+            default_branch: 'main',
+        };
+
+        createNodeFromVariant(NodeTypeEnum.TEXT_TO_TEXT, 'source-node-id', {
+            submission: {
+                message: 'Prompt text',
+                files: [file],
+                githubContext: {
+                    repo,
+                    selectedFiles: [repoFile],
+                    selectedIssues: [],
+                    currentBranch: 'feature',
+                },
+            },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'primary-github-context',
+                data: {
+                    repo,
+                    files: [repoFile],
+                    selectedIssues: [],
+                    branch: 'feature',
+                },
+            }),
+        );
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(stubs.resolveOverlaps).toHaveBeenCalledWith(
+            'chat-main-id',
+            ['attached-prompt-id', 'attached-file-id', 'attached-github-id'],
             { direction: 'below' },
         );
     });

--- a/ui/tests/unit/imagePlayground.spec.ts
+++ b/ui/tests/unit/imagePlayground.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+    IMAGE_PLAYGROUND_GALLERY_SIZES,
+    imagePlaygroundDownloadUrl,
+    imagePlaygroundGallerySrcset,
+    imagePlaygroundImageUrl,
+} from '@/utils/imagePlayground';
+
+describe('Image Playground image URLs', () => {
+    it('preserves original and download URLs', () => {
+        expect(imagePlaygroundImageUrl('image-1')).toBe(
+            '/api/auth/refresh/files/view/image-1',
+        );
+        expect(imagePlaygroundDownloadUrl('image-1')).toBe(
+            '/api/auth/refresh/files/view/image-1?download=1',
+        );
+    });
+
+    it('builds exact allowlisted preview URLs', () => {
+        expect(imagePlaygroundImageUrl('image-1', '48x48')).toBe(
+            '/api/auth/refresh/files/view/image-1?size=48x48',
+        );
+        expect(imagePlaygroundImageUrl('image-1', '160x160')).toBe(
+            '/api/auth/refresh/files/view/image-1?size=160x160',
+        );
+        expect(imagePlaygroundImageUrl('image-1', '512x512')).toBe(
+            '/api/auth/refresh/files/view/image-1?size=512x512',
+        );
+    });
+
+    it('builds gallery candidates and grid-aligned sizes metadata', () => {
+        expect(imagePlaygroundGallerySrcset('image-1')).toBe(
+            '/api/auth/refresh/files/view/image-1?size=160x160 160w, '
+            + '/api/auth/refresh/files/view/image-1?size=512x512 512w',
+        );
+        expect(IMAGE_PLAYGROUND_GALLERY_SIZES).toBe(
+            '(min-width: 1536px) 20vw, (min-width: 1280px) 25vw, '
+            + '(min-width: 768px) 33vw, 50vw',
+        );
+    });
+});


### PR DESCRIPTION
# Meridian 1.7.5-beta

Meridian `1.7.5-beta` brings repository context directly into chat, adds faster image previews, and records chat-generated media in the image playground. This release also improves multi-worker coordination, GitHub Copilot runtime cleanup, and beta release operations.

## Highlights

### Repository Context in Chat

Chat prompts can now include selected repository files, issues, and pull requests without first configuring a GitHub node on the canvas.

- Open repository context from the chat add menu, choose the files or issues and pull requests tab, and review the selected repository, branch, and item counts before sending.
- Search available repositories and switch between connected GitHub and GitLab providers in the new repository picker.
- Sending a prompt with repository context creates a populated context node alongside the prompt and any file-attachment nodes, preserving the selected branch and items in the graph.
- Manual chat generation now opens the upcoming node settings before creating the next generator, so model and node options are available at the expected point in the workflow.

### Attachment and Image Previews

Images are easier to identify before sending and faster to browse in generated-media galleries.

- Chat image attachments render as thumbnail tiles with accessible remove controls, while non-image files remain in a separate compact row.
- Pasted images use keep-both upload handling, so sequential clipboard images with the same original filename remain attached as distinct files.
- File previews are generated on demand as cached WebP images at fixed `48x48`, `160x160`, or `512x512` sizes; full downloads continue to use the original file.
- Image playground galleries use responsive `160x160` and `512x512` previews, while compose, detail, and video-reference thumbnails use fixed `160x160` previews. Full downloads and original-media paths continue to request original files.

### Completed Generation History

Images and videos created through chat generation tools now carry the completed-job metadata used by the image playground.

- Successful tool generations record prompt, resolved model, media type, requested aspect ratio and resolution, source-image references, and completion timestamps.
- Image records also include measured dimensions and actual aspect ratio; video records retain requested duration and audio-generation choice.
- Generated media can therefore appear in the existing playground gallery with metadata available for inspection and settings reuse.

### Distributed API Coordination

API instances now coordinate more runtime state through the existing Redis service.

- Rate limits use shared Redis-backed storage instead of process-local memory, using the configured Redis host, port, and password.
- Model discovery caches, including per-user available models and subscription-provider catalogs, are shared through Redis with bounded expiry and invalidated after provider credential changes.
- WebSocket user events and generation-task cancellation requests fan out through Redis so connections and tasks owned by another API worker can receive the relevant update.
- Redis cache failures fall back to fresh model loading, and WebSocket publishing still attempts local delivery while broker listeners reconnect after interruption.

### GitHub Copilot Runtime Cleanup

GitHub Copilot integration now uses the current SDK lifecycle and more deliberate process cleanup.

- `github-copilot-sdk` is upgraded from `0.2.3` to `1.0.8`.
- Model-list and chat sessions use scoped runtime environments, bounded session and client shutdown, force-stop fallback, and cleanup of remaining scoped Copilot processes.
- Runtime heartbeat and temporary-directory cleanup now run even when session startup, execution, or cancellation fails.

## Self-Hosting and Upgrade Notes

Meridian `1.7.5-beta` requires no database migration and adds no application configuration keys. Existing Redis settings are reused for rate limits, model caches, and WebSocket fanout; these are expanded uses of the configured Redis service, not new Redis configuration.

- Redeploy or restart matching API and UI versions to apply the chat context, preview, generation metadata, Redis coordination, and Copilot lifecycle changes.
- Reinstall backend dependencies or rebuild the backend image to apply the `github-copilot-sdk` upgrade from `0.2.3` to `1.0.8`.
- Host-development API startup now loads `docker/env/.env.local` before importing the application, ensuring existing Redis settings are available when the rate limiter is initialized.
- Maintainers using the new release workflows must provision a repository Actions secret named `RELEASE_TOKEN` with repository contents and pull-request read/write access. This secret is only for release preparation and publishing; application deployments do not consume it.
- Release preparation is now a manual workflow that validates the next changelog and creates or updates a `dev`-to-`main` release pull request. Merging that trusted release pull request creates the strict non-`v` beta tag and GitHub prerelease.
- Docker image publication now runs from strict `X.Y.Z-beta` tags for frontend, backend, browser service, sandbox manager, and sandbox Python images. Release pull requests build the same matrix without pushing, ordinary pushes to `main` no longer publish images, and production deployment remains a separate manual step.
