### PR TITLE
Release Meridian 1.7.9-beta

### DIFF
--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -18,6 +18,7 @@ RUN pnpm install --frozen-lockfile
 
 # Copy the rest of the application source code
 COPY ./ui .
+COPY ./docs/changelogs /docs/changelogs
 
 # Build the Nuxt application
 RUN pnpm run build

--- a/docs/changelogs/Update-1.7.9-beta.md
+++ b/docs/changelogs/Update-1.7.9-beta.md
@@ -1,0 +1,36 @@
+# Meridian 1.7.9-beta
+
+Meridian `1.7.9-beta` turns the homepage version into a complete release-notes viewer, adds a browser-local update indicator, and tightens release changelog validation during publishing.
+
+## Highlights
+
+### Homepage Release Notes
+
+The homepage version now opens the complete repository changelog catalog without a runtime API request.
+
+- Select the version display to open formatted release notes for every changelog under `docs/changelogs`, ordered by numeric release version from newest to oldest.
+- Switch between releases inside a responsive modal; the newest release is selected again whenever the modal opens.
+- Changelogs are loaded and rendered during the Nuxt build, with embedded raw HTML escaped before the generated content reaches the browser.
+
+### Browser-Local Update Indicator
+
+The version display now shows when the loaded release is newer than the release last viewed in the current browser.
+
+- A first visit with a valid beta version shows an update indicator. Opening release notes immediately clears it and stores the current version under `meridian-last-seen-release`.
+- Older stored versions restore the indicator, while equal or newer stored versions do not. Viewing a rolled-back build preserves the newer watermark.
+- Development or malformed version values do not create a release watermark, and unavailable browser storage does not prevent release notes from opening.
+
+### Exact Release Changelog Validation
+
+Release publishing now rejects a release pull request when its body differs from the merged changelog.
+
+- Pull request bodies must exactly match the changelog, including line endings and the trailing newline.
+- A mismatch stops publishing before tag or release mutation begins.
+
+## Self-Hosting and Upgrade Notes
+
+Meridian `1.7.9-beta` is a non-breaking frontend and release-tooling update with no database migration, new configuration keys, new secrets, dependency-manifest changes, or lockfile changes.
+
+- Rebuild and redeploy the UI to include the build-time changelog catalog and homepage release-notes viewer. Frontend Docker builds now copy `docs/changelogs` into the builder before Nuxt compilation.
+- Existing accounts and server data require no migration. Seen-release state remains browser-local in `localStorage` and is not synchronized through an account or backend service.
+- Release maintainers using custom pull request preparation must preserve the changelog body exactly, including line endings and the final newline, for publish validation to succeed.

