### PR TITLE
Release Meridian 1.7.7-beta

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: docker-publish-${{ github.ref }}
+  group: ${{ startsWith(github.ref, 'refs/tags/') && format('meridian-release-{0}', github.repository) || format('docker-publish-{0}', github.ref) }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 env:
@@ -33,6 +33,16 @@ jobs:
             echo "Tag must be a strict non-v X.Y.Z-beta version." >&2
             exit 1
           fi
+
+      - name: Verify release is newest
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: >-
+          python scripts/release_automation.py verify-promotion
+          --repository "$GITHUB_REPOSITORY"
+          --version "$RELEASE_VERSION"
 
       - name: Run release automation tests
         run: python -m unittest discover -s scripts/tests -p 'test_release_automation.py'
@@ -178,3 +188,118 @@ jobs:
           build-args: ${{ matrix.frontend && format('NUXT_PUBLIC_VERSION={0}', steps.meta.outputs.version) || '' }}
           cache-from: type=gha,scope=${{ matrix.cache-scope }}
           cache-to: type=gha,scope=${{ matrix.cache-scope }},mode=max
+
+  promote-images:
+    name: Promote Docker images to latest
+    needs: build-and-push
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Validate release tag
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-beta$ ]]; then
+            echo "Tag must be a strict non-v X.Y.Z-beta version." >&2
+            exit 1
+          fi
+
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prevalidate and promote image manifests
+        env:
+          RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          images=(frontend backend browser-service sandbox-manager sandbox-python)
+          repository="${GITHUB_REPOSITORY,,}"
+          sources=()
+          digests=()
+
+          for image in "${images[@]}"; do
+            source="$REGISTRY/$repository/$image:$RELEASE_VERSION"
+            digest="$(docker buildx imagetools inspect "$source" --format '{{json .Manifest}}' | jq -er '.digest')"
+            sources+=("$source")
+            digests+=("$digest")
+          done
+
+          python scripts/release_automation.py verify-promotion \
+            --repository "$GITHUB_REPOSITORY" \
+            --version "$RELEASE_VERSION"
+          unset RELEASE_TOKEN
+
+          for index in "${!sources[@]}"; do
+            target="${sources[$index]%:$RELEASE_VERSION}:latest"
+            source="${sources[$index]%:$RELEASE_VERSION}@${digests[$index]}"
+            docker buildx imagetools create --prefer-index=false --tag "$target" "$source"
+          done
+
+  promote-release:
+    name: Promote GitHub Release
+    needs: promote-images
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate release tag
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-beta$ ]]; then
+            echo "Tag must be a strict non-v X.Y.Z-beta version." >&2
+            exit 1
+          fi
+
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Wait for and promote GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          python scripts/release_automation.py verify-promotion \
+            --repository "$GITHUB_REPOSITORY" \
+            --version "$RELEASE_VERSION"
+
+          release_found=false
+          for attempt in {1..12}; do
+            if gh release view "$RELEASE_VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              release_found=true
+              break
+            fi
+            if (( attempt < 12 )); then
+              sleep 10
+            fi
+          done
+          if [[ "$release_found" != true ]]; then
+            echo "GitHub Release $RELEASE_VERSION was not found after 12 attempts." >&2
+            exit 1
+          fi
+
+          python scripts/release_automation.py verify-promotion \
+            --repository "$GITHUB_REPOSITORY" \
+            --version "$RELEASE_VERSION"
+          gh release edit "$RELEASE_VERSION" --prerelease=false --latest --repo "$GITHUB_REPOSITORY"

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ ui/test-results/
 api/app/data/cloned_repos/4c0a28f1-d50c-4825-bbd0-b8ff89ae7b8a/
 .cbmignore
 .codebase-memory/
-.opencode/skills/create-update-changelog/
 sandbox_manager/.mypy_cache/
+.opencode/

