### PR TITLE
fix(graph): place new generators beside existing children

### DIFF
--- a/ui/app/composables/useGraphChat.ts
+++ b/ui/app/composables/useGraphChat.ts
@@ -1,10 +1,15 @@
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow, type GraphNode } from '@vue-flow/core';
 
 import { DEFAULT_NODE_ID } from '@/constants';
 import { AUTO_PLACEMENT_GAP } from '@/composables/useGraphOverlaps';
 import { NodeTypeEnum } from '@/types/enums';
 import type { ChatInputSubmission } from '@/types/chat';
 import type { RepoContent } from '@/types/github';
+import type { NodeWithDimensions } from '@/types/graph';
+import {
+    calculateGeneratorChildPosition,
+    type GeneratorPlacementNode,
+} from '@/utils/graphGeometry';
 
 type CreatedChatNodes = {
     generatorNodeId: string | undefined;
@@ -18,6 +23,7 @@ export const useGraphChat = () => {
     const chatStore = useChatStore();
     const { error } = useToast();
     const { placeBlock, placeEdge } = useGraphActions();
+    const { getBlockByNodeType } = useBlocks();
 
     const { upcomingModelData } = storeToRefs(chatStore);
 
@@ -60,19 +66,50 @@ export const useGraphChat = () => {
         };
     };
 
+    const getNodeWidth = (node: GraphNode): number => {
+        const dimensionsWidth = (node as NodeWithDimensions).dimensions?.width;
+        if (dimensionsWidth && dimensionsWidth > 0) return dimensionsWidth;
+        if (typeof node.width === 'number' && node.width > 0) return node.width;
+        return getBlockByNodeType(node.type as NodeTypeEnum)?.minSize.width ?? 0;
+    };
+
+    const getGeneratorPlacement = (fromNodeId: string) => {
+        const parentRect = getNodeRect(fromNodeId);
+        const { findNode, getNodes, getEdges } = useVueFlow('main-graph-' + graphId.value);
+        const parentNode = findNode(fromNodeId);
+        const normalizedNodes: GeneratorPlacementNode[] = getNodes.value.map((node) => ({
+            id: node.id,
+            type: node.type,
+            position: node.position,
+            width: getNodeWidth(node),
+            height:
+                (node as NodeWithDimensions).dimensions?.height ??
+                (typeof node.height === 'number' ? node.height : 0),
+        }));
+        const normalizedParent: GeneratorPlacementNode = {
+            id: fromNodeId,
+            type: parentNode?.type,
+            position: { x: parentRect.x, y: parentRect.y },
+            width: parentNode ? getNodeWidth(parentNode) : 0,
+            height: parentRect.height,
+        };
+
+        return calculateGeneratorChildPosition({
+            parent: normalizedParent,
+            nodes: normalizedNodes,
+            edges: getEdges.value.map((edge) => ({ source: edge.source, target: edge.target })),
+            gap: AUTO_PLACEMENT_GAP,
+        });
+    };
+
     const addTextToTextFromNodeId = (input: string, fromNodeId: string) => {
-        const {
-            x: inputNodeBaseX,
-            y: inputNodeBaseY,
-            height: inputNodeHeight,
-        } = getNodeRect(fromNodeId);
+        const position = getGeneratorPlacement(fromNodeId);
 
         const newTextToTextNode = placeBlock({
             graphId: graphId.value,
             blocId: 'primary-model-text-to-text',
             fromNodeId: fromNodeId,
-            positionFrom: { x: inputNodeBaseX, y: inputNodeBaseY },
-            positionOffset: { x: 0, y: inputNodeHeight + AUTO_PLACEMENT_GAP },
+            positionFrom: position,
             data: {
                 ...upcomingModelData.value.data,
                 reply: '',
@@ -223,18 +260,13 @@ export const useGraphChat = () => {
             return addParallelizationFromEmptyGraph(input, forcedParallelizationNodeId);
         }
 
-        const {
-            x: inputNodeBaseX,
-            y: inputNodeBaseY,
-            height: inputNodeHeight,
-        } = getNodeRect(fromNodeId);
+        const position = getGeneratorPlacement(fromNodeId);
 
         const newParallelizationNode = placeBlock({
             graphId: graphId.value,
             blocId: 'primary-model-parallelization',
             fromNodeId: fromNodeId,
-            positionFrom: { x: inputNodeBaseX, y: inputNodeBaseY },
-            positionOffset: { x: 0, y: inputNodeHeight + AUTO_PLACEMENT_GAP },
+            positionFrom: position,
             data: {
                 ...upcomingModelData.value.data,
             },
@@ -260,18 +292,13 @@ export const useGraphChat = () => {
             return addRoutingFromEmptyGraph(input, forcedRoutingNodeId);
         }
 
-        const {
-            x: inputNodeBaseX,
-            y: inputNodeBaseY,
-            height: inputNodeHeight,
-        } = getNodeRect(fromNodeId);
+        const position = getGeneratorPlacement(fromNodeId);
 
         const newRoutingNode = placeBlock({
             graphId: graphId.value,
             blocId: 'primary-model-routing',
             fromNodeId: fromNodeId,
-            positionFrom: { x: inputNodeBaseX, y: inputNodeBaseY },
-            positionOffset: { x: 0, y: inputNodeHeight + AUTO_PLACEMENT_GAP },
+            positionFrom: position,
             data: {
                 ...upcomingModelData.value.data,
             },

--- a/ui/app/composables/useQuickWorkflow.ts
+++ b/ui/app/composables/useQuickWorkflow.ts
@@ -5,7 +5,11 @@ import type { QuickWorkflowCreatePayload } from '@/composables/useGraphEvents';
 import { AUTO_PLACEMENT_GAP } from '@/composables/useGraphOverlaps';
 import { NodeCategoryEnum, NodeTypeEnum } from '@/types/enums';
 import type { BlockDefinition, NodeWithDimensions } from '@/types/graph';
-import { calculateQuickWorkflowPositionOffset } from '@/utils/graphGeometry';
+import {
+    calculateGeneratorChildPosition,
+    calculateQuickWorkflowPositionOffset,
+    type GeneratorPlacementNode,
+} from '@/utils/graphGeometry';
 import {
     getQuickWorkflowBlockId,
     getQuickWorkflowHandleId,
@@ -21,6 +25,12 @@ const LINKED_NODE_OFFSETS: Partial<Record<NodeTypeEnum, { x: number; y: number }
     [NodeTypeEnum.GITHUB]: { x: -600, y: 0 },
 };
 
+const GENERATOR_NODE_TYPES = [
+    NodeTypeEnum.TEXT_TO_TEXT,
+    NodeTypeEnum.PARALLELIZATION,
+    NodeTypeEnum.ROUTING,
+] as const;
+
 export const useQuickWorkflow = (graphIdOverride?: GraphIdRef) => {
     const route = useRoute();
     const graphId = computed(() => graphIdOverride?.value ?? (route.params.id as string) ?? '');
@@ -29,6 +39,13 @@ export const useQuickWorkflow = (graphIdOverride?: GraphIdRef) => {
     const { getBlockByNodeType } = useBlocks();
     const { acceptsMultipleInputEdges } = useEdgeCompatibility();
     const { resolveOverlaps } = useGraphOverlaps(graphId);
+
+    const getNodeWidth = (node: GraphNode): number => {
+        const dimensionsWidth = (node as NodeWithDimensions).dimensions?.width;
+        if (dimensionsWidth && dimensionsWidth > 0) return dimensionsWidth;
+        if (typeof node.width === 'number' && node.width > 0) return node.width;
+        return getBlockByNodeType(node.type as NodeTypeEnum)?.minSize.width ?? 0;
+    };
 
     const targetIsAvailable = (payload: QuickWorkflowCreatePayload, anchor: GraphNode): boolean => {
         if (payload.direction !== 'target') return true;
@@ -103,20 +120,55 @@ export const useQuickWorkflow = (graphIdOverride?: GraphIdRef) => {
                 : (getBlockByNodeType(anchor.type as NodeTypeEnum)?.minSize.width ?? 0));
         const mainHeight = definitions.main.minSize.height ?? 0;
         const mainWidth = definitions.main.minSize.width ?? 0;
-        const positionOffset = calculateQuickWorkflowPositionOffset({
-            category: payload.category,
-            direction: payload.direction,
-            anchorWidth,
-            anchorHeight,
-            mainWidth,
-            mainHeight,
-            gap: AUTO_PLACEMENT_GAP,
-        });
+        const usesGeneratorChildPlacement =
+            payload.category === NodeCategoryEnum.CONTEXT &&
+            payload.direction === 'source' &&
+            GENERATOR_NODE_TYPES.includes(
+                definitions.main.nodeType as (typeof GENERATOR_NODE_TYPES)[number],
+            );
+        const positionFrom = usesGeneratorChildPlacement
+            ? calculateGeneratorChildPosition({
+                  parent: {
+                      id: anchor.id,
+                      type: anchor.type,
+                      position: anchor.position,
+                      width: anchorWidth,
+                      height: anchorHeight,
+                  },
+                  nodes: getNodes.value.map(
+                      (node): GeneratorPlacementNode => ({
+                          id: node.id,
+                          type: node.type,
+                          position: node.position,
+                          width: getNodeWidth(node),
+                          height:
+                              (node as NodeWithDimensions).dimensions?.height ??
+                              (typeof node.height === 'number' ? node.height : 0),
+                      }),
+                  ),
+                  edges: getEdges.value.map((edge) => ({
+                      source: edge.source,
+                      target: edge.target,
+                  })),
+                  gap: AUTO_PLACEMENT_GAP,
+              })
+            : anchor.position;
+        const positionOffset = usesGeneratorChildPlacement
+            ? undefined
+            : calculateQuickWorkflowPositionOffset({
+                  category: payload.category,
+                  direction: payload.direction,
+                  anchorWidth,
+                  anchorHeight,
+                  mainWidth,
+                  mainHeight,
+                  gap: AUTO_PLACEMENT_GAP,
+              });
         const mainNode = placeBlock({
             graphId: graphId.value,
             blocId: definitions.main.id,
             fromNodeId: anchor.id,
-            positionFrom: anchor.position,
+            positionFrom,
             positionOffset,
         });
         if (!mainNode) return;

--- a/ui/app/utils/graphGeometry.ts
+++ b/ui/app/utils/graphGeometry.ts
@@ -1,4 +1,4 @@
-import { NodeCategoryEnum } from '@/types/enums';
+import { NodeCategoryEnum, NodeTypeEnum } from '@/types/enums';
 import type { QuickWorkflowDirection } from '@/utils/quickWorkflow';
 
 export interface GeometryPoint {
@@ -23,6 +23,26 @@ export interface QuickWorkflowPlacementInput {
     gap: number;
 }
 
+export interface GeneratorPlacementNode {
+    id: string;
+    type?: string;
+    position: GeometryPoint;
+    width: number;
+    height: number;
+}
+
+export interface GeneratorPlacementEdge {
+    source: string;
+    target: string;
+}
+
+export interface GeneratorChildPlacementInput {
+    parent: GeneratorPlacementNode;
+    nodes: readonly GeneratorPlacementNode[];
+    edges: readonly GeneratorPlacementEdge[];
+    gap: number;
+}
+
 export interface WheelGeometryConfig {
     radius: number;
     innerRadius: number;
@@ -35,6 +55,48 @@ export interface WheelSectorGeometry {
     iconX: number;
     iconY: number;
 }
+
+const GENERATOR_NODE_TYPES = new Set<string>([
+    NodeTypeEnum.TEXT_TO_TEXT,
+    NodeTypeEnum.PARALLELIZATION,
+    NodeTypeEnum.ROUTING,
+]);
+
+export const calculateGeneratorChildPosition = (
+    input: GeneratorChildPlacementInput,
+): GeometryPoint => {
+    const belowParent = {
+        x: input.parent.position.x,
+        y: input.parent.position.y + input.parent.height + input.gap,
+    };
+    if (!input.parent.type || !GENERATOR_NODE_TYPES.has(input.parent.type)) return belowParent;
+
+    const directChildIds = new Set(
+        input.edges
+            .filter((edge) => edge.source === input.parent.id)
+            .map((edge) => edge.target),
+    );
+    const directGeneratorChildren = input.nodes.filter(
+        (node) =>
+            directChildIds.has(node.id) &&
+            !!node.type &&
+            GENERATOR_NODE_TYPES.has(node.type),
+    );
+    const rightmostChild = directGeneratorChildren.reduce<GeneratorPlacementNode | undefined>(
+        (rightmost, child) =>
+            !rightmost || child.position.x + child.width > rightmost.position.x + rightmost.width
+                ? child
+                : rightmost,
+        undefined,
+    );
+
+    return rightmostChild
+        ? {
+              x: rightmostChild.position.x + rightmostChild.width + input.gap,
+              y: rightmostChild.position.y,
+          }
+        : belowParent;
+};
 
 export const calculateQuickWorkflowPositionOffset = (
     input: QuickWorkflowPlacementInput,

--- a/ui/tests/nuxt/useGraphChat.spec.ts
+++ b/ui/tests/nuxt/useGraphChat.spec.ts
@@ -1,13 +1,18 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import type { GraphNode } from '@vue-flow/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NodeTypeEnum } from '@/types/enums';
 import { useGraphChat } from '@/composables/useGraphChat';
 
 const stubs = vi.hoisted(() => ({
-    findNode: vi.fn((nodeId: string) => ({
-        id: nodeId,
-        position: { x: 100, y: 200 },
-    })),
+    nodes: { value: [] as GraphNode[] },
+    edges: { value: [] as Array<{ source: string; target: string }> },
+    findNode: vi.fn((nodeId: string) =>
+        stubs.nodes.value.find((node) => node.id === nodeId) ?? {
+            id: nodeId,
+            position: { x: 100, y: 200 },
+        },
+    ),
     placeBlock: vi.fn((options: { blocId: string }) => ({
         id:
             options.blocId === 'primary-prompt-text'
@@ -23,7 +28,11 @@ const stubs = vi.hoisted(() => ({
 }));
 
 vi.mock('@vue-flow/core', () => ({
-    useVueFlow: () => ({ findNode: stubs.findNode }),
+    useVueFlow: () => ({
+        findNode: stubs.findNode,
+        getNodes: stubs.nodes,
+        getEdges: stubs.edges,
+    }),
 }));
 
 mockNuxtImport('useRoute', () => () => ({ params: { id: 'graph-id' } }));
@@ -39,15 +48,79 @@ mockNuxtImport('useGraphActions', () => () => ({
 mockNuxtImport('useGraphOverlaps', () => () => ({
     resolveOverlaps: stubs.resolveOverlaps,
 }));
+mockNuxtImport('useBlocks', () => () => ({
+    getBlockByNodeType: () => ({ minSize: { width: 100, height: 100 } }),
+}));
 
 describe('useGraphChat createNodeFromVariant', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.useFakeTimers();
+        stubs.nodes.value = [
+            {
+                id: 'source-node-id',
+                type: NodeTypeEnum.TEXT_TO_TEXT,
+                position: { x: 100, y: 200 },
+            } as GraphNode,
+        ];
+        stubs.edges.value = [];
+        const parentElement = document.createElement('div');
+        parentElement.dataset.id = 'source-node-id';
+        parentElement.style.height = '180px';
+        document.body.append(parentElement);
     });
 
     afterEach(() => {
         vi.useRealTimers();
+        document.body.replaceChildren();
+    });
+
+    it('places a generator below a generator parent without direct generator children', () => {
+        const { createNodeFromVariant } = useGraphChat();
+
+        createNodeFromVariant(NodeTypeEnum.TEXT_TO_TEXT, 'source-node-id', {
+            submission: { message: 'Prompt text', files: [], githubContext: null },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'primary-model-text-to-text',
+                positionFrom: { x: 100, y: 530 },
+            }),
+        );
+    });
+
+    it('places a generator right of the rightmost direct generator child', () => {
+        stubs.nodes.value.push(
+            {
+                id: 'direct-child',
+                type: NodeTypeEnum.ROUTING,
+                position: { x: 500, y: 600 },
+                dimensions: { width: 350, height: 100 },
+            } as GraphNode,
+            {
+                id: 'descendant',
+                type: NodeTypeEnum.PARALLELIZATION,
+                position: { x: 1200, y: 1000 },
+                width: 300,
+            } as GraphNode,
+        );
+        stubs.edges.value = [
+            { source: 'source-node-id', target: 'direct-child' },
+            { source: 'direct-child', target: 'descendant' },
+        ];
+        const { createNodeFromVariant } = useGraphChat();
+
+        createNodeFromVariant(NodeTypeEnum.ROUTING, 'source-node-id', {
+            submission: { message: 'Prompt text', files: [], githubContext: null },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'primary-model-routing',
+                positionFrom: { x: 1000, y: 600 },
+            }),
+        );
     });
 
     it('resolves the main node and attached prompt below collisions after the placement delay', async () => {

--- a/ui/tests/nuxt/useQuickWorkflow.spec.ts
+++ b/ui/tests/nuxt/useQuickWorkflow.spec.ts
@@ -9,9 +9,16 @@ import type { BlockDefinition } from '@/types/graph';
 
 const stubs = vi.hoisted(() => ({
     nodes: { value: [] as GraphNode[] },
-    edges: { value: [] as Array<{ target: string; targetHandle: string }> },
+    edges: {
+        value: [] as Array<{
+            source: string;
+            target: string;
+            targetHandle?: string;
+        }>,
+    },
     placeBlock: vi.fn(),
     placeEdge: vi.fn(),
+    resolveOverlaps: vi.fn(),
 }));
 
 vi.mock('@vue-flow/core', () => ({
@@ -26,7 +33,7 @@ mockNuxtImport('useGraphActions', () => () => ({
 mockNuxtImport('useEdgeCompatibility', () => () => ({
     acceptsMultipleInputEdges: () => false,
 }));
-mockNuxtImport('useGraphOverlaps', () => () => ({ resolveOverlaps: vi.fn() }));
+mockNuxtImport('useGraphOverlaps', () => () => ({ resolveOverlaps: stubs.resolveOverlaps }));
 mockNuxtImport('useBlocks', () => () => ({
     getBlockByNodeType: (nodeType: NodeTypeEnum) =>
         ({
@@ -43,14 +50,28 @@ mockNuxtImport('useBlocks', () => () => ({
 
 describe('useQuickWorkflow availability', () => {
     beforeEach(() => {
+        vi.clearAllMocks();
         stubs.nodes.value = [
             {
                 id: 'anchor',
                 type: NodeTypeEnum.TEXT_TO_TEXT,
                 position: { x: 0, y: 0 },
+                dimensions: { width: 320, height: 180 },
             } as GraphNode,
         ];
         stubs.edges.value = [];
+        stubs.placeBlock.mockImplementation(
+            (options: {
+                positionFrom: { x: number; y: number };
+                positionOffset?: { x: number; y: number };
+            }) => ({
+                id: 'quick-main-id',
+                position: {
+                    x: options.positionFrom.x + (options.positionOffset?.x ?? 0),
+                    y: options.positionFrom.y + (options.positionOffset?.y ?? 0),
+                },
+            }),
+        );
     });
 
     it('uses creation validation for valid, invalid, missing, and occupied anchors', () => {
@@ -71,7 +92,96 @@ describe('useQuickWorkflow availability', () => {
         ).toBe(false);
         expect(canCreateQuickWorkflow({ ...validPayload, fromNodeId: 'missing' })).toBe(false);
 
-        stubs.edges.value = [{ target: 'anchor', targetHandle: 'prompt_anchor' }];
+        stubs.edges.value = [
+            { source: 'occupied-source', target: 'anchor', targetHandle: 'prompt_anchor' },
+        ];
         expect(canCreateQuickWorkflow(validPayload)).toBe(false);
+    });
+
+    it('places a context source generator below an anchor without generator children', () => {
+        const { createQuickWorkflow } = useQuickWorkflow(ref('graph-id'));
+
+        createQuickWorkflow({
+            fromNodeId: 'anchor',
+            category: NodeCategoryEnum.CONTEXT,
+            direction: 'source',
+            slot: {
+                name: 'Generator',
+                mainBloc: NodeTypeEnum.TEXT_TO_TEXT,
+                options: [],
+            },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'block-textToText',
+                positionFrom: { x: 0, y: 330 },
+                positionOffset: undefined,
+            }),
+        );
+    });
+
+    it('places a context source generator right of the rightmost direct generator child', () => {
+        stubs.nodes.value.push(
+            {
+                id: 'direct-child',
+                type: NodeTypeEnum.ROUTING,
+                position: { x: 500, y: 600 },
+                dimensions: { width: 350, height: 100 },
+            } as GraphNode,
+            {
+                id: 'descendant',
+                type: NodeTypeEnum.PARALLELIZATION,
+                position: { x: 1200, y: 1000 },
+                width: 300,
+            } as GraphNode,
+        );
+        stubs.edges.value = [
+            { source: 'anchor', target: 'direct-child' },
+            { source: 'direct-child', target: 'descendant' },
+        ];
+        const { createQuickWorkflow } = useQuickWorkflow(ref('graph-id'));
+
+        createQuickWorkflow({
+            fromNodeId: 'anchor',
+            category: NodeCategoryEnum.CONTEXT,
+            direction: 'source',
+            slot: {
+                name: 'Generator',
+                mainBloc: NodeTypeEnum.ROUTING,
+                options: [],
+            },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'block-routing',
+                positionFrom: { x: 1000, y: 600 },
+                positionOffset: undefined,
+            }),
+        );
+    });
+
+    it('keeps target-direction workflow placement unchanged', () => {
+        const { createQuickWorkflow } = useQuickWorkflow(ref('graph-id'));
+
+        createQuickWorkflow({
+            fromNodeId: 'anchor',
+            category: NodeCategoryEnum.CONTEXT,
+            direction: 'target',
+            slot: {
+                name: 'Generator',
+                mainBloc: NodeTypeEnum.PARALLELIZATION,
+                options: [],
+            },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'block-parallelization',
+                positionFrom: { x: 0, y: 0 },
+                positionOffset: { x: 0, y: -250 },
+            }),
+        );
     });
 });

--- a/ui/tests/unit/graphGeometry.spec.ts
+++ b/ui/tests/unit/graphGeometry.spec.ts
@@ -1,10 +1,123 @@
 import { describe, expect, it } from 'vitest';
-import { NodeCategoryEnum } from '@/types/enums';
+import { NodeCategoryEnum, NodeTypeEnum } from '@/types/enums';
 import {
+    calculateGeneratorChildPosition,
     calculateOverlapTranslation,
     calculateQuickWorkflowPositionOffset,
     calculateWheelSectorGeometry,
 } from '@/utils/graphGeometry';
+
+describe('calculateGeneratorChildPosition', () => {
+    const parent = {
+        id: 'parent',
+        type: NodeTypeEnum.TEXT_TO_TEXT,
+        position: { x: 100, y: 200 },
+        width: 320,
+        height: 180,
+    };
+
+    it('keeps below-parent placement when no direct generator child exists', () => {
+        expect(
+            calculateGeneratorChildPosition({ parent, nodes: [parent], edges: [], gap: 150 }),
+        ).toEqual({ x: 100, y: 530 });
+    });
+
+    it('uses right edge of rightmost direct generator child and ignores other topology', () => {
+        const nodes = [
+            parent,
+            {
+                id: 'wide-child',
+                type: NodeTypeEnum.TEXT_TO_TEXT,
+                position: { x: 450, y: 600 },
+                width: 400,
+                height: 100,
+            },
+            {
+                id: 'higher-x-child',
+                type: NodeTypeEnum.ROUTING,
+                position: { x: 700, y: 650 },
+                width: 100,
+                height: 100,
+            },
+            {
+                id: 'descendant',
+                type: NodeTypeEnum.PARALLELIZATION,
+                position: { x: 1200, y: 1000 },
+                width: 300,
+                height: 100,
+            },
+            {
+                id: 'non-generator',
+                type: NodeTypeEnum.PROMPT,
+                position: { x: 1600, y: 1200 },
+                width: 200,
+                height: 100,
+            },
+            {
+                id: 'incoming-generator',
+                type: NodeTypeEnum.ROUTING,
+                position: { x: 2000, y: 1400 },
+                width: 200,
+                height: 100,
+            },
+        ];
+        const edges = [
+            { source: parent.id, target: 'wide-child' },
+            { source: parent.id, target: 'higher-x-child' },
+            { source: 'wide-child', target: 'descendant' },
+            { source: parent.id, target: 'non-generator' },
+            { source: 'incoming-generator', target: parent.id },
+        ];
+
+        expect(calculateGeneratorChildPosition({ parent, nodes, edges, gap: 150 })).toEqual({
+            x: 1000,
+            y: 600,
+        });
+    });
+
+    it.each([
+        NodeTypeEnum.TEXT_TO_TEXT,
+        NodeTypeEnum.PARALLELIZATION,
+        NodeTypeEnum.ROUTING,
+    ])('accepts direct %s children', (type) => {
+        const child = {
+            id: 'child',
+            type,
+            position: { x: 500, y: 700 },
+            width: 250,
+            height: 100,
+        };
+
+        expect(
+            calculateGeneratorChildPosition({
+                parent,
+                nodes: [parent, child],
+                edges: [{ source: parent.id, target: child.id }],
+                gap: 150,
+            }),
+        ).toEqual({ x: 900, y: 700 });
+    });
+
+    it('keeps below-parent placement for a non-generator parent', () => {
+        const promptParent = { ...parent, type: NodeTypeEnum.PROMPT };
+        const child = {
+            id: 'child',
+            type: NodeTypeEnum.TEXT_TO_TEXT,
+            position: { x: 500, y: 700 },
+            width: 250,
+            height: 100,
+        };
+
+        expect(
+            calculateGeneratorChildPosition({
+                parent: promptParent,
+                nodes: [promptParent, child],
+                edges: [{ source: promptParent.id, target: child.id }],
+                gap: 150,
+            }),
+        ).toEqual({ x: 100, y: 530 });
+    });
+});
 
 describe('calculateQuickWorkflowPositionOffset', () => {
     it.each([


### PR DESCRIPTION
## Summary
- place chat-created generator nodes to the right of existing direct generator children
- apply same sibling placement to quick action wheel workflows
- preserve below-parent placement when no direct generator children exist
- add geometry and composable regression coverage

## Testing
- `make test-ui-unit ARGS='--project unit tests/unit/graphGeometry.spec.ts'`\n- `make test-ui-unit ARGS='--project nuxt tests/nuxt/useGraphChat.spec.ts tests/nuxt/useQuickWorkflow.spec.ts'`\n- `make lint-ui`\n- `make typecheck-ui`\n- `make test-ui-unit` *(281/283 passed; two pre-existing `releaseVersionInfo.spec.ts` expectations still target 1.7.8-beta instead of committed 1.7.9-beta)*