--- a/ui/app/components/ui/home/releaseVersionInfo.vue
+++ b/ui/app/components/ui/home/releaseVersionInfo.vue
@@ -1,0 +1,137 @@
+<script lang="ts" setup>
+import {
+    compareReleaseVersions,
+    parseReleaseVersion,
+    type ReleaseChangelog,
+} from '@/utils/releaseVersions';
+
+const STORAGE_KEY = 'meridian-last-seen-release';
+
+const props = defineProps<{
+    currentVersion: string;
+}>();
+
+const changelogs = useAppConfig().releaseChangelogs as ReleaseChangelog[];
+const isOpen = ref(false);
+const hasUnreadRelease = ref(false);
+const selectedChangelog = ref<ReleaseChangelog | null>(changelogs[0] ?? null);
+
+const readStoredVersion = (): string | null => {
+    try {
+        return window.localStorage.getItem(STORAGE_KEY);
+    } catch {
+        return null;
+    }
+};
+
+const writeStoredVersion = (version: string): void => {
+    try {
+        window.localStorage.setItem(STORAGE_KEY, version);
+    } catch {
+        // Release-note persistence is noncritical and may be blocked by browser privacy settings.
+    }
+};
+
+const markCurrentReleaseSeen = (): void => {
+    if (!parseReleaseVersion(props.currentVersion)) return;
+
+    hasUnreadRelease.value = false;
+    const storedVersion = readStoredVersion();
+    const versionToStore =
+        storedVersion &&
+        parseReleaseVersion(storedVersion) &&
+        compareReleaseVersions(storedVersion, props.currentVersion) > 0
+            ? storedVersion
+            : props.currentVersion;
+    writeStoredVersion(versionToStore);
+};
+
+const openReleaseNotes = (): void => {
+    selectedChangelog.value = changelogs[0] ?? null;
+    isOpen.value = true;
+    markCurrentReleaseSeen();
+};
+
+onMounted(() => {
+    if (!parseReleaseVersion(props.currentVersion)) return;
+
+    const storedVersion = readStoredVersion();
+    hasUnreadRelease.value =
+        !storedVersion ||
+        !parseReleaseVersion(storedVersion) ||
+        compareReleaseVersions(props.currentVersion, storedVersion) > 0;
+});
+</script>
+
+<template>
+    <button
+        type="button"
+        class="hover:text-stone-gray/60 focus-visible:ring-ember-glow/60 relative cursor-pointer
+            rounded-md px-1 py-0.5 transition-colors outline-none focus-visible:ring-2
+            focus-visible:ring-offset-2 focus-visible:ring-offset-obsidian"
+        aria-haspopup="dialog"
+        :aria-label="`Version ${currentVersion}${hasUnreadRelease ? ', update available' : ''}`"
+        @click="openReleaseNotes"
+    >
+        Version {{ currentVersion }}
+        <span
+            v-if="hasUnreadRelease"
+            data-testid="release-unread-indicator"
+            class="bg-ember-glow absolute -top-0.5 -right-1 h-2 w-2 rounded-full
+                shadow-[0_0_6px_var(--color-ember-glow)]"
+            aria-hidden="true"
+        ></span>
+    </button>
+
+    <UiUtilsBaseModal
+        v-model="isOpen"
+        title="Release notes"
+        size="xl"
+        panel-class="flex h-[85vh] max-h-[48rem] flex-col"
+        body-class="flex min-h-0 flex-1 flex-col p-0 md:flex-row"
+    >
+        <nav
+            class="border-stone-gray/10 flex max-h-44 shrink-0 flex-col border-b md:max-h-none
+                md:w-56 md:border-r md:border-b-0"
+            aria-label="Release versions"
+        >
+            <div class="dark-scrollbar min-h-0 flex-1 overflow-y-auto p-3">
+                <ul class="space-y-1">
+                    <li v-for="changelog in changelogs" :key="changelog.version">
+                        <button
+                            type="button"
+                            data-release-version
+                            class="focus-visible:ring-ember-glow/60 w-full cursor-pointer rounded-lg
+                                px-3 py-2 text-left text-sm font-medium transition-colors outline-none
+                                focus-visible:ring-2"
+                            :class="
+                                selectedChangelog?.version === changelog.version
+                                    ? 'bg-ember-glow/10 text-ember-glow'
+                                    : 'text-stone-gray/70 hover:bg-stone-gray/10 hover:text-soft-silk'
+                            "
+                            :aria-current="
+                                selectedChangelog?.version === changelog.version
+                                    ? 'true'
+                                    : undefined
+                            "
+                            @click="selectedChangelog = changelog"
+                        >
+                            {{ changelog.version }}
+                        </button>
+                    </li>
+                </ul>
+            </div>
+        </nav>
+
+        <div class="dark-scrollbar min-h-0 flex-1 overflow-y-auto p-5 sm:p-7">
+            <article
+                v-if="selectedChangelog"
+                :key="selectedChangelog.version"
+                data-testid="release-changelog-content"
+                class="prose prose-invert prose-sm max-w-none prose-headings:text-soft-silk
+                    prose-a:text-ember-glow prose-code:text-soft-silk prose-strong:text-soft-silk"
+                v-html="selectedChangelog.html"
+            ></article>
+        </div>
+    </UiUtilsBaseModal>
+</template>