--- a/docs/changelogs/Update-1.7.7-beta.md
+++ b/docs/changelogs/Update-1.7.7-beta.md
@@ -1,0 +1,31 @@
+# Meridian 1.7.7-beta
+
+Meridian `1.7.7-beta` automates promotion of successful beta releases across GitHub Container Registry and GitHub Releases. This release also prevents stale release runs from moving `latest` back to an older version.
+
+## Highlights
+
+### Automatic Image and Release Promotion
+
+Successful strict beta-tag builds now promote the complete release without rebuilding its images.
+
+- After all five versioned images build and publish successfully, the `frontend`, `backend`, `browser-service`, `sandbox-manager`, and `sandbox-python` manifests are resolved before their GHCR `latest` aliases are updated.
+- Each `latest` alias is created from the corresponding versioned manifest digest, avoiding another image build.
+- GitHub Release promotion runs only after every image alias succeeds, then marks the same release non-prerelease and latest after a bounded availability check.
+
+### Safer Release Ordering and Recovery
+
+Release automation now fails closed when a run is no longer eligible to publish the newest release.
+
+- Strict non-`v` beta tags are compared numerically before image builds, immediately before image alias updates, and again before GitHub Release promotion. Historic runs fail when a newer strict beta tag exists.
+- Release and beta-tag workflows share non-cancelling repository-level serialization, while pull requests retain ref-scoped cancellation, linting, and five no-push image builds without promotion.
+- Re-running publication preserves an already promoted full release instead of changing it back to a prerelease.
+
+## Self-Hosting and Upgrade Notes
+
+Meridian `1.7.7-beta` changes release automation only. It has no application runtime changes, database migration, new configuration key, new secret, or dependency-file change.
+
+- No data migration or application configuration action is required. Production deployment remains manual with `./docker/run.sh prod 1.7.7-beta`; release automation does not deploy or restart services.
+- For repositories using this release workflow, successful beta publication now updates all five GHCR `latest` aliases and then promotes the matching GitHub Release automatically. Pull-request builds never push or promote images.
+- Missing or unreadable versioned manifests stop promotion before any alias changes. A registry failure during alias updates can leave a subset changed, blocks GitHub Release promotion, and should be recovered by rerunning the same eligible tag after fixing the cause.
+- If image aliases succeed but GitHub Release lookup or editing fails, the images remain promoted while the release remains a prerelease; ensure the release exists and rerun the failed release-promotion job.
+- Rolling back workflow code does not restore remote image aliases or release flags. Operators must repoint all five `latest` aliases to one known-good beta version and then mark that version's GitHub Release latest.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Releasing Meridian
 
-Meridian releases use a manually started preparation workflow, manual CI review and merge, then automatic tag, prerelease, and image publication. Production deployment remains manual.
+Meridian releases use a manually started preparation workflow, manual CI review and merge, then automatic tag, image, and GitHub Release publication. Production deployment remains manual.
 
 ## Prerequisites
 
@@ -21,19 +21,37 @@ At least one existing non-`v` tag matching strict `X.Y.Z-beta` syntax must exist
 4. Wait for required CI to pass. Release PR image workflow runs shared lint and five parallel image builds without pushing packages. User remains responsible for CI review and manual merge.
 5. Merge PR manually. Publish workflow refetches merged PR and changelog from merge commit, validates title, body, branches, repository, successor version, and tag target before writing release artifacts.
 
-Finalization creates lightweight non-`v` `<version>` tag at merge commit and GitHub prerelease named `<version>` with exact changelog body. Tag starts five parallel publications for `frontend`, `backend`, `browser-service`, `sandbox-manager`, and `sandbox-python`. Observe all five matrix entries and verify exact beta image tags in GHCR. Ordinary pushes to `main` do not run image builds.
+Finalization creates lightweight non-`v` `<version>` tag at merge commit and GitHub prerelease named `<version>` with exact changelog body. Tag starts five parallel publications for `frontend`, `backend`, `browser-service`, `sandbox-manager`, and `sandbox-python`. After all five exact beta images succeed, `promote-images` resolves every beta manifest before writing and repoints each corresponding GHCR `latest` alias to its resolved digest without rebuilding. `promote-release` then waits for GitHub Release availability and marks same release non-prerelease and latest. Ordinary pushes to `main` do not run image builds. Pull requests run lint and five no-push builds but never run either promotion job.
+
+Prepare, publish, and tag workflows share repository-scoped, non-cancelling release concurrency. Pull-request image workflows remain ref-scoped and cancel superseded runs. Every tag run must be current numeric maximum among authoritative strict non-`v` `X.Y.Z-beta` GitHub tags. First check occurs in lint before beta image writes. Image promotion repeats check after all five manifest reads and immediately before first `latest` write. Release promotion checks before lookup and again immediately before Release edit. Malformed tags, stale historic reruns, missing tags, and GitHub API failures fail rather than skip promotion or move either meaning of `latest` backward.
 
 ## Failure and recovery
 
 Failures before tag creation are fail-closed. Correct changelog, PR, branch, token, or version issue, then rerun preparation or failed publish workflow. Repeated preparation updates one matching open PR; multiple matching open PRs stop automation without mutation.
 