--- a/ui/app/pages/index.vue
+++ b/ui/app/pages/index.vue
@@ -314,8 +314,8 @@ onBeforeUnmount(() => {
     <div ref="pageRef" class="bg-obsidian relative h-full w-full overflow-hidden">
         <UiSettingsUtilsBlobBackground />
 
-        <div class="text-stone-gray/25 absolute top-4 left-4 text-sm">
-            <span>Version {{ appVersion }}</span>
+        <div class="text-stone-gray/25 absolute top-4 left-4 z-30 text-sm">
+            <UiHomeReleaseVersionInfo :current-version="appVersion" />
         </div>
 
         <!-- Background dots -->

--- a/ui/app/utils/releaseVersions.ts
+++ b/ui/app/utils/releaseVersions.ts
@@ -1,0 +1,34 @@
+export type ReleaseVersion = readonly [major: number, minor: number, patch: number];
+
+export interface ReleaseChangelog {
+    version: string;
+    html: string;
+}
+
+const RELEASE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta$/;
+
+export const parseReleaseVersion = (version: string): ReleaseVersion | null => {
+    const match = RELEASE_VERSION_PATTERN.exec(version);
+    if (!match) return null;
+
+    const parts = match.slice(1).map(Number);
+    if (parts.some((part) => !Number.isSafeInteger(part))) return null;
+
+    return [parts[0]!, parts[1]!, parts[2]!];
+};
+
+export const compareReleaseVersions = (left: string, right: string): number => {
+    const leftParts = parseReleaseVersion(left);
+    const rightParts = parseReleaseVersion(right);
+
+    if (!leftParts || !rightParts) {
+        throw new Error(`Cannot compare invalid release versions: "${left}" and "${right}"`);
+    }
+
+    for (let index = 0; index < leftParts.length; index += 1) {
+        const difference = leftParts[index]! - rightParts[index]!;
+        if (difference !== 0) return difference;
+    }
+
+    return 0;
+};

--- a/ui/build/releaseChangelogs.ts
+++ b/ui/build/releaseChangelogs.ts
@@ -1,0 +1,91 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Marked } from 'marked';
+import {
+    compareReleaseVersions,
+    parseReleaseVersion,
+    type ReleaseChangelog,
+} from '../app/utils/releaseVersions';
+
+const CHANGELOG_FILENAME_PATTERN = /^Update-(.+)\.md$/;
+
+const escapeHtml = (value: string): string =>
+    value.replace(
+        /[&<>"']/g,
+        (character) =>
+            ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+            })[character]!,
+    );
+
+const changelogMarkdown = new Marked({
+    gfm: true,
+    renderer: {
+        html: ({ text }) => escapeHtml(text),
+    },
+});
+
+export const loadReleaseChangelogs = async (directory: string): Promise<ReleaseChangelog[]> => {
+    let filenames: string[];
+
+    try {
+        const entries = await readdir(directory, { withFileTypes: true });
+        filenames = entries
+            .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+            .map((entry) => entry.name);
+    } catch (error) {
+        throw new Error(`Unable to read release changelog directory "${directory}"`, {
+            cause: error,
+        });
+    }
+
+    if (filenames.length === 0) {
+        throw new Error(`Release changelog directory "${directory}" contains no Markdown files`);
+    }
+
+    const seenVersions = new Set<string>();
+    const changelogs: ReleaseChangelog[] = [];
+
+    for (const filename of filenames) {
+        const match = CHANGELOG_FILENAME_PATTERN.exec(filename);
+        const version = match?.[1];
+
+        if (!version || !parseReleaseVersion(version)) {
+            throw new Error(`Invalid release changelog filename "${filename}"`);
+        }
+        if (seenVersions.has(version)) {
+            throw new Error(`Duplicate release changelog version "${version}"`);
+        }
+
+        const filePath = join(directory, filename);
+        let markdown: string;
+        try {
+            markdown = await readFile(filePath, 'utf8');
+        } catch (error) {
+            throw new Error(`Unable to read release changelog "${filePath}"`, { cause: error });
+        }
+
+        if (!markdown.trim()) {
+            throw new Error(`Release changelog "${filePath}" is empty`);
+        }
+
+        let html: string | Promise<string>;
+        try {
+            html = changelogMarkdown.parse(markdown);
+        } catch (error) {
+            throw new Error(`Unable to parse release changelog "${filePath}"`, { cause: error });
+        }
+        if (typeof html !== 'string') {
+            throw new Error(`Release changelog parser unexpectedly became asynchronous for "${filePath}"`);
+        }
+
+        seenVersions.add(version);
+        changelogs.push({ version, html });
+    }
+
+    return changelogs.sort((left, right) => compareReleaseVersions(right.version, left.version));
+};

--- a/ui/nuxt.config.ts
+++ b/ui/nuxt.config.ts
@@ -1,5 +1,11 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
+import { loadReleaseChangelogs } from './build/releaseChangelogs';
+
+const releaseChangelogs = await loadReleaseChangelogs(
+    fileURLToPath(new URL('../docs/changelogs/', import.meta.url)),
+);
 
 export default defineNuxtConfig({
     compatibilityDate: '2024-11-01',
@@ -87,6 +93,10 @@ export default defineNuxtConfig({
                 { name: 'theme-color', content: '#ccc5b9' },
             ],
         },
+    },
+
+    appConfig: {
+        releaseChangelogs,
     },
 
     vite: {

--- a/ui/tests/nuxt/releaseVersionInfo.spec.ts
+++ b/ui/tests/nuxt/releaseVersionInfo.spec.ts
@@ -1,0 +1,155 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { defineComponent, h, nextTick, type PropType } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ReleaseVersionInfo from '@/components/ui/home/releaseVersionInfo.vue';
+
+const STORAGE_KEY = 'meridian-last-seen-release';
+
+const BaseModalStub = defineComponent({
+    name: 'UiUtilsBaseModal',
+    props: {
+        modelValue: { type: Boolean, required: true },
+        title: { type: String as PropType<string | undefined>, default: undefined },
+    },
+    emits: ['update:modelValue', 'close'],
+    setup(props, { emit, slots }) {
+        return () =>
+            props.modelValue
+                ? h('section', { 'data-testid': 'release-modal' }, [
+                      h('h2', props.title),
+                      h(
+                          'button',
+                          {
+                              'data-testid': 'close-modal',
+                              onClick: () => {
+                                  emit('update:modelValue', false);
+                                  emit('close');
+                              },
+                          },
+                          'Close',
+                      ),
+                      slots.default?.(),
+                  ])
+                : null;
+    },
+});
+
+const mountReleaseVersion = (currentVersion = '1.7.8-beta') =>
+    mountSuspended(ReleaseVersionInfo, {
+        props: { currentVersion },
+        global: {
+            stubs: {
+                UiUtilsBaseModal: BaseModalStub,
+                UiIcon: true,
+            },
+        },
+    });
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+describe('releaseVersionInfo', () => {
+    it('shows first visit as unread, opens every release newest-first, and marks it seen', async () => {
+        const wrapper = await mountReleaseVersion();
+
+        expect(wrapper.find('[data-testid="release-unread-indicator"]').exists()).toBe(true);
+        expect(wrapper.get('[aria-haspopup="dialog"]').attributes('aria-label')).toContain(
+            'update available',
+        );
+
+        await wrapper.get('[aria-haspopup="dialog"]').trigger('click');
+
+        expect(wrapper.find('[data-testid="release-unread-indicator"]').exists()).toBe(false);
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1.7.8-beta');
+        expect(wrapper.find('[data-testid="release-modal"]').exists()).toBe(true);
+
+        const versions = wrapper.findAll('[data-release-version]').map((button) => button.text());
+        expect(versions).toHaveLength(13);
+        expect(versions[0]).toBe('1.7.8-beta');
+        expect(versions.at(-1)).toBe('1.4.0-beta');
+        expect(wrapper.get('[data-release-version][aria-current="true"]').text()).toBe(
+            '1.7.8-beta',
+        );
+
+        wrapper.unmount();
+    });
+
+    it('switches displayed notes and resets selection to latest on each open', async () => {
+        const wrapper = await mountReleaseVersion();
+        await wrapper.get('[aria-haspopup="dialog"]').trigger('click');
+        const latestHtml = wrapper.get('[data-testid="release-changelog-content"]').html();
+        const olderRelease = wrapper
+            .findAll('[data-release-version]')
+            .find((button) => button.text() === '1.7.7-beta');
+
+        expect(olderRelease).toBeDefined();
+        await olderRelease!.trigger('click');
+        expect(wrapper.get('[data-release-version][aria-current="true"]').text()).toBe(
+            '1.7.7-beta',
+        );
+        expect(wrapper.get('[data-testid="release-changelog-content"]').html()).not.toBe(latestHtml);
+
+        await wrapper.get('[data-testid="close-modal"]').trigger('click');
+        await wrapper.get('[aria-haspopup="dialog"]').trigger('click');
+        expect(wrapper.get('[data-release-version][aria-current="true"]').text()).toBe(
+            '1.7.8-beta',
+        );
+
+        wrapper.unmount();
+    });
+
+    it.each([
+        ['1.7.7-beta', true],
+        ['1.7.8-beta', false],
+        ['1.8.0-beta', false],
+        ['malformed', true],
+    ])('compares stored version %s against current release', async (storedVersion, expectedUnread) => {
+        window.localStorage.setItem(STORAGE_KEY, storedVersion);
+        const wrapper = await mountReleaseVersion();
+
+        expect(wrapper.find('[data-testid="release-unread-indicator"]').exists()).toBe(
+            expectedUnread,
+        );
+        wrapper.unmount();
+    });
+
+    it('does not show or persist unread state for an invalid current version', async () => {
+        const setItem = vi.spyOn(Storage.prototype, 'setItem');
+        const wrapper = await mountReleaseVersion('development');
+
+        expect(wrapper.find('[data-testid="release-unread-indicator"]').exists()).toBe(false);
+        await wrapper.get('[aria-haspopup="dialog"]').trigger('click');
+        expect(setItem).not.toHaveBeenCalled();
+
+        wrapper.unmount();
+    });
+
+    it('preserves a newer stored watermark when opening a rolled-back build', async () => {
+        window.localStorage.setItem(STORAGE_KEY, '1.8.0-beta');
+        const wrapper = await mountReleaseVersion();
+
+        await wrapper.get('[aria-haspopup="dialog"]').trigger('click');
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1.8.0-beta');
+
+        wrapper.unmount();
+    });
+
+    it('remains usable when localStorage reads and writes fail', async () => {
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new Error('storage read blocked');
+        });
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new Error('storage write blocked');
+        });
+        const wrapper = await mountReleaseVersion();
+
+        await nextTick();
+        expect(wrapper.find('[data-testid="release-unread-indicator"]').exists()).toBe(true);
+        await expect(wrapper.get('[aria-haspopup="dialog"]').trigger('click')).resolves.toBeUndefined();
+        expect(wrapper.find('[data-testid="release-unread-indicator"]').exists()).toBe(false);
+        expect(wrapper.find('[data-testid="release-modal"]').exists()).toBe(true);
+
+        wrapper.unmount();
+    });
+});