-If tag already resolves to same merge commit, publish workflow can be rerun safely to create or reconcile prerelease. Partial tag-before-release failure is therefore recoverable. Existing release metadata is restored to canonical name, body, draft status, and prerelease status.
+If tag already resolves to same merge commit, publish workflow can be rerun safely to create or reconcile release metadata. Partial tag-before-release failure is therefore recoverable. New releases remain prereleases until image promotion succeeds; reconciliation preserves an existing full release instead of demoting it.
 
-Automation never moves or deletes tags. Tag resolving to another commit or newer strict beta tag requires operator investigation; do not retarget immutable release tag through this workflow. If image publication fails after tag creation, rerun failed image workflow for same tag rather than recreating release.
+Automation never moves or deletes immutable beta tags. Tag resolving to another commit requires operator investigation. Historic rerun with newer strict beta tag is intentionally stale and must not be retried expecting promotion.
+
+Failure before image alias writes leaves all `latest` aliases unchanged. Missing or unreadable beta manifest fails during all-five prevalidation. Registry failure during write loop can leave subset of aliases updated; dependent Release promotion remains blocked and GitHub Release stays prerelease. Fix cause and rerun same-tag workflow or failed jobs to converge all five aliases. If all aliases promoted but bounded Release lookup or edit fails, ensure Release exists and rerun failed Release job. Same-tag operations are idempotent.
+
+Workflow or script rollback prevents future automation but does not undo remote GHCR aliases or GitHub Release flags. For manual rollback, authenticate Docker Buildx and GitHub CLI, choose one known-good prior beta version, and repoint all five aliases before changing Release state:
+
+```bash
+repository="ghcr.io/<owner>/<repository>"
+version="<known-good-version>"
+for image in frontend backend browser-service sandbox-manager sandbox-python; do
+    docker buildx imagetools create --prefer-index=false \
+        --tag "$repository/$image:latest" "$repository/$image:$version"
+done
+gh release edit "$version" --prerelease=false --latest --repo <owner>/<repository>
+```
+
+Use lowercase `<owner>/<repository>` in GHCR references. Verify known-good manifests before rollback. If needed, separately mark failed release as prerelease. Never move or delete source beta tags, and never roll back only subset of five aliases.
 
 ## Production
 