--- a/ui/tests/unit/releaseChangelogs.spec.ts
+++ b/ui/tests/unit/releaseChangelogs.spec.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadReleaseChangelogs } from '../../build/releaseChangelogs';
+import { compareReleaseVersions, parseReleaseVersion } from '@/utils/releaseVersions';
+
+const temporaryDirectories: string[] = [];
+
+const createFixtureDirectory = async (): Promise<string> => {
+    const directory = await mkdtemp(join(tmpdir(), 'meridian-release-changelogs-'));
+    temporaryDirectories.push(directory);
+    return directory;
+};
+
+afterEach(async () => {
+    await Promise.all(
+        temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+    );
+});
+
+describe('release versions', () => {
+    it('parses only strict numeric beta versions', () => {
+        expect(parseReleaseVersion('1.7.8-beta')).toEqual([1, 7, 8]);
+        expect(parseReleaseVersion('0.0.0-beta')).toEqual([0, 0, 0]);
+
+        for (const invalid of [
+            'development',
+            'v1.7.8-beta',
+            '1.07.8-beta',
+            '1.7.8',
+            '1.7.8-alpha',
+        ]) {
+            expect(parseReleaseVersion(invalid)).toBeNull();
+        }
+    });
+
+    it('compares numeric components instead of lexical order', () => {
+        expect(compareReleaseVersions('1.7.10-beta', '1.7.9-beta')).toBeGreaterThan(0);
+        expect(compareReleaseVersions('2.0.0-beta', '1.99.99-beta')).toBeGreaterThan(0);
+        expect(compareReleaseVersions('1.7.8-beta', '1.7.8-beta')).toBe(0);
+        expect(() => compareReleaseVersions('development', '1.7.8-beta')).toThrow(
+            'Cannot compare invalid release versions',
+        );
+    });
+});
+
+describe('release changelog catalog', () => {
+    it('loads every repository changelog once in numeric newest-first order', async () => {
+        const directory = fileURLToPath(
+            new URL('../../../docs/changelogs/', import.meta.url),
+        );
+        const sourceFiles = (await readdir(directory)).filter((filename) => filename.endsWith('.md'));
+        const changelogs = await loadReleaseChangelogs(directory);
+
+        expect(changelogs).toHaveLength(sourceFiles.length);
+        expect(new Set(changelogs.map(({ version }) => version)).size).toBe(sourceFiles.length);
+        expect(changelogs.map(({ version }) => version)).toEqual(
+            [...changelogs]
+                .sort((left, right) => compareReleaseVersions(right.version, left.version))
+                .map(({ version }) => version),
+        );
+        expect(changelogs.find(({ version }) => version === '1.4.0-beta')?.html).toContain(
+            'Meridian 1.4.0',
+        );
+    });
+
+    it('renders Markdown while neutralizing embedded raw HTML', async () => {
+        const directory = await createFixtureDirectory();
+        await writeFile(
+            join(directory, 'Update-1.0.0-beta.md'),
+            '# Release\n\n<script>alert("unsafe")</script>\n\n- Fixed',
+        );
+
+        const [changelog] = await loadReleaseChangelogs(directory);
+
+        expect(changelog?.html).toContain('<h1>Release</h1>');
+        expect(changelog?.html).toContain('&lt;script&gt;alert(&quot;unsafe&quot;)&lt;/script&gt;');
+        expect(changelog?.html).not.toContain('<script>');
+    });
+
+    it('rejects malformed filenames and empty changelogs', async () => {
+        const malformedDirectory = await createFixtureDirectory();
+        await writeFile(join(malformedDirectory, 'Update-1.0.0.md'), '# Invalid');
+        await expect(loadReleaseChangelogs(malformedDirectory)).rejects.toThrow(
+            'Invalid release changelog filename',
+        );
+
+        const emptyDirectory = await createFixtureDirectory();
+        await writeFile(join(emptyDirectory, 'Update-1.0.0-beta.md'), '   \n');
+        await expect(loadReleaseChangelogs(emptyDirectory)).rejects.toThrow('is empty');
+    });
+
+    it('rejects missing directories and catalogs without Markdown files', async () => {
+        const directory = await createFixtureDirectory();
+        await writeFile(join(directory, 'README.txt'), 'not a changelog');
+
+        await expect(loadReleaseChangelogs(directory)).rejects.toThrow(
+            'contains no Markdown files',
+        );
+        await expect(loadReleaseChangelogs(join(directory, 'missing'))).rejects.toThrow(
+            'Unable to read release changelog directory',
+        );
+    });
+});


### PR DESCRIPTION
# Meridian 1.7.9-beta

Meridian `1.7.9-beta` turns the homepage version into a complete release-notes viewer, adds a browser-local update indicator, and tightens release changelog validation during publishing.

## Highlights

### Homepage Release Notes

The homepage version now opens the complete repository changelog catalog without a runtime API request.

- Select the version display to open formatted release notes for every changelog under `docs/changelogs`, ordered by numeric release version from newest to oldest.
- Switch between releases inside a responsive modal; the newest release is selected again whenever the modal opens.
- Changelogs are loaded and rendered during the Nuxt build, with embedded raw HTML escaped before the generated content reaches the browser.

### Browser-Local Update Indicator

The version display now shows when the loaded release is newer than the release last viewed in the current browser.

- A first visit with a valid beta version shows an update indicator. Opening release notes immediately clears it and stores the current version under `meridian-last-seen-release`.
- Older stored versions restore the indicator, while equal or newer stored versions do not. Viewing a rolled-back build preserves the newer watermark.
- Development or malformed version values do not create a release watermark, and unavailable browser storage does not prevent release notes from opening.

### Exact Release Changelog Validation

Release publishing now rejects a release pull request when its body differs from the merged changelog.

- Pull request bodies must exactly match the changelog, including line endings and the trailing newline.
- A mismatch stops publishing before tag or release mutation begins.

## Self-Hosting and Upgrade Notes

Meridian `1.7.9-beta` is a non-breaking frontend and release-tooling update with no database migration, new configuration keys, new secrets, dependency-manifest changes, or lockfile changes.

- Rebuild and redeploy the UI to include the build-time changelog catalog and homepage release-notes viewer. Frontend Docker builds now copy `docs/changelogs` into the builder before Nuxt compilation.
- Existing accounts and server data require no migration. Seen-release state remains browser-local in `localStorage` and is not synchronized through an account or backend service.
- Release maintainers using custom pull request preparation must preserve the changelog body exactly, including line endings and the final newline, for publish validation to succeed.