-Production update is separate, manually authorized operation after all five images succeed. Use existing deployment command and exact beta tag:
+Production update is separate, manually authorized operation after all five images and automated promotions succeed. Use existing deployment command and exact beta tag:
 
 ```bash
 ./docker/run.sh prod <version>

--- a/scripts/release_automation.py
+++ b/scripts/release_automation.py
@@ -181,6 +181,17 @@ def latest_version(tags: list[Any], excluded: str | None = None) -> Version:
     return max(versions)
 
 
+def verify_promotion(client: GitHubClient, version: str) -> str:
+    candidate = Version.parse(version)
+    tags = client.paginate("/tags?per_page=100")
+    newest = latest_version(tags)
+    if candidate != newest:
+        raise ReleaseError(
+            f"promotion candidate {candidate} is stale; newest strict beta tag is {newest}"
+        )
+    return str(candidate)
+
+
 def release_title(version: str) -> str:
     Version.parse(version)
     return f"Release Meridian {version}"
@@ -330,6 +341,8 @@ def _ensure_release(client: GitHubClient, version: str, changelog: str) -> None:
         raise ReleaseError("GitHub release response is invalid")
     comparable = {key: release.get(key) for key in canonical if key != "generate_release_notes"}
     desired = {key: value for key, value in canonical.items() if key != "generate_release_notes"}
+    if release.get("prerelease") is False:
+        desired["prerelease"] = False
     if comparable != desired:
         client.request("PATCH", f"/releases/{release['id']}", desired)
 
@@ -372,13 +385,18 @@ def main(argv: list[str] | None = None) -> int:
     publish_parser = subparsers.add_parser("publish")
     publish_parser.add_argument("--repository", required=True)
     publish_parser.add_argument("--pull-request-number", required=True, type=int)
+    verify_parser = subparsers.add_parser("verify-promotion")
+    verify_parser.add_argument("--repository", required=True)
+    verify_parser.add_argument("--version", required=True)
     args = parser.parse_args(argv)
     try:
         client = GitHubClient(args.repository, os.environ.get("RELEASE_TOKEN", ""))
         if args.command == "prepare":
             version = prepare(client, args.bump, args.base, args.head)
-        else:
+        elif args.command == "publish":
             version = publish(client, args.pull_request_number)
+        else:
+            version = verify_promotion(client, args.version)
         print(version)
         return 0
     except ReleaseError as exc:

--- a/scripts/tests/test_release_automation.py
+++ b/scripts/tests/test_release_automation.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import json
 import os
 import sys
@@ -163,6 +164,44 @@ class ClientTests(unittest.TestCase):
         self.assertNotIn("secret", str(raised.exception))
 
 
+class PromotionTests(unittest.TestCase):
+    def setUp(self):
+        self.transport = FakeTransport()
+        self.client = release.GitHubClient(REPOSITORY, "secret", self.transport)
+
+    def test_numeric_newest_strict_beta_is_accepted_with_gets_only(self):
+        self.transport.add(
+            "GET",
+            "/tags?per_page=100",
+            [
+                {"name": "1.9.9-beta"},
+                {"name": "1.10.0-beta"},
+                {"name": "v2.0.0-beta"},
+                {"name": "2.0.0"},
+                {"name": "01.11.0-beta"},
+            ],
+        )
+
+        self.assertEqual(release.verify_promotion(self.client, "1.10.0-beta"), "1.10.0-beta")
+        self.assertTrue(all(call["method"] == "GET" for call in self.transport.calls))
+        self.transport.assert_done()
+
+    def test_stale_candidate_is_rejected_with_gets_only(self):
+        self.transport.add(
+            "GET",
+            "/tags?per_page=100",
+            [{"name": "1.9.9-beta"}, {"name": "1.10.0-beta"}],
+        )
+
+        with self.assertRaisesRegex(
+            release.ReleaseError,
+            r"promotion candidate 1\.9\.9-beta is stale; newest strict beta tag is 1\.10\.0-beta",
+        ):
+            release.verify_promotion(self.client, "1.9.9-beta")
+        self.assertTrue(all(call["method"] == "GET" for call in self.transport.calls))
+        self.transport.assert_done()
+
+
 class PrepareTests(unittest.TestCase):
     def setUp(self):
         self.transport = FakeTransport()
@@ -289,7 +328,7 @@ class PublishTests(unittest.TestCase):
                 "name": "1.7.5-beta",
                 "body": CHANGELOG,
                 "draft": False,
-                "prerelease": True,
+                "prerelease": False,
             },
         )
 
@@ -301,6 +340,19 @@ class PublishTests(unittest.TestCase):
         existing = {"id": 8, **release._canonical_release("1.7.5-beta", CHANGELOG)}
         self.transport.add("GET", "/releases/tags/1.7.5-beta", existing)
         release.publish(self.client, 12)
+        self.assertTrue(all(call["method"] == "GET" for call in self.transport.calls))
+
+    def test_exact_existing_promoted_release_is_noop(self):
+        self.queue_publish_validation()
+        self.transport.add(
+            "GET", "/git/ref/tags/1.7.5-beta", {"object": {"type": "commit", "sha": SHA}}
+        )
+        existing = {"id": 8, **release._canonical_release("1.7.5-beta", CHANGELOG)}
+        existing["prerelease"] = False
+        self.transport.add("GET", "/releases/tags/1.7.5-beta", existing)
+
+        release.publish(self.client, 12)
+
         self.assertTrue(all(call["method"] == "GET" for call in self.transport.calls))
 
     def test_tag_create_race_is_reread(self):
@@ -364,6 +416,7 @@ class PublishTests(unittest.TestCase):
         )
         self.transport.add("PATCH", "/releases/8", {"id": 8})
         release.publish(self.client, 12)
+        self.assertIs(self.transport.calls[-1]["payload"]["prerelease"], False)
 
 
 class CliTests(unittest.TestCase):
@@ -374,6 +427,35 @@ class CliTests(unittest.TestCase):
             self.assertEqual(
                 release.main(["prepare", "--repository", REPOSITORY, "--bump", "patch"]), 1
             )
+
+    def test_verify_promotion_stale_candidate_exits_nonzero_without_writes(self):
+        transport = FakeTransport()
+        client = release.GitHubClient(REPOSITORY, "secret", transport)
+        transport.add(
+            "GET",
+            "/tags?per_page=100",
+            [{"name": "1.7.5-beta"}, {"name": "1.8.0-beta"}],
+        )
+        stderr = io.StringIO()
+
+        with mock.patch.object(release, "GitHubClient", return_value=client), mock.patch.dict(
+            os.environ, {"RELEASE_TOKEN": "secret"}, clear=True
+        ), mock.patch("sys.stderr", stderr):
+            result = release.main(
+                [
+                    "verify-promotion",
+                    "--repository",
+                    REPOSITORY,
+                    "--version",
+                    "1.7.5-beta",
+                ]
+            )
+
+        self.assertEqual(result, 1)
+        self.assertIn("1.7.5-beta is stale", stderr.getvalue())
+        self.assertIn("1.8.0-beta", stderr.getvalue())
+        self.assertTrue(all(call["method"] == "GET" for call in transport.calls))
+        transport.assert_done()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Meridian 1.7.7-beta

Meridian `1.7.7-beta` automates promotion of successful beta releases across GitHub Container Registry and GitHub Releases. This release also prevents stale release runs from moving `latest` back to an older version.

## Highlights

### Automatic Image and Release Promotion

Successful strict beta-tag builds now promote the complete release without rebuilding its images.

- After all five versioned images build and publish successfully, the `frontend`, `backend`, `browser-service`, `sandbox-manager`, and `sandbox-python` manifests are resolved before their GHCR `latest` aliases are updated.
- Each `latest` alias is created from the corresponding versioned manifest digest, avoiding another image build.
- GitHub Release promotion runs only after every image alias succeeds, then marks the same release non-prerelease and latest after a bounded availability check.

### Safer Release Ordering and Recovery

Release automation now fails closed when a run is no longer eligible to publish the newest release.

- Strict non-`v` beta tags are compared numerically before image builds, immediately before image alias updates, and again before GitHub Release promotion. Historic runs fail when a newer strict beta tag exists.
- Release and beta-tag workflows share non-cancelling repository-level serialization, while pull requests retain ref-scoped cancellation, linting, and five no-push image builds without promotion.
- Re-running publication preserves an already promoted full release instead of changing it back to a prerelease.

## Self-Hosting and Upgrade Notes

Meridian `1.7.7-beta` changes release automation only. It has no application runtime changes, database migration, new configuration key, new secret, or dependency-file change.

- No data migration or application configuration action is required. Production deployment remains manual with `./docker/run.sh prod 1.7.7-beta`; release automation does not deploy or restart services.
- For repositories using this release workflow, successful beta publication now updates all five GHCR `latest` aliases and then promotes the matching GitHub Release automatically. Pull-request builds never push or promote images.
- Missing or unreadable versioned manifests stop promotion before any alias changes. A registry failure during alias updates can leave a subset changed, blocks GitHub Release promotion, and should be recovered by rerunning the same eligible tag after fixing the cause.
- If image aliases succeed but GitHub Release lookup or editing fails, the images remain promoted while the release remains a prerelease; ensure the release exists and rerun the failed release-promotion job.
- Rolling back workflow code does not restore remote image aliases or release flags. Operators must repoint all five `latest` aliases to one known-good beta version and then mark that version's GitHub Release latest.
