### PR TITLE
Release Meridian 1.7.10-beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ api/app/data/cloned_repos/4c0a28f1-d50c-4825-bbd0-b8ff89ae7b8a/
 .codebase-memory/
 sandbox_manager/.mypy_cache/
 .opencode/
+
+/paseo.json

--- a/docs/changelogs/Update-1.7.10-beta.md
+++ b/docs/changelogs/Update-1.7.10-beta.md
@@ -1,0 +1,38 @@
+# Meridian 1.7.10-beta
+
+Meridian `1.7.10-beta` adds canvas graph auto layout, improves generator chain placement to reduce overlap, and tightens release changelog validation to require an exact match.
+
+## Highlights
+
+### Graph Auto Layout
+
+The canvas now supports automatic arrangement of graph nodes with a deterministic, multi-strategy layout.
+
+- Use **Auto layout** from the canvas toolbar (`Controls` top-left) or from the quick-action wheel (right-click / `Shift+F10` on the canvas). The toolbar control is disabled when the graph is empty; the wheel action appears alongside **Fit graph**.
+- Layout normalizes grouped nodes to their outer container, deduplicates constraints, splits disconnected components, and arranges each component with layered strategies for vertical ranking, branch columns, attachment stacks, fanout hierarchy, and serial prompt spines before packing components into rows.
+- Running auto layout repositions nodes via `@dagrejs/dagre` (`network-simplex` ranking, `greedy` acyclicer), fits the viewport (`maxZoom: 1`, `minZoom: 0.4`, `padding: 0.2`), and persists the new positions through the existing graph save path. Layout anchoring preserves the previous minimum `x`/`y` so the graph remains in its existing coordinate context, with positions rounded to whole pixels.
+
+### Smarter Generator Chain Placement
+
+Creating generator nodes from an existing generator parent now avoids stacking directly below the parent when a chain already exists.
+
+- Applies to chat actions that create `text-to-text`, `parallelization`, and `routing` nodes and to quick-workflow creation when `category` is `CONTEXT`, `direction` is `source`, and the target block is a generator type.
+- When the parent is a generator (`text-to-text`, `parallelization`, `routing`) and has directly-connected generator children, the new node is placed to the right of the rightmost child (`child.x + child.width + gap`) at the same `y`; otherwise it is placed below the parent (`parent.y + parent.height + gap`).
+- Non-generator parents and all other quick-workflow directions/categories keep the original offset calculation, including `calculateQuickWorkflowPositionOffset` handling. Node dimensions are resolved from rendered dimensions, explicit width/height, style dimensions, or block `minSize`.
+
+### Stricter Release Changelog Validation
+
+Release publishing now requires byte-exact equality between the merged release pull request body and the versioned changelog.
+
+- `scripts/release_automation.py` no longer normalizes `CRLF` (`\r\n`) to `LF` (`\n`) before comparison; `pull.get("body") != changelog` now fails the publish step before tag or release mutation.
+- `docs/releasing.md` is updated to state that the PR body must exactly match the changelog, including trailing newline. The previous wording that treated `CRLF` and `LF` as equivalent is removed.
+
+## Self-Hosting and Upgrade Notes
+
+Meridian `1.7.10-beta` is a non-breaking frontend and release-tooling update with no database migration, new configuration keys, or new secrets. UI dependency manifests and lockfile are updated to include the layout engine.
+
+- Rebuild and redeploy the UI to include `ui/package.json` addition `@dagrejs/dagre@^3.1.0` and `ui/pnpm-lock.yaml` updates. Frontend Docker builds include the new `graphAutoLayout` utilities (`graphAutoLayout.ts`, `graphAutoLayoutAttachmentStacks.ts`, `graphAutoLayoutBranchColumns.ts`, `graphAutoLayoutComponent.ts`, `graphAutoLayoutConstraints.ts`, `graphAutoLayoutFanoutHierarchy.ts`, `graphAutoLayoutSerialPrompts.ts`) and updated `graphGeometry.ts` / canvas wiring.
+- Existing graphs, accounts, and server data require no migration. Auto layout is manual-only and saves through the existing `saveGraph` path; no automatic re-layout occurs on load.
+- Release maintainers must preserve the generated release PR body exactly as the changelog, including line endings and final trailing newline, for publish validation to succeed. Mismatched bodies stop publication before any tag or release is written.
+- No API image rebuild is required for the layout changes alone, but rebuilding all images from the same commit remains the standard deployment path.
+

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,7 @@
+{
+  "metadataGeneration": {
+    "commitMessage": {
+      "instructions": "Use the Conventional Commits format. Valid types: feat, fix, test, docs, refactor, chore, style, perf. Example: feat(invoice): add amount validation. The first line should not exceed 72 characters. The second line should be blank. Starting with the third line, write a more detailed description in explaining the reason for the change and any additional context. Use bullet points if there are several important points."
+    }
+  }
+}

--- a/paseo.json
+++ b/paseo.json
@@ -1,7 +1,0 @@
-{
-  "metadataGeneration": {
-    "commitMessage": {
-      "instructions": "Use the Conventional Commits format. Valid types: feat, fix, test, docs, refactor, chore, style, perf. Example: feat(invoice): add amount validation. The first line should not exceed 72 characters. The second line should be blank. Starting with the third line, write a more detailed description in explaining the reason for the change and any additional context. Use bullet points if there are several important points."
-    }
-  }
-}

--- a/ui/app/components/ui/graph/canvasControls.vue
+++ b/ui/app/components/ui/graph/canvasControls.vue
@@ -7,6 +7,9 @@ import { ExecutionPlanDirectionEnum } from '@/types/enums';
 const props = defineProps<{
     graphId: string;
 }>();
+const emit = defineEmits<{
+    'auto-layout': [];
+}>();
 
 // --- Stores ---
 const sidebarSelectorStore = useSidebarCanvasStore();
@@ -62,6 +65,17 @@ const deleteAllNodes = () => {
             "
         >
             <UiIcon name="CodiconRunAll" class="text-stone-gray absolute shrink-0 scale-125" />
+        </ControlButton>
+
+        <ControlButton
+            :disabled="getNodes.length === 0"
+            title="Auto layout"
+            @click="emit('auto-layout')"
+        >
+            <UiIcon
+                name="MaterialSymbolsAccountTreeOutlineRounded"
+                class="text-stone-gray absolute shrink-0 scale-125"
+            />
         </ControlButton>
     </Controls>
 </template>

--- a/ui/app/composables/useGraphAutoLayout.ts
+++ b/ui/app/composables/useGraphAutoLayout.ts
@@ -1,0 +1,77 @@
+import { useVueFlow, type GraphNode } from '@vue-flow/core';
+import type { ComputedRef, Ref } from 'vue';
+
+import type { NodeTypeEnum } from '@/types/enums';
+import type { NodeWithDimensions } from '@/types/graph';
+import {
+    calculateGraphAutoLayout,
+    type GraphAutoLayoutNode,
+} from '@/utils/graphAutoLayout';
+
+interface UseGraphAutoLayoutOptions {
+    graphId: Ref<string> | ComputedRef<string>;
+    fitGraph: () => unknown | Promise<unknown>;
+}
+
+const positiveNumber = (value: unknown): number | undefined =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
+
+const styleDimension = (style: GraphNode['style'], key: 'width' | 'height'): number | undefined => {
+    if (!style || typeof style !== 'object' || Array.isArray(style)) return undefined;
+    const value = (style as Record<string, unknown>)[key];
+    if (typeof value === 'number') return positiveNumber(value);
+    if (typeof value !== 'string') return undefined;
+    return positiveNumber(Number.parseFloat(value));
+};
+
+export const useGraphAutoLayout = (options: UseGraphAutoLayoutOptions) => {
+    const { getNodes, getEdges, setNodes } = useVueFlow('main-graph-' + options.graphId.value);
+    const { getBlockByNodeType } = useBlocks();
+    const { saveGraph } = useCanvasSaveStore();
+
+    const resolveDimension = (
+        node: NodeWithDimensions,
+        key: 'width' | 'height',
+    ): number =>
+        positiveNumber(node.dimensions?.[key]) ??
+        positiveNumber(node[key]) ??
+        styleDimension(node.style, key) ??
+        positiveNumber(getBlockByNodeType(node.type as NodeTypeEnum)?.minSize[key]) ??
+        100;
+
+    const autoLayoutGraph = async (): Promise<boolean> => {
+        const nodes = getNodes.value;
+        if (!nodes.length) return false;
+
+        const layoutNodes: GraphAutoLayoutNode[] = nodes.map((node) => ({
+            id: node.id,
+            position: { ...node.position },
+            width: resolveDimension(node as NodeWithDimensions, 'width'),
+            height: resolveDimension(node as NodeWithDimensions, 'height'),
+            type: node.type,
+            parentNode: node.parentNode,
+        }));
+        const positions = calculateGraphAutoLayout(
+            layoutNodes,
+            getEdges.value.map((edge) => ({
+                id: edge.id,
+                source: edge.source,
+                target: edge.target,
+                sourceHandle: edge.sourceHandle,
+                targetHandle: edge.targetHandle,
+            })),
+        );
+        setNodes(
+            nodes.map((node) => {
+                const position = positions.get(node.id);
+                return position ? { ...node, position } : node;
+            }),
+        );
+        await nextTick();
+        await options.fitGraph();
+        await saveGraph();
+        return true;
+    };
+
+    return { autoLayoutGraph };
+};

--- a/ui/app/composables/useGraphChat.ts
+++ b/ui/app/composables/useGraphChat.ts
@@ -1,10 +1,15 @@
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow, type GraphNode } from '@vue-flow/core';
 
 import { DEFAULT_NODE_ID } from '@/constants';
 import { AUTO_PLACEMENT_GAP } from '@/composables/useGraphOverlaps';
 import { NodeTypeEnum } from '@/types/enums';
 import type { ChatInputSubmission } from '@/types/chat';
 import type { RepoContent } from '@/types/github';
+import type { NodeWithDimensions } from '@/types/graph';
+import {
+    calculateGeneratorChildPosition,
+    type GeneratorPlacementNode,
+} from '@/utils/graphGeometry';
 
 type CreatedChatNodes = {
     generatorNodeId: string | undefined;
@@ -18,6 +23,7 @@ export const useGraphChat = () => {
     const chatStore = useChatStore();
     const { error } = useToast();
     const { placeBlock, placeEdge } = useGraphActions();
+    const { getBlockByNodeType } = useBlocks();
 
     const { upcomingModelData } = storeToRefs(chatStore);
 
@@ -60,19 +66,50 @@ export const useGraphChat = () => {
         };
     };
 
+    const getNodeWidth = (node: GraphNode): number => {
+        const dimensionsWidth = (node as NodeWithDimensions).dimensions?.width;
+        if (dimensionsWidth && dimensionsWidth > 0) return dimensionsWidth;
+        if (typeof node.width === 'number' && node.width > 0) return node.width;
+        return getBlockByNodeType(node.type as NodeTypeEnum)?.minSize.width ?? 0;
+    };
+
+    const getGeneratorPlacement = (fromNodeId: string) => {
+        const parentRect = getNodeRect(fromNodeId);
+        const { findNode, getNodes, getEdges } = useVueFlow('main-graph-' + graphId.value);
+        const parentNode = findNode(fromNodeId);
+        const normalizedNodes: GeneratorPlacementNode[] = getNodes.value.map((node) => ({
+            id: node.id,
+            type: node.type,
+            position: node.position,
+            width: getNodeWidth(node),
+            height:
+                (node as NodeWithDimensions).dimensions?.height ??
+                (typeof node.height === 'number' ? node.height : 0),
+        }));
+        const normalizedParent: GeneratorPlacementNode = {
+            id: fromNodeId,
+            type: parentNode?.type,
+            position: { x: parentRect.x, y: parentRect.y },
+            width: parentNode ? getNodeWidth(parentNode) : 0,
+            height: parentRect.height,
+        };
+
+        return calculateGeneratorChildPosition({
+            parent: normalizedParent,
+            nodes: normalizedNodes,
+            edges: getEdges.value.map((edge) => ({ source: edge.source, target: edge.target })),
+            gap: AUTO_PLACEMENT_GAP,
+        });
+    };
+
     const addTextToTextFromNodeId = (input: string, fromNodeId: string) => {
-        const {
-            x: inputNodeBaseX,
-            y: inputNodeBaseY,
-            height: inputNodeHeight,
-        } = getNodeRect(fromNodeId);
+        const position = getGeneratorPlacement(fromNodeId);
 
         const newTextToTextNode = placeBlock({
             graphId: graphId.value,
             blocId: 'primary-model-text-to-text',
             fromNodeId: fromNodeId,
-            positionFrom: { x: inputNodeBaseX, y: inputNodeBaseY },
-            positionOffset: { x: 0, y: inputNodeHeight + AUTO_PLACEMENT_GAP },
+            positionFrom: position,
             data: {
                 ...upcomingModelData.value.data,
                 reply: '',
@@ -223,18 +260,13 @@ export const useGraphChat = () => {
             return addParallelizationFromEmptyGraph(input, forcedParallelizationNodeId);
         }
 
-        const {
-            x: inputNodeBaseX,
-            y: inputNodeBaseY,
-            height: inputNodeHeight,
-        } = getNodeRect(fromNodeId);
+        const position = getGeneratorPlacement(fromNodeId);
 
         const newParallelizationNode = placeBlock({
             graphId: graphId.value,
             blocId: 'primary-model-parallelization',
             fromNodeId: fromNodeId,
-            positionFrom: { x: inputNodeBaseX, y: inputNodeBaseY },
-            positionOffset: { x: 0, y: inputNodeHeight + AUTO_PLACEMENT_GAP },
+            positionFrom: position,
             data: {
                 ...upcomingModelData.value.data,
             },
@@ -260,18 +292,13 @@ export const useGraphChat = () => {
             return addRoutingFromEmptyGraph(input, forcedRoutingNodeId);
         }
 
-        const {
-            x: inputNodeBaseX,
-            y: inputNodeBaseY,
-            height: inputNodeHeight,
-        } = getNodeRect(fromNodeId);
+        const position = getGeneratorPlacement(fromNodeId);
 
         const newRoutingNode = placeBlock({
             graphId: graphId.value,
             blocId: 'primary-model-routing',
             fromNodeId: fromNodeId,
-            positionFrom: { x: inputNodeBaseX, y: inputNodeBaseY },
-            positionOffset: { x: 0, y: inputNodeHeight + AUTO_PLACEMENT_GAP },
+            positionFrom: position,
             data: {
                 ...upcomingModelData.value.data,
             },

--- a/ui/app/composables/useGraphQuickActionMenu.ts
+++ b/ui/app/composables/useGraphQuickActionMenu.ts
@@ -18,6 +18,7 @@ interface UseGraphQuickActionMenuOptions {
     unlinkNode: (nodeId: string) => void;
     deleteGroup: (graphId: string, groupId: string) => void;
     fitGraph: () => unknown;
+    autoLayoutGraph: () => unknown;
 }
 
 const GENERATOR_TYPES = new Set<string>([
@@ -165,6 +166,12 @@ export const useGraphQuickActionMenu = (options: UseGraphQuickActionMenuOptions)
                         ),
                 });
             }
+            result.push({
+                id: 'auto-layout',
+                label: 'Auto layout',
+                icon: 'MaterialSymbolsAccountTreeOutlineRounded',
+                run: options.autoLayoutGraph,
+            });
             result.push({
                 id: 'fit-graph',
                 label: 'Fit graph',

--- a/ui/app/composables/useGraphQuickActions.ts
+++ b/ui/app/composables/useGraphQuickActions.ts
@@ -30,6 +30,7 @@ interface UseGraphQuickActionsOptions {
     unlinkNode: (nodeId: string) => void;
     deleteGroup: (graphId: string, groupId: string) => void;
     fitGraph: () => unknown;
+    autoLayoutGraph: () => unknown;
 }
 
 interface PendingGesture {

--- a/ui/app/composables/useQuickWorkflow.ts
+++ b/ui/app/composables/useQuickWorkflow.ts
@@ -5,7 +5,11 @@ import type { QuickWorkflowCreatePayload } from '@/composables/useGraphEvents';
 import { AUTO_PLACEMENT_GAP } from '@/composables/useGraphOverlaps';
 import { NodeCategoryEnum, NodeTypeEnum } from '@/types/enums';
 import type { BlockDefinition, NodeWithDimensions } from '@/types/graph';
-import { calculateQuickWorkflowPositionOffset } from '@/utils/graphGeometry';
+import {
+    calculateGeneratorChildPosition,
+    calculateQuickWorkflowPositionOffset,
+    type GeneratorPlacementNode,
+} from '@/utils/graphGeometry';
 import {
     getQuickWorkflowBlockId,
     getQuickWorkflowHandleId,
@@ -21,6 +25,12 @@ const LINKED_NODE_OFFSETS: Partial<Record<NodeTypeEnum, { x: number; y: number }
     [NodeTypeEnum.GITHUB]: { x: -600, y: 0 },
 };
 
+const GENERATOR_NODE_TYPES = [
+    NodeTypeEnum.TEXT_TO_TEXT,
+    NodeTypeEnum.PARALLELIZATION,
+    NodeTypeEnum.ROUTING,
+] as const;
+
 export const useQuickWorkflow = (graphIdOverride?: GraphIdRef) => {
     const route = useRoute();
     const graphId = computed(() => graphIdOverride?.value ?? (route.params.id as string) ?? '');
@@ -29,6 +39,13 @@ export const useQuickWorkflow = (graphIdOverride?: GraphIdRef) => {
     const { getBlockByNodeType } = useBlocks();
     const { acceptsMultipleInputEdges } = useEdgeCompatibility();
     const { resolveOverlaps } = useGraphOverlaps(graphId);
+
+    const getNodeWidth = (node: GraphNode): number => {
+        const dimensionsWidth = (node as NodeWithDimensions).dimensions?.width;
+        if (dimensionsWidth && dimensionsWidth > 0) return dimensionsWidth;
+        if (typeof node.width === 'number' && node.width > 0) return node.width;
+        return getBlockByNodeType(node.type as NodeTypeEnum)?.minSize.width ?? 0;
+    };
 
     const targetIsAvailable = (payload: QuickWorkflowCreatePayload, anchor: GraphNode): boolean => {
         if (payload.direction !== 'target') return true;
@@ -103,20 +120,55 @@ export const useQuickWorkflow = (graphIdOverride?: GraphIdRef) => {
                 : (getBlockByNodeType(anchor.type as NodeTypeEnum)?.minSize.width ?? 0));
         const mainHeight = definitions.main.minSize.height ?? 0;
         const mainWidth = definitions.main.minSize.width ?? 0;
-        const positionOffset = calculateQuickWorkflowPositionOffset({
-            category: payload.category,
-            direction: payload.direction,
-            anchorWidth,
-            anchorHeight,
-            mainWidth,
-            mainHeight,
-            gap: AUTO_PLACEMENT_GAP,
-        });
+        const usesGeneratorChildPlacement =
+            payload.category === NodeCategoryEnum.CONTEXT &&
+            payload.direction === 'source' &&
+            GENERATOR_NODE_TYPES.includes(
+                definitions.main.nodeType as (typeof GENERATOR_NODE_TYPES)[number],
+            );
+        const positionFrom = usesGeneratorChildPlacement
+            ? calculateGeneratorChildPosition({
+                  parent: {
+                      id: anchor.id,
+                      type: anchor.type,
+                      position: anchor.position,
+                      width: anchorWidth,
+                      height: anchorHeight,
+                  },
+                  nodes: getNodes.value.map(
+                      (node): GeneratorPlacementNode => ({
+                          id: node.id,
+                          type: node.type,
+                          position: node.position,
+                          width: getNodeWidth(node),
+                          height:
+                              (node as NodeWithDimensions).dimensions?.height ??
+                              (typeof node.height === 'number' ? node.height : 0),
+                      }),
+                  ),
+                  edges: getEdges.value.map((edge) => ({
+                      source: edge.source,
+                      target: edge.target,
+                  })),
+                  gap: AUTO_PLACEMENT_GAP,
+              })
+            : anchor.position;
+        const positionOffset = usesGeneratorChildPlacement
+            ? undefined
+            : calculateQuickWorkflowPositionOffset({
+                  category: payload.category,
+                  direction: payload.direction,
+                  anchorWidth,
+                  anchorHeight,
+                  mainWidth,
+                  mainHeight,
+                  gap: AUTO_PLACEMENT_GAP,
+              });
         const mainNode = placeBlock({
             graphId: graphId.value,
             blocId: definitions.main.id,
             fromNodeId: anchor.id,
-            positionFrom: anchor.position,
+            positionFrom,
             positionOffset,
         });
         if (!mainNode) return;

--- a/ui/app/pages/auth/canvas-quick-action-wheel-fixture.vue
+++ b/ui/app/pages/auth/canvas-quick-action-wheel-fixture.vue
@@ -103,6 +103,68 @@ const seedEdges = () => [
         type: 'default',
     },
 ];
+const mixedWorkflowNodeSpecs: Array<[string, NodeTypeEnum, number, number]> = [
+    ['prompt1', NodeTypeEnum.PROMPT, 260, 100],
+    ['attachment-file', NodeTypeEnum.FILE_PROMPT, 180, 80],
+    ['attachment-github', NodeTypeEnum.GITHUB, 220, 120],
+    ['generator1', NodeTypeEnum.TEXT_TO_TEXT, 240, 140],
+    ['prompt2', NodeTypeEnum.PROMPT, 200, 90],
+    ['generator2', NodeTypeEnum.TEXT_TO_TEXT, 260, 160],
+];
+const mixedWorkflowNodes = (): GraphNode[] =>
+    mixedWorkflowNodeSpecs.map(
+        ([id, type, width, height], index) =>
+            ({
+                id,
+                type,
+                position: { x: 180 + index * 80, y: 180 },
+                width,
+                height,
+                data: { label: id },
+            }) as GraphNode,
+    );
+const mixedWorkflowEdges = () => [
+    {
+        id: 'prompt1-generator1',
+        source: 'prompt1',
+        target: 'generator1',
+        sourceHandle: null,
+        targetHandle: 'prompt_generator1',
+        type: 'default',
+    },
+    {
+        id: 'attachment-file-generator1',
+        source: 'attachment-file',
+        target: 'generator1',
+        sourceHandle: null,
+        targetHandle: 'attachment_generator1',
+        type: 'default',
+    },
+    {
+        id: 'attachment-github-generator1',
+        source: 'attachment-github',
+        target: 'generator1',
+        sourceHandle: null,
+        targetHandle: 'attachment_generator1',
+        type: 'default',
+    },
+    {
+        id: 'generator1-generator2',
+        source: 'generator1',
+        target: 'generator2',
+        sourceHandle: null,
+        targetHandle: 'context_generator2',
+        type: 'default',
+    },
+    {
+        id: 'prompt2-generator2',
+        source: 'prompt2',
+        target: 'generator2',
+        sourceHandle: null,
+        targetHandle: 'prompt_generator2',
+        type: 'default',
+    },
+];
 const edges = ref(seedEdges());
 const {
     getNodes,
@@ -114,6 +176,7 @@ const {
     addSelectedNodes,
     panBy,
     fitView,
+    getViewport,
 } = useVueFlow('main-graph-' + graphId.value);
 const isOverSidebar = ref(false);
 const { isSelecting, selectionRect, onSelectionStart } = useGraphSelection(
@@ -133,13 +196,16 @@ const unlinkNode = (nodeId: string) => {
     if (node) node.parentNode = undefined;
 };
 const deleteGroup = (_graphId: string, groupId: string) => deleteNode(groupId);
+const fitGraph = () => fitView({ maxZoom: 1, minZoom: 0.4, padding: 0.2 });
+const { autoLayoutGraph } = useGraphAutoLayout({ graphId, fitGraph });
 const quickActions = useGraphQuickActions({
     graphId,
     onSelectionStart,
     deleteNode,
     unlinkNode,
     deleteGroup,
-    fitGraph: () => fitView({ padding: 0.2 }),
+    fitGraph,
+    autoLayoutGraph,
 });
 const graphContainer = ref<HTMLElement | null>(null);
 const fixtureReady = ref(false);
@@ -149,6 +215,10 @@ const activate = (action: GraphQuickAction) => {
     actionLog.value.push(action.id);
     quickActions.activate(action);
 };
+const autoLayoutFromControls = async () => {
+    actionLog.value.push('controls-auto-layout');
+    await autoLayoutGraph();
+};
 const onKeyDown = (event: KeyboardEvent) => {
     if (graphContainer.value) quickActions.onKeyboardContextMenu(event, graphContainer.value);
 };
@@ -157,6 +227,12 @@ const reset = () => {
     setEdges(seedEdges());
     settingsStore.nodePresetSettings.presets.splice(0);
     setPlan('premium');
+    actionLog.value = [];
+    quickActions.close(false);
+};
+const seedMixedWorkflow = () => {
+    setNodes(mixedWorkflowNodes());
+    setEdges(mixedWorkflowEdges());
     actionLog.value = [];
     quickActions.close(false);
 };
@@ -178,6 +254,8 @@ const state = computed(() => ({
         id: node.id,
         type: node.type,
         position: node.position,
+        width: node.dimensions.width || node.width || 0,
+        height: node.dimensions.height || node.height || 0,
         parentNode: node.parentNode,
         data: node.data,
     })),
@@ -187,11 +265,13 @@ const state = computed(() => ({
         target: edge.target,
         sourceHandle: edge.sourceHandle,
         targetHandle: edge.targetHandle,
+        type: edge.type,
     })),
     presetNames: settingsStore.nodePresetSettings.presets.map((preset) => preset.name),
     plan: (user.value as User | null)?.plan_type ?? null,
     actions: actionLog.value,
     selecting: isSelecting.value,
+    viewport: getViewport(),
 }));
 
 onMounted(async () => {
@@ -213,6 +293,9 @@ onMounted(async () => {
             <button data-testid="seed-valid-preset" @click="seedPresets('valid')">Seed valid preset</button>
             <button data-testid="seed-invalid-preset" @click="seedPresets('invalid')">Seed invalid preset</button>
             <button data-testid="seed-github-preset" @click="seedPresets('github')">Seed GitHub preset</button>
+            <button data-testid="seed-mixed-workflow" @click="seedMixedWorkflow">
+                Seed mixed workflow
+            </button>
         </div>
         <pre data-testid="canvas-quick-action-state" class="absolute top-2 left-20 z-30 text-xs">{{
             JSON.stringify(state)
@@ -235,6 +318,11 @@ onMounted(async () => {
                 :fit-view-on-init="false"
                 :delete-key-code="null"
             >
+                <UiGraphCanvasControls
+                    :graph-id="graphId"
+                    @auto-layout="autoLayoutFromControls"
+                />
+
                 <template #node-textToText="nodeProps">
                     <div class="bg-olive-grove h-full w-full rounded-xl p-4 text-black">
                         {{ nodeProps.data.label ?? nodeProps.id }}
@@ -247,6 +335,16 @@ onMounted(async () => {
                     </div>
                 </template>
                 <template #node-prompt="nodeProps">
+                    <div class="bg-slate-blue h-full w-full rounded-xl p-4">
+                        {{ nodeProps.data.label ?? nodeProps.id }}
+                    </div>
+                </template>
+                <template #node-filePrompt="nodeProps">
+                    <div class="bg-slate-blue h-full w-full rounded-xl p-4">
+                        {{ nodeProps.data.label ?? nodeProps.id }}
+                    </div>
+                </template>
+                <template #node-github="nodeProps">
                     <div class="bg-slate-blue h-full w-full rounded-xl p-4">
                         {{ nodeProps.data.label ?? nodeProps.id }}
                     </div>

--- a/ui/app/pages/graph/[id].vue
+++ b/ui/app/pages/graph/[id].vue
@@ -86,6 +86,8 @@ const {
     getViewport,
     onMoveEnd,
 } = useVueFlow('main-graph-' + graphId.value);
+const fitGraph = () => fitView({ maxZoom: 1, minZoom: 0.4, padding: 0.2 });
+const { autoLayoutGraph } = useGraphAutoLayout({ graphId, fitGraph });
 const graphEvents = useGraphEvents();
 const { error, warning } = useToast();
 const { setExecutionPlan } = useExecutionPlan();
@@ -241,7 +243,8 @@ const {
     deleteNode,
     unlinkNode: unlinkNodeFromGroup,
     deleteGroup: deleteCommentGroup,
-    fitGraph: () => fitView({ maxZoom: 1, minZoom: 0.4, padding: 0.2 }),
+    fitGraph,
+    autoLayoutGraph,
 });
 
 const fetchGraph = async (id: string) => {
@@ -303,11 +306,7 @@ const setupLoadedGraphView = async () => {
 
     if (!isViewportRestored) {
         setTimeout(() => {
-            fitView({
-                maxZoom: 1,
-                minZoom: 0.4,
-                padding: 0.2,
-            }).then(() => {
+            fitGraph().then(() => {
                 graphReady.value = true;
             });
         }, 0);
@@ -680,7 +679,7 @@ onUnmounted(() => {
             >
                 <UiGraphBackground pattern-color="var(--color-stone-gray)" :gap="16" />
 
-                <UiGraphCanvasControls :graph-id="graphId" />
+                <UiGraphCanvasControls :graph-id="graphId" @auto-layout="autoLayoutGraph" />
 
                 <template #connection-line="connectionProps">
                     <UiGraphEdgesCustomConnectionLine v-bind="connectionProps" />

--- a/ui/app/utils/graphAutoLayout.ts
+++ b/ui/app/utils/graphAutoLayout.ts
@@ -1,0 +1,194 @@
+import type { XYPosition } from '@vue-flow/core';
+
+import {
+    layoutGraphComponent,
+    type ComponentLayout,
+    type LayoutComponentInput,
+    type NormalizedEdge,
+} from '@/utils/graphAutoLayoutComponent';
+import { classifyLayoutEdge } from '@/utils/graphAutoLayoutConstraints';
+
+export const GRAPH_AUTO_LAYOUT_NODE_SEPARATION = 160;
+export const GRAPH_AUTO_LAYOUT_RANK_SEPARATION = 100;
+export const GRAPH_AUTO_LAYOUT_EDGE_SEPARATION = 40;
+export const GRAPH_AUTO_LAYOUT_COMPONENT_SEPARATION = 240;
+
+export interface GraphAutoLayoutNode {
+    id: string;
+    position: XYPosition;
+    width: number;
+    height: number;
+    type?: string;
+    parentNode?: string;
+}
+
+export interface GraphAutoLayoutEdge {
+    id: string;
+    source: string;
+    target: string;
+    sourceHandle?: string | null;
+    targetHandle?: string | null;
+}
+
+const compareIds = (left: string, right: string) => left.localeCompare(right);
+
+const getOuterUnitId = (
+    nodeId: string,
+    nodesById: ReadonlyMap<string, GraphAutoLayoutNode>,
+): string => {
+    let currentId = nodeId;
+    const visited = new Set<string>();
+
+    while (true) {
+        if (visited.has(currentId)) return nodeId;
+        visited.add(currentId);
+        const parentId = nodesById.get(currentId)?.parentNode;
+        if (!parentId || !nodesById.has(parentId)) return currentId;
+        currentId = parentId;
+    }
+};
+
+const normalizeGraph = (nodes: readonly GraphAutoLayoutNode[], edges: readonly GraphAutoLayoutEdge[]) => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const outerUnitByNode = new Map<string, string>();
+    for (const node of nodes) outerUnitByNode.set(node.id, getOuterUnitId(node.id, nodesById));
+
+    const units = [...new Set(outerUnitByNode.values())]
+        .map((id) => nodesById.get(id))
+        .filter((node): node is GraphAutoLayoutNode => node !== undefined)
+        .sort((left, right) => compareIds(left.id, right.id));
+    const seenConstraints = new Set<string>();
+    const normalizedEdges: NormalizedEdge[] = [];
+    const sortedEdges = [...edges].sort(
+        (left, right) =>
+            compareIds(left.source, right.source) ||
+            compareIds(left.target, right.target) ||
+            compareIds(left.id, right.id),
+    );
+    for (const edge of sortedEdges) {
+        const source = outerUnitByNode.get(edge.source);
+        const target = outerUnitByNode.get(edge.target);
+        if (!source || !target || source === target) continue;
+        const category = classifyLayoutEdge(edge, nodesById.get(edge.source)?.type);
+        const constraint = `${category}\u0000${source}\u0000${target}`;
+        if (seenConstraints.has(constraint)) continue;
+        seenConstraints.add(constraint);
+        normalizedEdges.push({ source, target, category });
+    }
+    normalizedEdges.sort(
+        (left, right) =>
+            compareIds(left.category, right.category) ||
+            compareIds(left.source, right.source) ||
+            compareIds(left.target, right.target),
+    );
+
+    return { units, edges: normalizedEdges };
+};
+
+const splitComponents = (
+    units: readonly GraphAutoLayoutNode[],
+    edges: readonly NormalizedEdge[],
+): LayoutComponentInput[] => {
+    const adjacency = new Map(units.map((unit) => [unit.id, new Set<string>()]));
+    for (const edge of edges) {
+        adjacency.get(edge.source)?.add(edge.target);
+        adjacency.get(edge.target)?.add(edge.source);
+    }
+
+    const unitsById = new Map(units.map((unit) => [unit.id, unit]));
+    const componentByUnit = new Map<string, number>();
+    const componentUnits: GraphAutoLayoutNode[][] = [];
+    for (const unit of units) {
+        if (componentByUnit.has(unit.id)) continue;
+        const componentIndex = componentUnits.length;
+        const pending = [unit.id];
+        let pendingIndex = 0;
+        const members: GraphAutoLayoutNode[] = [];
+        componentByUnit.set(unit.id, componentIndex);
+        while (pendingIndex < pending.length) {
+            const id = pending[pendingIndex];
+            pendingIndex += 1;
+            if (!id) continue;
+            const member = unitsById.get(id);
+            if (member) members.push(member);
+            for (const neighbor of [...(adjacency.get(id) ?? [])].sort(compareIds)) {
+                if (componentByUnit.has(neighbor)) continue;
+                componentByUnit.set(neighbor, componentIndex);
+                pending.push(neighbor);
+            }
+        }
+        members.sort((left, right) => compareIds(left.id, right.id));
+        componentUnits.push(members);
+    }
+
+    const componentEdges = componentUnits.map((): NormalizedEdge[] => []);
+    for (const edge of edges) {
+        const componentIndex = componentByUnit.get(edge.source);
+        if (componentIndex !== undefined) componentEdges[componentIndex]?.push(edge);
+    }
+    return componentUnits.map((members, index) => ({
+        units: members,
+        edges: componentEdges[index] ?? [],
+    }));
+};
+
+const packComponents = (components: readonly ComponentLayout[]): Map<string, XYPosition> => {
+    const totalArea = components.reduce(
+        (area, component) => area + component.width * component.height,
+        0,
+    );
+    const widestComponent = Math.max(...components.map((component) => component.width));
+    const targetRowWidth = Math.max(widestComponent, 1.6 * Math.sqrt(totalArea));
+    const packed = new Map<string, XYPosition>();
+    let rowX = 0;
+    let rowY = 0;
+    let rowHeight = 0;
+
+    for (const component of components) {
+        if (rowX > 0 && rowX + component.width > targetRowWidth) {
+            rowX = 0;
+            rowY += rowHeight + GRAPH_AUTO_LAYOUT_COMPONENT_SEPARATION;
+            rowHeight = 0;
+        }
+        for (const [id, position] of component.positions) {
+            packed.set(id, { x: rowX + position.x, y: rowY + position.y });
+        }
+        rowX += component.width + GRAPH_AUTO_LAYOUT_COMPONENT_SEPARATION;
+        rowHeight = Math.max(rowHeight, component.height);
+    }
+    return packed;
+};
+
+export const calculateGraphAutoLayout = (
+    nodes: readonly GraphAutoLayoutNode[],
+    edges: readonly GraphAutoLayoutEdge[],
+): ReadonlyMap<string, XYPosition> => {
+    if (!nodes.length) return new Map();
+    const normalized = normalizeGraph(nodes, edges);
+    if (!normalized.units.length) return new Map();
+    const componentSpacing = {
+        node: GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+        rank: GRAPH_AUTO_LAYOUT_RANK_SEPARATION,
+        edge: GRAPH_AUTO_LAYOUT_EDGE_SEPARATION,
+    };
+    const components = splitComponents(normalized.units, normalized.edges).map((component) =>
+        layoutGraphComponent(component, componentSpacing),
+    );
+    const positions = packComponents(components);
+    const finiteUnitPositions = normalized.units.filter(
+        (unit) => Number.isFinite(unit.position.x) && Number.isFinite(unit.position.y),
+    );
+    const anchorX = finiteUnitPositions.length
+        ? Math.min(...finiteUnitPositions.map((unit) => unit.position.x))
+        : 0;
+    const anchorY = finiteUnitPositions.length
+        ? Math.min(...finiteUnitPositions.map((unit) => unit.position.y))
+        : 0;
+
+    return new Map(
+        [...positions.entries()].map(([id, position]) => [
+            id,
+            { x: Math.round(position.x + anchorX), y: Math.round(position.y + anchorY) },
+        ]),
+    );
+};

--- a/ui/app/utils/graphAutoLayoutAttachmentStacks.ts
+++ b/ui/app/utils/graphAutoLayoutAttachmentStacks.ts
@@ -1,0 +1,197 @@
+import type { XYPosition } from '@vue-flow/core';
+
+import { NodeTypeEnum } from '@/types/enums';
+import {
+    isGeneratorNode,
+    type LayoutConstraintEdge,
+    type LayoutHorizontalBlock,
+} from '@/utils/graphAutoLayoutConstraints';
+
+export interface AttachmentStackNode {
+    id: string;
+    type?: string;
+    width: number;
+    height: number;
+}
+
+export interface AttachmentLateralSubgraph {
+    members: string[];
+    edges: LayoutConstraintEdge[];
+}
+
+export interface AttachmentStack {
+    targetId: string;
+    sourceIds: string[];
+}
+
+export interface AttachmentEnvelopeReservation {
+    blocks: LayoutHorizontalBlock[];
+    rowByNode: Map<string, number>;
+}
+
+interface StackInterval extends AttachmentStack {
+    top: number;
+    bottom: number;
+    width: number;
+}
+
+interface PlacementObstacle {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+}
+
+const compareIds = (left: string, right: string) => left.localeCompare(right);
+
+const isAttachmentSource = (node: AttachmentStackNode | undefined): boolean =>
+    node?.type === NodeTypeEnum.FILE_PROMPT || node?.type === NodeTypeEnum.GITHUB;
+
+const intervalsOverlap = (
+    firstTop: number,
+    firstBottom: number,
+    secondTop: number,
+    secondBottom: number,
+): boolean => firstTop < secondBottom && firstBottom > secondTop;
+
+const nearestCollisionFreeRight = (
+    preferredRight: number,
+    interval: StackInterval,
+    obstacles: readonly PlacementObstacle[],
+    separation: number,
+): number => {
+    let right = preferredRight;
+    while (true) {
+        const left = right - interval.width;
+        const blockingLefts = obstacles
+            .filter(
+                (obstacle) =>
+                    intervalsOverlap(interval.top, interval.bottom, obstacle.top, obstacle.bottom) &&
+                    right > obstacle.left &&
+                    left < obstacle.right,
+            )
+            .map((obstacle) => obstacle.left);
+        if (!blockingLefts.length) return right;
+        right = Math.min(...blockingLefts) - separation;
+    }
+};
+
+export const partitionAttachmentStackSubgraphs = (
+    subgraphs: readonly AttachmentLateralSubgraph[],
+    nodes: readonly AttachmentStackNode[],
+    verticalParticipantIds: ReadonlySet<string>,
+): { stacks: AttachmentStack[]; fallback: AttachmentLateralSubgraph[] } => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const stacks: AttachmentStack[] = [];
+    const fallback: AttachmentLateralSubgraph[] = [];
+    for (const subgraph of subgraphs) {
+        const targetIds = subgraph.members.filter((id) => verticalParticipantIds.has(id));
+        const targetId = targetIds[0];
+        const sourceIds = subgraph.members.filter((id) => id !== targetId).sort(compareIds);
+        const directSourceIds = new Set(
+            subgraph.edges
+                .filter((edge) => edge.target === targetId && edge.source !== targetId)
+                .map((edge) => edge.source),
+        );
+        const qualifies =
+            targetIds.length === 1 &&
+            !!targetId &&
+            isGeneratorNode(nodesById.get(targetId)) &&
+            sourceIds.length > 0 &&
+            sourceIds.every((id) => isAttachmentSource(nodesById.get(id))) &&
+            subgraph.edges.length === sourceIds.length &&
+            directSourceIds.size === sourceIds.length &&
+            sourceIds.every((id) => directSourceIds.has(id));
+        if (qualifies) stacks.push({ targetId, sourceIds });
+        else fallback.push(subgraph);
+    }
+    stacks.sort((left, right) => compareIds(left.targetId, right.targetId));
+    return { stacks, fallback };
+};
+
+export const reserveAttachmentStackEnvelopes = (
+    stacks: readonly AttachmentStack[],
+    nodes: readonly AttachmentStackNode[],
+    blocks: readonly LayoutHorizontalBlock[],
+    rowByNode: ReadonlyMap<string, number>,
+    spacing: { node: number },
+): AttachmentEnvelopeReservation => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const stackByTarget = new Map(stacks.map((stack) => [stack.targetId, stack]));
+    const reservedRows = new Map(rowByNode);
+    const reservedBlocks = blocks.map((block) => {
+        const targetMember = block.members.find((member) => stackByTarget.has(member.id));
+        if (!targetMember) return block;
+        const stack = stackByTarget.get(targetMember.id)!;
+        const targetRow = rowByNode.get(stack.targetId);
+        const right = targetMember.left - spacing.node;
+        const sourceMembers = stack.sourceIds.map((id) => {
+            if (targetRow !== undefined) reservedRows.set(id, targetRow);
+            return { id, left: right - (nodesById.get(id)?.width ?? 0) };
+        });
+        return {
+            ...block,
+            members: [...block.members.map((member) => ({ ...member })), ...sourceMembers],
+        };
+    });
+    return { blocks: reservedBlocks, rowByNode: reservedRows };
+};
+
+export const placeAttachmentStacks = (
+    stacks: readonly AttachmentStack[],
+    nodes: readonly AttachmentStackNode[],
+    corePositions: ReadonlyMap<string, XYPosition>,
+    spacing: { node: number; edge: number },
+): Map<string, XYPosition> => {
+    if (!stacks.length) return new Map();
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const intervals: StackInterval[] = stacks.map((stack) => {
+        const target = nodesById.get(stack.targetId)!;
+        const targetPosition = corePositions.get(stack.targetId)!;
+        const totalHeight = stack.sourceIds.reduce(
+            (height, id, index) =>
+                height + (nodesById.get(id)?.height ?? 0) + (index ? spacing.edge : 0),
+            0,
+        );
+        const top = targetPosition.y + target.height / 2 - totalHeight / 2;
+        const width = Math.max(...stack.sourceIds.map((id) => nodesById.get(id)?.width ?? 0));
+        return { ...stack, top, bottom: top + totalHeight, width };
+    });
+    intervals.sort((left, right) => left.top - right.top || compareIds(left.targetId, right.targetId));
+
+    const obstacles: PlacementObstacle[] = [...corePositions]
+        .sort(([leftId], [rightId]) => compareIds(leftId, rightId))
+        .map(([id, position]) => {
+            const node = nodesById.get(id)!;
+            return {
+                left: position.x,
+                right: position.x + node.width,
+                top: position.y,
+                bottom: position.y + node.height,
+            };
+        });
+
+    const positions = new Map<string, XYPosition>();
+    for (const interval of intervals) {
+        const targetPosition = corePositions.get(interval.targetId)!;
+        const right = nearestCollisionFreeRight(
+            targetPosition.x - spacing.node,
+            interval,
+            obstacles,
+            spacing.node,
+        );
+        let top = interval.top;
+        for (const id of interval.sourceIds) {
+            const node = nodesById.get(id)!;
+            positions.set(id, { x: right - node.width, y: top });
+            top += node.height + spacing.edge;
+        }
+        obstacles.push({
+            left: right - interval.width,
+            right,
+            top: interval.top,
+            bottom: interval.bottom,
+        });
+    }
+    return positions;
+};

--- a/ui/app/utils/graphAutoLayoutBranchColumns.ts
+++ b/ui/app/utils/graphAutoLayoutBranchColumns.ts
@@ -1,0 +1,249 @@
+import type {
+    LayoutConstraintEdge,
+    LayoutHorizontalBlock,
+} from '@/utils/graphAutoLayoutConstraints';
+import {
+    discoverFanoutHierarchy,
+    type FanoutHierarchyFamily,
+} from '@/utils/graphAutoLayoutFanoutHierarchy';
+
+interface BranchColumnNode {
+    id: string;
+    type?: string;
+    width: number;
+}
+
+interface BaseRef {
+    kind: 'base';
+    block: LayoutHorizontalBlock;
+    left: number;
+    right: number;
+    minimumRow: number;
+    maximumRow: number;
+}
+
+interface CompositeRef {
+    kind: 'composite';
+    family: FanoutHierarchyFamily;
+    id: string;
+    preferredLeft: number;
+    parts: Array<{ ref: LayoutRef; shift: number }>;
+    left: number;
+    right: number;
+    minimumRow: number;
+    maximumRow: number;
+}
+
+type LayoutRef = BaseRef | CompositeRef;
+const shiftedBounds = (ref: LayoutRef, shift: number) => ({
+    left: ref.left + shift,
+    right: ref.right + shift,
+});
+
+export const mergePromptFanoutStageBlocks = (
+    nodes: readonly BranchColumnNode[],
+    edges: readonly LayoutConstraintEdge[],
+    blocks: readonly LayoutHorizontalBlock[],
+    rowByNode: ReadonlyMap<string, number>,
+    spacing: { node: number },
+): LayoutHorizontalBlock[] => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const blockByMember = new Map<string, LayoutHorizontalBlock>();
+    const centerByMember = new Map<string, number>();
+    const baseByBlock = new Map<LayoutHorizontalBlock, BaseRef>();
+    for (const block of blocks) {
+        let left = Infinity;
+        let right = -Infinity;
+        let minimumRow = Infinity;
+        let maximumRow = -Infinity;
+        let valid = true;
+        for (const member of block.members) {
+            const node = nodesById.get(member.id);
+            const row = rowByNode.get(member.id);
+            if (!node || row === undefined || blockByMember.has(member.id)) {
+                valid = false;
+                break;
+            }
+            blockByMember.set(member.id, block);
+            centerByMember.set(member.id, member.left + node.width / 2);
+            left = Math.min(left, member.left);
+            right = Math.max(right, member.left + node.width);
+            minimumRow = Math.min(minimumRow, row);
+            maximumRow = Math.max(maximumRow, row);
+        }
+        if (valid && block.members.length) {
+            baseByBlock.set(block, { kind: 'base', block, left, right, minimumRow, maximumRow });
+        }
+    }
+
+    const families = discoverFanoutHierarchy(nodes, edges, rowByNode);
+    const composites = new Map<string, CompositeRef>();
+    const claimed = new Map<LayoutHorizontalBlock, string>();
+    const failed = new Set<string>();
+    for (const family of families) {
+        if (family.dependencies.some((id) => failed.has(id) || !composites.has(id))) {
+            failed.add(family.id);
+            continue;
+        }
+        const contextBlock = family.contextParentId
+            ? blockByMember.get(family.contextParentId)
+            : undefined;
+        const promptBlock = family.promptParentId
+            ? blockByMember.get(family.promptParentId)
+            : undefined;
+        const parentBlocks = [contextBlock, promptBlock].filter(
+            (block): block is LayoutHorizontalBlock => block !== undefined,
+        );
+        const parentIds = [family.contextParentId, family.promptParentId].filter(
+            (id): id is string => id !== undefined,
+        );
+        const newBlocks: LayoutHorizontalBlock[] = [...parentBlocks];
+        const dependencyByParent = new Map(
+            family.dependencies.map((id) => {
+                const composite = composites.get(id)!;
+                return [composite.family.contextParentId!, composite] as const;
+            }),
+        );
+        const branchParts: Array<{
+            parts: Array<{ ref: LayoutRef; shift: number }>;
+            left: number;
+            right: number;
+        }> = [];
+        let valid = parentBlocks.length === parentIds.length &&
+            new Set(parentBlocks).size === parentBlocks.length;
+        let preferredLeft = 0;
+        for (let index = 0; valid && index < parentBlocks.length; index += 1) {
+            const block = parentBlocks[index]!;
+            const id = parentIds[index]!;
+            const base = baseByBlock.get(block);
+            const center = centerByMember.get(id);
+            const row = rowByNode.get(id);
+            if (
+                !base || center === undefined || row === undefined || base.maximumRow > row ||
+                (id === family.promptParentId &&
+                    (block.members.length !== 1 || block.members[0]?.id !== id))
+            ) {
+                valid = false;
+                break;
+            }
+            if (id === (family.contextParentId ?? family.promptParentId)) {
+                preferredLeft = block.preferredLeft + center;
+            }
+        }
+        for (const child of family.children) {
+            if (!valid) break;
+            const dependency = dependencyByParent.get(child.childId);
+            const childBlock = blockByMember.get(child.childId);
+            const childRef: LayoutRef | undefined = dependency ??
+                (childBlock ? baseByBlock.get(childBlock) : undefined);
+            const childCenter = dependency ? 0 : centerByMember.get(child.childId);
+            const childRow = rowByNode.get(child.childId);
+            if (
+                !childRef || childCenter === undefined || childRow === undefined ||
+                childRef.minimumRow < childRow
+            ) {
+                valid = false;
+                break;
+            }
+            if (!dependency && childBlock) newBlocks.push(childBlock);
+            const parts = [{ ref: childRef, shift: -childCenter }];
+            let left = childRef.left - childCenter;
+            let right = childRef.right - childCenter;
+            if (child.dedicatedPromptId) {
+                const dedicatedBlock = blockByMember.get(child.dedicatedPromptId);
+                const dedicatedBase = dedicatedBlock ? baseByBlock.get(dedicatedBlock) : undefined;
+                const dedicatedCenter = centerByMember.get(child.dedicatedPromptId);
+                if (
+                    !dedicatedBlock || !dedicatedBase || dedicatedCenter === undefined ||
+                    dedicatedBlock.members.length !== 1 ||
+                    dedicatedBlock.members[0]?.id !== child.dedicatedPromptId
+                ) {
+                    valid = false;
+                    break;
+                }
+                newBlocks.push(dedicatedBlock);
+                parts.push({ ref: dedicatedBase, shift: -dedicatedCenter });
+                left = Math.min(left, dedicatedBase.left - dedicatedCenter);
+                right = Math.max(right, dedicatedBase.right - dedicatedCenter);
+            }
+            branchParts.push({ parts, left, right });
+        }
+        if (
+            !valid || new Set(newBlocks).size !== newBlocks.length ||
+            newBlocks.some((block) => claimed.has(block))
+        ) {
+            failed.add(family.id);
+            continue;
+        }
+
+        let cursor = 0;
+        const packedParts: Array<{ ref: LayoutRef; shift: number }> = [];
+        for (const branch of branchParts) {
+            const shift = cursor - branch.left;
+            for (const part of branch.parts) {
+                packedParts.push({ ref: part.ref, shift: part.shift + shift });
+            }
+            cursor = branch.right + shift + spacing.node;
+        }
+        const envelopeCenter = (cursor - spacing.node) / 2;
+        for (const part of packedParts) part.shift -= envelopeCenter;
+        const parts: Array<{ ref: LayoutRef; shift: number }> = [];
+        for (let index = 0; index < parentBlocks.length; index += 1) {
+            parts.push({
+                ref: baseByBlock.get(parentBlocks[index]!)!,
+                shift: -centerByMember.get(parentIds[index]!)!,
+            });
+        }
+        parts.push(...packedParts);
+        let left = Infinity;
+        let right = -Infinity;
+        let minimumRow = Infinity;
+        let maximumRow = -Infinity;
+        for (const part of parts) {
+            const bounds = shiftedBounds(part.ref, part.shift);
+            left = Math.min(left, bounds.left);
+            right = Math.max(right, bounds.right);
+            minimumRow = Math.min(minimumRow, part.ref.minimumRow);
+            maximumRow = Math.max(maximumRow, part.ref.maximumRow);
+        }
+        const composite: CompositeRef = {
+            kind: 'composite',
+            family,
+            id: contextBlock?.id ?? promptBlock!.id,
+            preferredLeft,
+            parts,
+            left,
+            right,
+            minimumRow,
+            maximumRow,
+        };
+        composites.set(family.id, composite);
+        for (const block of newBlocks) claimed.set(block, family.id);
+    }
+
+    const owned = new Set(
+        [...composites.values()].flatMap(({ family }) =>
+            family.dependencies.filter((id) => composites.has(id)),
+        ),
+    );
+    const flattened: LayoutHorizontalBlock[] = [];
+    for (const composite of [...composites.values()].filter(({ family }) => !owned.has(family.id))) {
+        const members: Array<{ id: string; left: number }> = [];
+        const pending: Array<{ ref: LayoutRef; shift: number }> = [{ ref: composite, shift: 0 }];
+        while (pending.length) {
+            const current = pending.pop()!;
+            if (current.ref.kind === 'base') {
+                for (const member of current.ref.block.members) {
+                    members.push({ id: member.id, left: member.left + current.shift });
+                }
+            } else {
+                for (let index = current.ref.parts.length - 1; index >= 0; index -= 1) {
+                    const part = current.ref.parts[index]!;
+                    pending.push({ ref: part.ref, shift: current.shift + part.shift });
+                }
+            }
+        }
+        flattened.push({ id: composite.id, preferredLeft: composite.preferredLeft, members });
+    }
+    return [...blocks.filter((block) => !claimed.has(block)), ...flattened];
+};

--- a/ui/app/utils/graphAutoLayoutComponent.ts
+++ b/ui/app/utils/graphAutoLayoutComponent.ts
@@ -1,0 +1,366 @@
+import { graphlib, layout } from '@dagrejs/dagre';
+import type { XYPosition } from '@vue-flow/core';
+
+import {
+    partitionAttachmentStackSubgraphs,
+    placeAttachmentStacks,
+    reserveAttachmentStackEnvelopes,
+} from '@/utils/graphAutoLayoutAttachmentStacks';
+import { mergePromptFanoutStageBlocks } from '@/utils/graphAutoLayoutBranchColumns';
+import {
+    derivePromptStageConstraints,
+    mergeGeneratorSpineBlocks,
+    type LayoutConstraintEdge,
+    type LayoutHorizontalBlock,
+} from '@/utils/graphAutoLayoutConstraints';
+import { mergeSerialSpinePromptBlocks } from '@/utils/graphAutoLayoutSerialPrompts';
+
+interface ComponentLayoutNode {
+    id: string;
+    position: XYPosition;
+    width: number;
+    height: number;
+    type?: string;
+    parentNode?: string;
+}
+
+export type NormalizedEdge = LayoutConstraintEdge;
+
+export interface LayoutComponentInput {
+    units: ComponentLayoutNode[];
+    edges: NormalizedEdge[];
+}
+
+export interface ComponentLayout {
+    positions: Map<string, XYPosition>;
+    width: number;
+    height: number;
+}
+
+interface ComponentSpacing {
+    node: number;
+    rank: number;
+    edge: number;
+}
+
+const compareIds = (left: string, right: string) => left.localeCompare(right);
+
+const dagreCenters = (
+    units: readonly ComponentLayoutNode[],
+    edges: readonly NormalizedEdge[],
+    rankdir: 'LR' | 'TB',
+    spacing: ComponentSpacing,
+): Map<string, XYPosition> => {
+    const graph = new graphlib.Graph();
+    graph.setGraph({
+        rankdir,
+        ranker: 'network-simplex',
+        acyclicer: 'greedy',
+        nodesep: spacing.node,
+        ranksep: spacing.rank,
+        edgesep: spacing.edge,
+        marginx: 0,
+        marginy: 0,
+    });
+    graph.setDefaultEdgeLabel(() => ({}));
+    for (const unit of units) graph.setNode(unit.id, { width: unit.width, height: unit.height });
+    for (const edge of edges) graph.setEdge(edge.source, edge.target);
+    layout(graph);
+    return new Map(
+        units.map((unit) => {
+            const position = graph.node(unit.id);
+            return [unit.id, { x: position.x, y: position.y }];
+        }),
+    );
+};
+
+const splitLateralSubgraphs = (
+    lateralEdges: readonly NormalizedEdge[],
+): { members: string[]; edges: NormalizedEdge[] }[] => {
+    const adjacency = new Map<string, Set<string>>();
+    for (const edge of lateralEdges) {
+        if (!adjacency.has(edge.source)) adjacency.set(edge.source, new Set());
+        if (!adjacency.has(edge.target)) adjacency.set(edge.target, new Set());
+        adjacency.get(edge.source)?.add(edge.target);
+        adjacency.get(edge.target)?.add(edge.source);
+    }
+
+    const subgraphByUnit = new Map<string, number>();
+    const memberGroups: string[][] = [];
+    for (const start of [...adjacency.keys()].sort(compareIds)) {
+        if (subgraphByUnit.has(start)) continue;
+        const subgraphIndex = memberGroups.length;
+        const pending = [start];
+        let pendingIndex = 0;
+        const members: string[] = [];
+        subgraphByUnit.set(start, subgraphIndex);
+        while (pendingIndex < pending.length) {
+            const id = pending[pendingIndex];
+            pendingIndex += 1;
+            if (!id) continue;
+            members.push(id);
+            for (const neighbor of [...(adjacency.get(id) ?? [])].sort(compareIds)) {
+                if (subgraphByUnit.has(neighbor)) continue;
+                subgraphByUnit.set(neighbor, subgraphIndex);
+                pending.push(neighbor);
+            }
+        }
+        members.sort(compareIds);
+        memberGroups.push(members);
+    }
+
+    const edgeGroups = memberGroups.map((): NormalizedEdge[] => []);
+    for (const edge of lateralEdges) {
+        const subgraphIndex = subgraphByUnit.get(edge.source);
+        if (subgraphIndex !== undefined) edgeGroups[subgraphIndex]?.push(edge);
+    }
+    return memberGroups.map((members, index) => ({ members, edges: edgeGroups[index] ?? [] }));
+};
+
+const assignNearestParticipantRows = (
+    members: readonly string[],
+    edges: readonly NormalizedEdge[],
+    participantRows: ReadonlyMap<string, number>,
+): Map<string, number> => {
+    const participants = members.filter((id) => participantRows.has(id)).sort(compareIds);
+    if (!participants.length) return new Map(members.map((id) => [id, 0]));
+
+    const adjacency = new Map(members.map((id) => [id, new Set<string>()]));
+    for (const edge of edges) {
+        adjacency.get(edge.source)?.add(edge.target);
+        adjacency.get(edge.target)?.add(edge.source);
+    }
+    const assignedAnchor = new Map<string, string>();
+    const pending = [...participants];
+    let pendingIndex = 0;
+    for (const participant of participants) assignedAnchor.set(participant, participant);
+    while (pendingIndex < pending.length) {
+        const id = pending[pendingIndex];
+        pendingIndex += 1;
+        if (!id) continue;
+        const anchor = assignedAnchor.get(id);
+        if (!anchor) continue;
+        for (const neighbor of [...(adjacency.get(id) ?? [])].sort(compareIds)) {
+            if (assignedAnchor.has(neighbor)) continue;
+            assignedAnchor.set(neighbor, anchor);
+            pending.push(neighbor);
+        }
+    }
+    return new Map(
+        members.map((id) => {
+            const anchor = assignedAnchor.get(id) ?? participants[0]!;
+            return [id, participantRows.get(anchor) ?? 0];
+        }),
+    );
+};
+
+export const layoutGraphComponent = (
+    { units, edges }: LayoutComponentInput,
+    spacing: ComponentSpacing,
+): ComponentLayout => {
+    const singleton = units[0];
+    if (units.length === 1 && singleton) {
+        return {
+            positions: new Map([[singleton.id, { x: 0, y: 0 }]]),
+            width: singleton.width,
+            height: singleton.height,
+        };
+    }
+
+    const unitsById = new Map(units.map((unit) => [unit.id, unit]));
+    const verticalEdges = edges.filter((edge) => edge.category !== 'attachment');
+    const verticalLayoutEdges = [
+        ...verticalEdges,
+        ...derivePromptStageConstraints(units, edges),
+    ];
+    const lateralEdges = edges.filter((edge) => edge.category === 'attachment');
+    const verticalParticipantIds = new Set(
+        verticalLayoutEdges.flatMap((edge) => [edge.source, edge.target]),
+    );
+    const verticalParticipants = units.filter((unit) => verticalParticipantIds.has(unit.id));
+    const verticalCenters = verticalParticipants.length
+        ? dagreCenters(verticalParticipants, verticalLayoutEdges, 'TB', spacing)
+        : new Map<string, XYPosition>();
+    const rowCenterValues = [
+        ...new Set([...verticalCenters.values()].map((position) => position.y)),
+    ].sort((left, right) => left - right);
+    const rowByCenter = new Map(rowCenterValues.map((center, index) => [center, index]));
+    const rowByUnit = new Map<string, number>();
+    for (const [id, position] of verticalCenters) {
+        rowByUnit.set(id, rowByCenter.get(position.y) ?? 0);
+    }
+
+    const lateralSubgraphs = splitLateralSubgraphs(lateralEdges);
+    const { stacks: attachmentStacks, fallback: fallbackLateralSubgraphs } =
+        partitionAttachmentStackSubgraphs(lateralSubgraphs, units, verticalParticipantIds);
+    const attachmentStackSourceIds = new Set(
+        attachmentStacks.flatMap((stack) => stack.sourceIds),
+    );
+    const lateralMemberIds = new Set<string>();
+    for (const subgraph of fallbackLateralSubgraphs) {
+        for (const id of subgraph.members) lateralMemberIds.add(id);
+        const assignedRows = assignNearestParticipantRows(
+            subgraph.members,
+            subgraph.edges,
+            rowByUnit,
+        );
+        for (const [id, row] of assignedRows) {
+            if (!rowByUnit.has(id)) rowByUnit.set(id, row);
+        }
+    }
+    for (const unit of units) {
+        if (!rowByUnit.has(unit.id)) rowByUnit.set(unit.id, 0);
+    }
+
+    const initialBlocks: LayoutHorizontalBlock[] = [];
+    for (const subgraph of fallbackLateralSubgraphs) {
+        const members = subgraph.members
+            .map((id) => unitsById.get(id))
+            .filter((unit): unit is ComponentLayoutNode => unit !== undefined);
+        const lateralCenters = dagreCenters(members, subgraph.edges, 'LR', spacing);
+        const orderedMembers = [...members].sort(
+            (left, right) =>
+                (lateralCenters.get(left.id)?.x ?? 0) -
+                    (lateralCenters.get(right.id)?.x ?? 0) || compareIds(left.id, right.id),
+        );
+        let nextLeft = 0;
+        const packedMembers = orderedMembers.map((unit) => {
+            const member = { id: unit.id, left: nextLeft };
+            nextLeft += unit.width + spacing.node;
+            return member;
+        });
+        const anchorId = subgraph.members
+            .filter((id) => verticalParticipantIds.has(id))
+            .sort(compareIds)[0];
+        const anchorMember = packedMembers.find((member) => member.id === anchorId);
+        const anchorUnit = anchorId ? unitsById.get(anchorId) : undefined;
+        const preferredLeft =
+            anchorId && anchorMember && anchorUnit
+                ? (verticalCenters.get(anchorId)?.x ?? 0) -
+                  (anchorMember.left + anchorUnit.width / 2)
+                : 0;
+        initialBlocks.push({
+            id: subgraph.members[0] ?? '',
+            preferredLeft,
+            members: packedMembers,
+        });
+    }
+    for (const unit of verticalParticipants) {
+        if (lateralMemberIds.has(unit.id)) continue;
+        initialBlocks.push({
+            id: unit.id,
+            preferredLeft: (verticalCenters.get(unit.id)?.x ?? 0) - unit.width / 2,
+            members: [{ id: unit.id, left: 0 }],
+        });
+    }
+
+    const { blocks, rowByNode: reservedRowByUnit } = reserveAttachmentStackEnvelopes(
+        attachmentStacks,
+        units,
+        initialBlocks,
+        rowByUnit,
+        spacing,
+    );
+
+    const rows = new Map<number, ComponentLayoutNode[]>();
+    for (const unit of units) {
+        if (attachmentStackSourceIds.has(unit.id)) continue;
+        const row = reservedRowByUnit.get(unit.id) ?? 0;
+        if (!rows.has(row)) rows.set(row, []);
+        rows.get(row)?.push(unit);
+    }
+    const rowIndexes = [...rows.keys()].sort((left, right) => left - right);
+    const centerYByRow = new Map<number, number>();
+    let nextTop = 0;
+    for (const row of rowIndexes) {
+        const rowHeight = Math.max(...(rows.get(row) ?? []).map((unit) => unit.height));
+        centerYByRow.set(row, nextTop + rowHeight / 2);
+        nextTop += rowHeight + spacing.rank;
+    }
+
+    const spineBlocks = mergeGeneratorSpineBlocks(units, edges, blocks, reservedRowByUnit);
+    const serialPromptBlocks = mergeSerialSpinePromptBlocks(
+        units,
+        edges,
+        spineBlocks,
+        reservedRowByUnit,
+    );
+    const constrainedBlocks = mergePromptFanoutStageBlocks(
+        units,
+        edges,
+        serialPromptBlocks,
+        reservedRowByUnit,
+        spacing,
+    );
+    constrainedBlocks.sort(
+        (left, right) => left.preferredLeft - right.preferredLeft || compareIds(left.id, right.id),
+    );
+    const rightBoundaryByRow = new Map<number, number>();
+    const positions = new Map<string, XYPosition>();
+    for (const block of constrainedBlocks) {
+        const boundsByRow = new Map<number, { left: number; right: number }>();
+        for (const member of block.members) {
+            const unit = unitsById.get(member.id);
+            if (!unit) continue;
+            const row = reservedRowByUnit.get(member.id) ?? 0;
+            const bounds = boundsByRow.get(row);
+            boundsByRow.set(row, {
+                left: Math.min(bounds?.left ?? Infinity, member.left),
+                right: Math.max(bounds?.right ?? -Infinity, member.left + unit.width),
+            });
+        }
+        let shift = block.preferredLeft;
+        for (const [row, bounds] of boundsByRow) {
+            const occupiedRight = rightBoundaryByRow.get(row);
+            if (occupiedRight !== undefined) {
+                shift = Math.max(shift, occupiedRight + spacing.node - bounds.left);
+            }
+        }
+        for (const member of block.members) {
+            const unit = unitsById.get(member.id);
+            if (!unit) continue;
+            const row = reservedRowByUnit.get(member.id) ?? 0;
+            positions.set(member.id, {
+                x: member.left + shift,
+                y: (centerYByRow.get(row) ?? 0) - unit.height / 2,
+            });
+        }
+        for (const [row, bounds] of boundsByRow) {
+            rightBoundaryByRow.set(
+                row,
+                Math.max(rightBoundaryByRow.get(row) ?? -Infinity, bounds.right + shift),
+            );
+        }
+    }
+
+    const corePositions = new Map(
+        [...positions].filter(([id]) => !attachmentStackSourceIds.has(id)),
+    );
+    for (const [id, position] of placeAttachmentStacks(
+        attachmentStacks,
+        units,
+        corePositions,
+        spacing,
+    )) {
+        positions.set(id, position);
+    }
+
+    const minimumX = Math.min(...units.map((unit) => positions.get(unit.id)?.x ?? 0));
+    const minimumY = Math.min(...units.map((unit) => positions.get(unit.id)?.y ?? 0));
+    const maximumX = Math.max(
+        ...units.map((unit) => (positions.get(unit.id)?.x ?? 0) + unit.width),
+    );
+    const maximumY = Math.max(
+        ...units.map((unit) => (positions.get(unit.id)?.y ?? 0) + unit.height),
+    );
+    return {
+        positions: new Map(
+            [...positions].map(([id, position]) => [
+                id,
+                { x: position.x - minimumX, y: position.y - minimumY },
+            ]),
+        ),
+        width: maximumX - minimumX,
+        height: maximumY - minimumY,
+    };
+};

--- a/ui/app/utils/graphAutoLayoutConstraints.ts
+++ b/ui/app/utils/graphAutoLayoutConstraints.ts
@@ -1,0 +1,223 @@
+import { NodeTypeEnum } from '@/types/enums';
+
+export type LayoutEdgeCategory = 'attachment' | 'context' | 'generic' | 'prompt';
+
+export interface LayoutConstraintNode {
+    id: string;
+    type?: string;
+}
+
+export interface LayoutConstraintEdge {
+    source: string;
+    target: string;
+    category: LayoutEdgeCategory;
+}
+
+export interface LayoutHorizontalBlock {
+    id: string;
+    preferredLeft: number;
+    members: Array<{ id: string; left: number }>;
+}
+
+interface SizedConstraintNode extends LayoutConstraintNode {
+    width: number;
+}
+
+interface RawLayoutEdge {
+    sourceHandle?: string | null;
+    targetHandle?: string | null;
+}
+
+const KNOWN_CATEGORIES = new Set<LayoutEdgeCategory>(['attachment', 'context', 'prompt']);
+const GENERATOR_TYPES = new Set<string>([
+    NodeTypeEnum.TEXT_TO_TEXT,
+    NodeTypeEnum.PARALLELIZATION,
+    NodeTypeEnum.ROUTING,
+]);
+
+const canonicalCategory = (handle: string | null | undefined): LayoutEdgeCategory | undefined => {
+    if (typeof handle !== 'string') return undefined;
+    const separator = handle.indexOf('_');
+    if (separator <= 0 || separator === handle.length - 1) return undefined;
+    const prefix = handle.slice(0, separator) as LayoutEdgeCategory;
+    return KNOWN_CATEGORIES.has(prefix) ? prefix : undefined;
+};
+
+const categoryForNodeType = (nodeType: string | undefined): LayoutEdgeCategory | undefined => {
+    if (nodeType === NodeTypeEnum.PROMPT) return 'prompt';
+    if (nodeType === NodeTypeEnum.FILE_PROMPT || nodeType === NodeTypeEnum.GITHUB) {
+        return 'attachment';
+    }
+    if (
+        nodeType === NodeTypeEnum.TEXT_TO_TEXT ||
+        nodeType === NodeTypeEnum.PARALLELIZATION ||
+        nodeType === NodeTypeEnum.ROUTING ||
+        nodeType === NodeTypeEnum.CONTEXT_MERGER
+    ) {
+        return 'context';
+    }
+    return undefined;
+};
+
+export const isGeneratorNode = (node: LayoutConstraintNode | undefined): boolean =>
+    !!node?.type && GENERATOR_TYPES.has(node.type);
+
+export const classifyLayoutEdge = (
+    edge: RawLayoutEdge,
+    sourceNodeType: string | undefined,
+): LayoutEdgeCategory => {
+    const targetCategory = canonicalCategory(edge.targetHandle);
+    if (!targetCategory) return 'generic';
+
+    const sourceCategory =
+        edge.sourceHandle === null || edge.sourceHandle === undefined
+            ? categoryForNodeType(sourceNodeType)
+            : canonicalCategory(edge.sourceHandle);
+    return sourceCategory === targetCategory ? targetCategory : 'generic';
+};
+
+export const derivePromptStageConstraints = (
+    nodes: readonly LayoutConstraintNode[],
+    edges: readonly LayoutConstraintEdge[],
+): LayoutConstraintEdge[] => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const generatorPredecessors = new Map<string, Set<string>>();
+    const promptSources = new Map<string, Set<string>>();
+    for (const edge of edges) {
+        const source = nodesById.get(edge.source);
+        const target = nodesById.get(edge.target);
+        if (
+            edge.category === 'context' &&
+            isGeneratorNode(source) &&
+            isGeneratorNode(target)
+        ) {
+            if (!generatorPredecessors.has(edge.target)) {
+                generatorPredecessors.set(edge.target, new Set());
+            }
+            generatorPredecessors.get(edge.target)?.add(edge.source);
+        }
+        if (
+            edge.category === 'prompt' &&
+            source?.type === NodeTypeEnum.PROMPT &&
+            isGeneratorNode(target)
+        ) {
+            if (!promptSources.has(edge.target)) promptSources.set(edge.target, new Set());
+            promptSources.get(edge.target)?.add(edge.source);
+        }
+    }
+
+    const constraints: LayoutConstraintEdge[] = [];
+    for (const generatorId of [...generatorPredecessors.keys()].sort()) {
+        const promptId = [...(promptSources.get(generatorId) ?? [])].sort()[0];
+        if (!promptId) continue;
+        for (const predecessorId of [...(generatorPredecessors.get(generatorId) ?? [])].sort()) {
+            if (predecessorId === promptId) continue;
+            constraints.push({ source: predecessorId, target: promptId, category: 'generic' });
+        }
+    }
+    return constraints;
+};
+
+export const deriveGeneratorSpines = (
+    nodes: readonly LayoutConstraintNode[],
+    edges: readonly LayoutConstraintEdge[],
+): string[][] => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const generatorEdges = edges.filter(
+        (edge) =>
+            edge.category === 'context' &&
+            isGeneratorNode(nodesById.get(edge.source)) &&
+            isGeneratorNode(nodesById.get(edge.target)),
+    );
+    const indegree = new Map<string, number>();
+    const outdegree = new Map<string, number>();
+    for (const edge of generatorEdges) {
+        outdegree.set(edge.source, (outdegree.get(edge.source) ?? 0) + 1);
+        indegree.set(edge.target, (indegree.get(edge.target) ?? 0) + 1);
+    }
+    const nextById = new Map<string, string>();
+    const previousIds = new Set<string>();
+    for (const edge of generatorEdges) {
+        if (outdegree.get(edge.source) !== 1 || indegree.get(edge.target) !== 1) continue;
+        nextById.set(edge.source, edge.target);
+        previousIds.add(edge.target);
+    }
+
+    const spines: string[][] = [];
+    for (const start of [...nextById.keys()].filter((id) => !previousIds.has(id)).sort()) {
+        const spine = [start];
+        const visited = new Set(spine);
+        let current = start;
+        while (nextById.has(current)) {
+            const next = nextById.get(current);
+            if (!next || visited.has(next)) break;
+            spine.push(next);
+            visited.add(next);
+            current = next;
+        }
+        if (spine.length > 1) spines.push(spine);
+    }
+    return spines;
+};
+
+export const mergeGeneratorSpineBlocks = (
+    nodes: readonly SizedConstraintNode[],
+    edges: readonly LayoutConstraintEdge[],
+    blocks: readonly LayoutHorizontalBlock[],
+    rowByNode: ReadonlyMap<string, number>,
+): LayoutHorizontalBlock[] => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const blockByMember = new Map<string, LayoutHorizontalBlock>();
+    for (const block of blocks) {
+        for (const member of block.members) blockByMember.set(member.id, block);
+    }
+
+    const consumed = new Set<LayoutHorizontalBlock>();
+    const merged: LayoutHorizontalBlock[] = [];
+    for (const spine of deriveGeneratorSpines(nodes, edges)) {
+        const spineBlocks = spine.map((id) => blockByMember.get(id));
+        if (spineBlocks.some((block) => !block || consumed.has(block))) continue;
+        const concreteBlocks = spineBlocks.filter(
+            (block): block is LayoutHorizontalBlock => block !== undefined,
+        );
+        if (new Set(concreteBlocks).size !== spine.length) continue;
+        const rows = spine.map((id) => rowByNode.get(id));
+        if (rows.some((row) => row === undefined) || new Set(rows).size !== spine.length) continue;
+        if (
+            concreteBlocks.some(
+                (block) =>
+                    block.members.filter((member) => isGeneratorNode(nodesById.get(member.id)))
+                        .length !== 1,
+            )
+        ) {
+            continue;
+        }
+
+        const anchorId = [...spine].sort(
+            (left, right) =>
+                (rowByNode.get(left) ?? 0) - (rowByNode.get(right) ?? 0) ||
+                left.localeCompare(right),
+        )[0]!;
+        const anchorBlock = blockByMember.get(anchorId)!;
+        const anchorMember = anchorBlock.members.find((member) => member.id === anchorId)!;
+        const preferredCenter =
+            anchorBlock.preferredLeft +
+            anchorMember.left +
+            (nodesById.get(anchorId)?.width ?? 0) / 2;
+        const members: Array<{ id: string; left: number }> = [];
+        for (let index = 0; index < spine.length; index += 1) {
+            const generatorId = spine[index]!;
+            const block = concreteBlocks[index]!;
+            const generatorMember = block.members.find((member) => member.id === generatorId)!;
+            const generatorCenter =
+                generatorMember.left + (nodesById.get(generatorId)?.width ?? 0) / 2;
+            for (const member of block.members) {
+                members.push({ id: member.id, left: member.left - generatorCenter });
+            }
+            consumed.add(block);
+        }
+        merged.push({ id: spine[0]!, preferredLeft: preferredCenter, members });
+    }
+
+    return [...blocks.filter((block) => !consumed.has(block)), ...merged];
+};

--- a/ui/app/utils/graphAutoLayoutFanoutHierarchy.ts
+++ b/ui/app/utils/graphAutoLayoutFanoutHierarchy.ts
@@ -1,0 +1,237 @@
+import { NodeTypeEnum } from '@/types/enums';
+import { isGeneratorNode, type LayoutConstraintEdge } from '@/utils/graphAutoLayoutConstraints';
+
+export interface FanoutHierarchyNode {
+    id: string;
+    type?: string;
+    width: number;
+}
+
+export interface FanoutHierarchyChild {
+    childId: string;
+    dedicatedPromptId?: string;
+}
+
+export interface FanoutHierarchyFamily {
+    id: string;
+    contextParentId?: string;
+    promptParentId?: string;
+    children: FanoutHierarchyChild[];
+    dependencies: string[];
+}
+
+interface CandidateFamily extends Omit<FanoutHierarchyFamily, 'dependencies'> {
+    childKey: string;
+}
+
+const compareIds = (left: string, right: string) => left.localeCompare(right);
+const addToSetMap = (map: Map<string, Set<string>>, key: string, value: string) => {
+    if (!map.has(key)) map.set(key, new Set());
+    map.get(key)?.add(value);
+};
+
+const graphIndexes = (edges: readonly LayoutConstraintEdge[]) => {
+    const contextSuccessors = new Map<string, Set<string>>();
+    const contextPredecessors = new Map<string, Set<string>>();
+    const promptTargets = new Map<string, Set<string>>();
+    const promptSources = new Map<string, Set<string>>();
+    for (const edge of edges) {
+        if (edge.category === 'context') {
+            addToSetMap(contextSuccessors, edge.source, edge.target);
+            addToSetMap(contextPredecessors, edge.target, edge.source);
+        } else if (edge.category === 'prompt') {
+            addToSetMap(promptTargets, edge.source, edge.target);
+            addToSetMap(promptSources, edge.target, edge.source);
+        }
+    }
+    return { contextSuccessors, contextPredecessors, promptTargets, promptSources };
+};
+
+export const discoverFanoutHierarchy = (
+    nodes: readonly FanoutHierarchyNode[],
+    edges: readonly LayoutConstraintEdge[],
+    rowByNode: ReadonlyMap<string, number>,
+): FanoutHierarchyFamily[] => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const indexes = graphIndexes(edges);
+    const candidates: CandidateFamily[] = [];
+    const blockedChildren = new Set<string>();
+    const coParentKeys = new Set<string>();
+
+    for (const parentId of [...indexes.contextSuccessors.keys()].sort(compareIds)) {
+        const childIds = [...(indexes.contextSuccessors.get(parentId) ?? [])].sort(compareIds);
+        const parentRow = rowByNode.get(parentId);
+        if (
+            !isGeneratorNode(nodesById.get(parentId)) ||
+            childIds.length < 2 ||
+            parentRow === undefined ||
+            childIds.some((id) =>
+                !isGeneratorNode(nodesById.get(id)) ||
+                indexes.contextPredecessors.get(id)?.size !== 1 ||
+                !indexes.contextPredecessors.get(id)?.has(parentId) ||
+                rowByNode.get(id) === undefined ||
+                parentRow >= (rowByNode.get(id) ?? -Infinity),
+            )
+        ) continue;
+
+        const children: FanoutHierarchyChild[] = [];
+        const sharedPromptIds = new Set<string>();
+        let valid = true;
+        for (const childId of childIds) {
+            const sourceIds = [...(indexes.promptSources.get(childId) ?? [])].sort(compareIds);
+            if (sourceIds.length > 1) {
+                valid = false;
+                break;
+            }
+            const promptId = sourceIds[0];
+            if (!promptId) {
+                children.push({ childId });
+                continue;
+            }
+            const promptRow = rowByNode.get(promptId);
+            const childRow = rowByNode.get(childId)!;
+            if (
+                nodesById.get(promptId)?.type !== NodeTypeEnum.PROMPT ||
+                promptRow === undefined ||
+                !(parentRow < promptRow && promptRow < childRow)
+            ) {
+                valid = false;
+                break;
+            }
+            const targets = indexes.promptTargets.get(promptId) ?? new Set();
+            if (targets.size === 1 && targets.has(childId)) {
+                children.push({ childId, dedicatedPromptId: promptId });
+            } else {
+                sharedPromptIds.add(promptId);
+                children.push({ childId });
+            }
+        }
+        const childKey = childIds.join('\0');
+        let promptParentId: string | undefined;
+        if (valid && sharedPromptIds.size) {
+            const sharedId = [...sharedPromptIds][0]!;
+            const targets = [...(indexes.promptTargets.get(sharedId) ?? [])].sort(compareIds);
+            if (
+                sharedPromptIds.size !== 1 ||
+                children.some(({ childId }) => !indexes.promptSources.get(childId)?.has(sharedId)) ||
+                targets.join('\0') !== childKey
+            ) valid = false;
+            else promptParentId = sharedId;
+        }
+        if (!valid) {
+            for (const childId of childIds) blockedChildren.add(childId);
+            continue;
+        }
+        candidates.push({
+            id: `context:${parentId}`,
+            contextParentId: parentId,
+            promptParentId,
+            children,
+            childKey,
+        });
+        if (promptParentId) coParentKeys.add(`${promptParentId}\0${childKey}`);
+    }
+
+    for (const promptId of [...indexes.promptTargets.keys()].sort(compareIds)) {
+        const childIds = [...(indexes.promptTargets.get(promptId) ?? [])].sort(compareIds);
+        const promptRow = rowByNode.get(promptId);
+        const childKey = childIds.join('\0');
+        if (
+            childIds.length < 2 ||
+            nodesById.get(promptId)?.type !== NodeTypeEnum.PROMPT ||
+            promptRow === undefined ||
+            coParentKeys.has(`${promptId}\0${childKey}`) ||
+            childIds.some((id) =>
+                !isGeneratorNode(nodesById.get(id)) ||
+                indexes.promptSources.get(id)?.size !== 1 ||
+                !indexes.promptSources.get(id)?.has(promptId) ||
+                rowByNode.get(id) === undefined ||
+                promptRow >= (rowByNode.get(id) ?? -Infinity),
+            )
+        ) continue;
+        candidates.push({
+            id: `prompt:${promptId}`,
+            promptParentId: promptId,
+            children: childIds.map((childId) => ({ childId })),
+            childKey,
+        });
+    }
+
+    const owners = new Map<string, CandidateFamily[]>();
+    for (const candidate of candidates) {
+        for (const { childId } of candidate.children) {
+            if (!owners.has(childId)) owners.set(childId, []);
+            owners.get(childId)?.push(candidate);
+        }
+    }
+    const rejected = new Set<string>();
+    for (const candidate of candidates) {
+        if (candidate.children.some(({ childId }) =>
+            blockedChildren.has(childId) || (owners.get(childId)?.length ?? 0) > 1,
+        )) rejected.add(candidate.id);
+    }
+    const byContextParent = new Map(
+        candidates.filter(({ contextParentId }) => contextParentId)
+            .map((family) => [family.contextParentId!, family]),
+    );
+    const dependentIds = new Map<string, string[]>();
+    for (const candidate of candidates) {
+        for (const { childId } of candidate.children) {
+            const dependency = byContextParent.get(childId);
+            if (!dependency) continue;
+            if (!dependentIds.has(dependency.id)) dependentIds.set(dependency.id, []);
+            dependentIds.get(dependency.id)?.push(candidate.id);
+        }
+    }
+    const rejectedQueue = [...rejected].sort(compareIds);
+    let rejectedIndex = 0;
+    while (rejectedIndex < rejectedQueue.length) {
+        const rejectedId = rejectedQueue[rejectedIndex++]!;
+        for (const dependentId of dependentIds.get(rejectedId) ?? []) {
+            if (rejected.has(dependentId)) continue;
+            rejected.add(dependentId);
+            rejectedQueue.push(dependentId);
+        }
+    }
+
+    const valid = candidates.filter(({ id }) => !rejected.has(id));
+    const validByContextParent = new Map(
+        valid.filter(({ contextParentId }) => contextParentId)
+            .map((family) => [family.contextParentId!, family]),
+    );
+    const families = valid.map((candidate): FanoutHierarchyFamily => ({
+        id: candidate.id,
+        contextParentId: candidate.contextParentId,
+        promptParentId: candidate.promptParentId,
+        children: candidate.children,
+        dependencies: candidate.children
+            .map(({ childId }) => validByContextParent.get(childId)?.id)
+            .filter((id): id is string => id !== undefined)
+            .sort(compareIds),
+    }));
+    const byId = new Map(families.map((family) => [family.id, family]));
+    const pendingCount = new Map(families.map((family) => [family.id, family.dependencies.length]));
+    const dependents = new Map<string, string[]>();
+    for (const family of families) {
+        for (const dependency of family.dependencies) {
+            if (!dependents.has(dependency)) dependents.set(dependency, []);
+            dependents.get(dependency)?.push(family.id);
+        }
+    }
+    let frontier = families.filter(({ id }) => pendingCount.get(id) === 0)
+        .map(({ id }) => id).sort(compareIds);
+    const ordered: FanoutHierarchyFamily[] = [];
+    while (frontier.length) {
+        const next: string[] = [];
+        for (const id of frontier) {
+            ordered.push(byId.get(id)!);
+            for (const dependent of dependents.get(id) ?? []) {
+                const count = (pendingCount.get(dependent) ?? 1) - 1;
+                pendingCount.set(dependent, count);
+                if (count === 0) next.push(dependent);
+            }
+        }
+        frontier = next.sort(compareIds);
+    }
+    return ordered;
+};

--- a/ui/app/utils/graphAutoLayoutSerialPrompts.ts
+++ b/ui/app/utils/graphAutoLayoutSerialPrompts.ts
@@ -1,0 +1,139 @@
+import { NodeTypeEnum } from '@/types/enums';
+import {
+    deriveGeneratorSpines,
+    type LayoutConstraintEdge,
+    type LayoutHorizontalBlock,
+} from '@/utils/graphAutoLayoutConstraints';
+
+interface SerialPromptNode {
+    id: string;
+    type?: string;
+    width: number;
+}
+
+interface SerialPromptCandidate {
+    targetId: string;
+    promptId: string;
+    spineBlock: LayoutHorizontalBlock;
+    promptBlock: LayoutHorizontalBlock;
+    promptLeft: number;
+}
+
+const PROMPT_TARGET_RATIO = 0.33;
+const compareIds = (left: string, right: string) => left.localeCompare(right);
+
+const addToSetMap = (map: Map<string, Set<string>>, key: string, value: string) => {
+    if (!map.has(key)) map.set(key, new Set());
+    map.get(key)?.add(value);
+};
+
+export const mergeSerialSpinePromptBlocks = (
+    nodes: readonly SerialPromptNode[],
+    edges: readonly LayoutConstraintEdge[],
+    blocks: readonly LayoutHorizontalBlock[],
+    rowByNode: ReadonlyMap<string, number>,
+): LayoutHorizontalBlock[] => {
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const blockByMember = new Map<string, LayoutHorizontalBlock>();
+    const memberLeftById = new Map<string, number>();
+    for (const block of blocks) {
+        for (const member of block.members) {
+            blockByMember.set(member.id, block);
+            memberLeftById.set(member.id, member.left);
+        }
+    }
+
+    const promptSources = new Map<string, Set<string>>();
+    const promptTargets = new Map<string, Set<string>>();
+    for (const edge of edges) {
+        if (edge.category !== 'prompt') continue;
+        addToSetMap(promptSources, edge.target, edge.source);
+        addToSetMap(promptTargets, edge.source, edge.target);
+    }
+
+    const candidates: SerialPromptCandidate[] = [];
+    for (const spine of deriveGeneratorSpines(nodes, edges)) {
+        for (let index = 1; index < spine.length; index += 1) {
+            const predecessorId = spine[index - 1]!;
+            const targetId = spine[index]!;
+            const sourceIds = [...(promptSources.get(targetId) ?? [])].sort(compareIds);
+            const promptId = sourceIds[0];
+            if (!promptId || sourceIds.length !== 1) continue;
+            const spineBlock = blockByMember.get(targetId);
+            const promptBlock = blockByMember.get(promptId);
+            const target = nodesById.get(targetId);
+            const prompt = nodesById.get(promptId);
+            const targetLeft = memberLeftById.get(targetId);
+            const predecessorRow = rowByNode.get(predecessorId);
+            const promptRow = rowByNode.get(promptId);
+            const targetRow = rowByNode.get(targetId);
+            if (
+                !spineBlock ||
+                spineBlock !== blockByMember.get(predecessorId) ||
+                !promptBlock ||
+                promptBlock === spineBlock ||
+                promptBlock.members.length !== 1 ||
+                promptBlock.members[0]?.id !== promptId ||
+                prompt?.type !== NodeTypeEnum.PROMPT ||
+                promptTargets.get(promptId)?.size !== 1 ||
+                !promptTargets.get(promptId)?.has(targetId) ||
+                !target ||
+                targetLeft === undefined ||
+                predecessorRow === undefined ||
+                promptRow === undefined ||
+                targetRow === undefined ||
+                !(predecessorRow < promptRow && promptRow < targetRow)
+            ) {
+                continue;
+            }
+            candidates.push({
+                targetId,
+                promptId,
+                spineBlock,
+                promptBlock,
+                promptLeft: targetLeft + PROMPT_TARGET_RATIO * target.width - prompt.width / 2,
+            });
+        }
+    }
+    candidates.sort(
+        (left, right) =>
+            compareIds(left.targetId, right.targetId) || compareIds(left.promptId, right.promptId),
+    );
+
+    const candidateCountByPromptBlock = new Map<LayoutHorizontalBlock, number>();
+    for (const candidate of candidates) {
+        candidateCountByPromptBlock.set(
+            candidate.promptBlock,
+            (candidateCountByPromptBlock.get(candidate.promptBlock) ?? 0) + 1,
+        );
+    }
+    const candidatesBySpine = new Map<LayoutHorizontalBlock, SerialPromptCandidate[]>();
+    for (const candidate of candidates) {
+        if (candidateCountByPromptBlock.get(candidate.promptBlock) !== 1) continue;
+        if (!candidatesBySpine.has(candidate.spineBlock)) {
+            candidatesBySpine.set(candidate.spineBlock, []);
+        }
+        candidatesBySpine.get(candidate.spineBlock)?.push(candidate);
+    }
+
+    const consumedPrompts = new Set<LayoutHorizontalBlock>();
+    const mergedBySpine = new Map<LayoutHorizontalBlock, LayoutHorizontalBlock>();
+    for (const [spineBlock, spineCandidates] of candidatesBySpine) {
+        mergedBySpine.set(spineBlock, {
+            id: spineBlock.id,
+            preferredLeft: spineBlock.preferredLeft,
+            members: [
+                ...spineBlock.members.map((member) => ({ ...member })),
+                ...spineCandidates.map(({ promptId, promptLeft }) => ({
+                    id: promptId,
+                    left: promptLeft,
+                })),
+            ],
+        });
+        for (const candidate of spineCandidates) consumedPrompts.add(candidate.promptBlock);
+    }
+
+    return blocks
+        .filter((block) => !consumedPrompts.has(block))
+        .map((block) => mergedBySpine.get(block) ?? block);
+};

--- a/ui/app/utils/graphGeometry.ts
+++ b/ui/app/utils/graphGeometry.ts
@@ -1,4 +1,4 @@
-import { NodeCategoryEnum } from '@/types/enums';
+import { NodeCategoryEnum, NodeTypeEnum } from '@/types/enums';
 import type { QuickWorkflowDirection } from '@/utils/quickWorkflow';
 
 export interface GeometryPoint {
@@ -23,6 +23,26 @@ export interface QuickWorkflowPlacementInput {
     gap: number;
 }
 
+export interface GeneratorPlacementNode {
+    id: string;
+    type?: string;
+    position: GeometryPoint;
+    width: number;
+    height: number;
+}
+
+export interface GeneratorPlacementEdge {
+    source: string;
+    target: string;
+}
+
+export interface GeneratorChildPlacementInput {
+    parent: GeneratorPlacementNode;
+    nodes: readonly GeneratorPlacementNode[];
+    edges: readonly GeneratorPlacementEdge[];
+    gap: number;
+}
+
 export interface WheelGeometryConfig {
     radius: number;
     innerRadius: number;
@@ -35,6 +55,48 @@ export interface WheelSectorGeometry {
     iconX: number;
     iconY: number;
 }
+
+const GENERATOR_NODE_TYPES = new Set<string>([
+    NodeTypeEnum.TEXT_TO_TEXT,
+    NodeTypeEnum.PARALLELIZATION,
+    NodeTypeEnum.ROUTING,
+]);
+
+export const calculateGeneratorChildPosition = (
+    input: GeneratorChildPlacementInput,
+): GeometryPoint => {
+    const belowParent = {
+        x: input.parent.position.x,
+        y: input.parent.position.y + input.parent.height + input.gap,
+    };
+    if (!input.parent.type || !GENERATOR_NODE_TYPES.has(input.parent.type)) return belowParent;
+
+    const directChildIds = new Set(
+        input.edges
+            .filter((edge) => edge.source === input.parent.id)
+            .map((edge) => edge.target),
+    );
+    const directGeneratorChildren = input.nodes.filter(
+        (node) =>
+            directChildIds.has(node.id) &&
+            !!node.type &&
+            GENERATOR_NODE_TYPES.has(node.type),
+    );
+    const rightmostChild = directGeneratorChildren.reduce<GeneratorPlacementNode | undefined>(
+        (rightmost, child) =>
+            !rightmost || child.position.x + child.width > rightmost.position.x + rightmost.width
+                ? child
+                : rightmost,
+        undefined,
+    );
+
+    return rightmostChild
+        ? {
+              x: rightmostChild.position.x + rightmostChild.width + input.gap,
+              y: rightmostChild.position.y,
+          }
+        : belowParent;
+};
 
 export const calculateQuickWorkflowPositionOffset = (
     input: QuickWorkflowPlacementInput,

--- a/ui/e2e/support/canvasQuickActionWheelFixture.ts
+++ b/ui/e2e/support/canvasQuickActionWheelFixture.ts
@@ -19,6 +19,8 @@ export interface CanvasQuickActionState {
         id: string;
         type?: string;
         position: { x: number; y: number };
+        width: number;
+        height: number;
         parentNode?: string;
         data: Record<string, unknown>;
     }>;
@@ -28,11 +30,13 @@ export interface CanvasQuickActionState {
         target: string;
         sourceHandle?: string | null;
         targetHandle?: string | null;
+        type?: string;
     }>;
     presetNames: string[];
     plan: 'free' | 'premium' | null;
     actions: string[];
     selecting: boolean;
+    viewport: { x: number; y: number; zoom: number };
 }
 
 const COLD_BOOTSTRAP_TIMEOUT = 120_000;

--- a/ui/e2e/tests/canvas-quick-action-wheel.spec.ts
+++ b/ui/e2e/tests/canvas-quick-action-wheel.spec.ts
@@ -9,6 +9,98 @@ test.beforeEach(async ({ page }) => {
     await mountCanvasQuickActionFixture(page);
 });
 
+test('auto layout is stable from controls and canvas wheel', async ({ page }) => {
+    await page.getByTestId('seed-mixed-workflow').click();
+    await expect.poll(async () => (await readCanvasQuickActionState(page)).nodeIds.length).toBe(6);
+    const edgeBefore = (await readCanvasQuickActionState(page)).edges;
+    await page.getByTitle('Auto layout').click();
+    await expect
+        .poll(async () => (await readCanvasQuickActionState(page)).actions)
+        .toContain('controls-auto-layout');
+    const controlsState = await readCanvasQuickActionState(page);
+    const controlsPositions = controlsState.nodes.map(({ id, position }) => ({ id, position }));
+    const node = (id: string) => controlsState.nodes.find((candidate) => candidate.id === id)!;
+    const centerX = (id: string) => node(id).position.x + node(id).width / 2;
+    const centerY = (id: string) => node(id).position.y + node(id).height / 2;
+    for (const id of [
+        'prompt1',
+        'attachment-file',
+        'attachment-github',
+        'generator1',
+        'prompt2',
+        'generator2',
+    ]) {
+        expect(node(id)).toBeDefined();
+        expect(node(id).width).toBeGreaterThan(0);
+        expect(node(id).height).toBeGreaterThan(0);
+    }
+    expect(node('generator1').position.y - (node('prompt1').position.y + node('prompt1').height)).toBe(
+        100,
+    );
+    expect(node('attachment-file').position.y + node('attachment-file').height + 40).toBe(
+        node('attachment-github').position.y,
+    );
+    const attachmentRight = node('attachment-file').position.x + node('attachment-file').width;
+    expect(attachmentRight).toBe(
+        node('attachment-github').position.x + node('attachment-github').width,
+    );
+    expect(
+        (node('attachment-file').position.y +
+            node('attachment-github').position.y +
+            node('attachment-github').height) /
+            2,
+    ).toBe(centerY('generator1'));
+    expect(
+        Math.min(node('prompt1').position.x, node('generator1').position.x) - attachmentRight,
+    ).toBeGreaterThanOrEqual(160);
+    expect(node('prompt2').position.y - (node('generator1').position.y + node('generator1').height)).toBe(
+        100,
+    );
+    expect(centerX('generator1')).toBe(centerX('generator2'));
+    expect(node('generator2').position.y - (node('prompt2').position.y + node('prompt2').height)).toBe(
+        100,
+    );
+    for (let leftIndex = 0; leftIndex < controlsState.nodes.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < controlsState.nodes.length; rightIndex += 1) {
+            const left = controlsState.nodes[leftIndex]!;
+            const right = controlsState.nodes[rightIndex]!;
+            const overlaps =
+                left.position.x < right.position.x + right.width &&
+                left.position.x + left.width > right.position.x &&
+                left.position.y < right.position.y + right.height &&
+                left.position.y + left.height > right.position.y;
+            expect(overlaps).toBe(false);
+        }
+    }
+    expect(controlsState.edges).toEqual(edgeBefore);
+    expect(Object.values(controlsState.viewport).every(Number.isFinite)).toBe(true);
+
+    await page.getByTestId('seed-mixed-workflow').click();
+    await expect.poll(async () => (await readCanvasQuickActionState(page)).actions).toEqual([]);
+    const wheelEdgesBefore = (await readCanvasQuickActionState(page)).edges;
+    const graph = page.getByTestId('canvas-quick-action-graph');
+    const box = await graph.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+    await page.mouse.click(box.x + box.width - 30, box.y + box.height - 30, {
+        button: 'right',
+    });
+    const autoLayoutAction = page.locator('[data-action-id="auto-layout"]');
+    await expect(autoLayoutAction).toBeVisible();
+    await autoLayoutAction.locator('[data-root-action-label]').click();
+    await expect
+        .poll(async () => (await readCanvasQuickActionState(page)).actions)
+        .toContain('auto-layout');
+
+    const wheelState = await readCanvasQuickActionState(page);
+    expect(wheelState.nodes.map(({ id, position }) => ({ id, position }))).toEqual(
+        controlsPositions,
+    );
+    expect(wheelState.edges).toEqual(wheelEdgesBefore);
+    expect(wheelState.edges).toEqual(edgeBefore);
+    expect(Object.values(wheelState.viewport).every(Number.isFinite)).toBe(true);
+});
+
 test('@smoke opens target-aware wheels and dispatches an add action', async ({ page }) => {
     const graph = page.getByTestId('canvas-quick-action-graph');
     const graphBox = await graph.boundingBox();

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
+        "@dagrejs/dagre": "^3.1.0",
         "@headlessui/tailwindcss": "^0.2.2",
         "@nuxt/eslint": "^1.15.2",
         "@nuxt/image": "^2.1.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: ^3.1.0
+        version: 3.1.0
       '@headlessui/tailwindcss':
         specifier: ^0.2.2
         version: 0.2.2(tailwindcss@4.2.2)
@@ -360,6 +363,12 @@ packages:
 
   '@colordx/core@5.5.0':
     resolution: {integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==}
+
+  '@dagrejs/dagre@3.1.0':
+    resolution: {integrity: sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw==}
+
+  '@dagrejs/graphlib@4.0.3':
+    resolution: {integrity: sha512-9kvysNliOxG5m3lr1Qq5uCc+SYxx+BaLDM2SDGkgoZvKJ1bSESzbZ3gn4rSxqX1xR07swcSdeuGyKYQhAURxAA==}
 
   '@dxup/nuxt@0.5.6':
     resolution: {integrity: sha512-uZjAFoocWtWHr7YP9jm6FqwI8kjX2QN9bjcncoZt0GS+zExIAP3Ewv6EqEUvVP7w9pjZE+T19QxLHeoacN/MNg==}
@@ -6088,6 +6097,12 @@ snapshots:
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
   '@colordx/core@5.5.0': {}
+
+  '@dagrejs/dagre@3.1.0':
+    dependencies:
+      '@dagrejs/graphlib': 4.0.3
+
+  '@dagrejs/graphlib@4.0.3': {}
 
   '@dxup/nuxt@0.5.6(esbuild@0.28.1)(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.0(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))':
     dependencies:

--- a/ui/tests/nuxt/useGraphAutoLayout.spec.ts
+++ b/ui/tests/nuxt/useGraphAutoLayout.spec.ts
@@ -1,0 +1,224 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import type { Edge, GraphNode } from '@vue-flow/core';
+import { computed, nextTick } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGraphAutoLayout } from '@/composables/useGraphAutoLayout';
+
+const stubs = vi.hoisted(() => ({
+    nodes: { value: [] as GraphNode[] },
+    edges: { value: [] as Edge[] },
+    setNodes: vi.fn(),
+    calculateGraphAutoLayout: vi.fn(),
+    getBlockByNodeType: vi.fn(),
+    saveGraph: vi.fn(),
+    calls: [] as string[],
+}));
+
+vi.mock('@vue-flow/core', () => ({
+    useVueFlow: () => ({
+        getNodes: stubs.nodes,
+        getEdges: stubs.edges,
+        setNodes: stubs.setNodes,
+    }),
+}));
+
+vi.mock('@/utils/graphAutoLayout', () => ({
+    calculateGraphAutoLayout: stubs.calculateGraphAutoLayout,
+}));
+
+mockNuxtImport('useBlocks', () => () => ({
+    getBlockByNodeType: stubs.getBlockByNodeType,
+}));
+
+mockNuxtImport('useCanvasSaveStore', () => () => ({
+    saveGraph: stubs.saveGraph,
+}));
+
+const node = (id: string, overrides: Partial<GraphNode> = {}): GraphNode =>
+    ({
+        id,
+        type: 'prompt',
+        position: { x: 10, y: 20 },
+        data: { marker: id },
+        ...overrides,
+    }) as GraphNode;
+
+describe('useGraphAutoLayout', () => {
+    beforeEach(() => {
+        stubs.nodes.value = [];
+        stubs.edges.value = [];
+        stubs.calls.length = 0;
+        stubs.setNodes.mockReset();
+        stubs.setNodes.mockImplementation(() => {
+            stubs.calls.push('setNodes');
+            void nextTick(() => stubs.calls.push('nextTick'));
+        });
+        stubs.saveGraph.mockReset();
+        stubs.saveGraph.mockImplementation(() => stubs.calls.push('saveGraph'));
+        stubs.calculateGraphAutoLayout.mockReset();
+        stubs.calculateGraphAutoLayout.mockReturnValue(new Map());
+        stubs.getBlockByNodeType.mockReset();
+        stubs.getBlockByNodeType.mockImplementation((type: string) =>
+            type === 'prompt' ? { minSize: { width: 260, height: 270 } } : undefined,
+        );
+    });
+
+    it('resolves each dimension fallback and forwards edge topology without mutation', async () => {
+        const measured = node('measured', {
+            dimensions: { width: 210, height: 0 },
+            width: 999,
+            height: 230,
+            style: { width: '998px', height: '997px' },
+        });
+        const numeric = node('numeric', { width: 220, height: 230 });
+        const styled = node('styled', {
+            width: 0,
+            height: Number.NaN,
+            style: { width: '240px', height: '250.5px' },
+        });
+        const minimum = node('minimum');
+        const safety = node('safety', { type: 'unknown' });
+        const originalEdge: Edge = {
+            id: 'edge',
+            source: 'measured',
+            target: 'numeric',
+            sourceHandle: 'attachment_measured',
+            targetHandle: 'attachment_numeric',
+            data: { untouched: true },
+        };
+        const nullableHandleEdge: Edge = {
+            id: 'nullable-edge',
+            source: 'numeric',
+            target: 'styled',
+            sourceHandle: null,
+            targetHandle: undefined,
+        };
+        stubs.nodes.value = [measured, numeric, styled, minimum, safety];
+        stubs.edges.value = [originalEdge, nullableHandleEdge];
+        const fitGraph = vi.fn().mockImplementation(() => stubs.calls.push('fitGraph'));
+
+        const result = await useGraphAutoLayout({
+            graphId: computed(() => 'graph-id'),
+            fitGraph,
+        }).autoLayoutGraph();
+
+        const layoutNodes = stubs.calculateGraphAutoLayout.mock.calls[0]![0];
+        expect(
+            layoutNodes.map(
+                ({ id, type, width, height, parentNode }: {
+                    id: string;
+                    type?: string;
+                    width: number;
+                    height: number;
+                    parentNode?: string;
+                }) => ({ id, type, width, height, parentNode }),
+            ),
+        ).toEqual([
+            { id: 'measured', type: 'prompt', width: 210, height: 230, parentNode: undefined },
+            { id: 'numeric', type: 'prompt', width: 220, height: 230, parentNode: undefined },
+            { id: 'styled', type: 'prompt', width: 240, height: 250.5, parentNode: undefined },
+            { id: 'minimum', type: 'prompt', width: 260, height: 270, parentNode: undefined },
+            { id: 'safety', type: 'unknown', width: 100, height: 100, parentNode: undefined },
+        ]);
+        expect(stubs.calculateGraphAutoLayout.mock.calls[0]![1]).toEqual([
+            {
+                id: 'edge',
+                source: 'measured',
+                target: 'numeric',
+                sourceHandle: 'attachment_measured',
+                targetHandle: 'attachment_numeric',
+            },
+            {
+                id: 'nullable-edge',
+                source: 'numeric',
+                target: 'styled',
+                sourceHandle: null,
+                targetHandle: undefined,
+            },
+        ]);
+        expect(stubs.edges.value[0]).toBe(originalEdge);
+        expect(stubs.edges.value[0]).toEqual(originalEdge);
+        expect(stubs.edges.value[1]).toBe(nullableHandleEdge);
+        expect(result).toBe(true);
+        expect(stubs.setNodes).toHaveBeenCalledOnce();
+        expect(fitGraph).toHaveBeenCalledOnce();
+        expect(stubs.saveGraph).toHaveBeenCalledOnce();
+        expect(stubs.calls).toEqual(['setNodes', 'nextTick', 'fitGraph', 'saveGraph']);
+    });
+
+    it('moves only returned outer roots in one ordered batch and preserves children', async () => {
+        const group = node('group', { type: 'group', position: { x: 0, y: 0 }, selected: true });
+        const child = node('child', {
+            parentNode: 'group',
+            position: { x: 30, y: 40 },
+            dimensions: { width: 80, height: 90 },
+        });
+        const external = node('external', { position: { x: 500, y: 600 } });
+        stubs.nodes.value = [child, group, external];
+        stubs.calculateGraphAutoLayout.mockReturnValue(
+            new Map([
+                ['group', { x: 100, y: 200 }],
+                ['external', { x: 300, y: 700 }],
+            ]),
+        );
+        const fitGraph = vi.fn().mockImplementation(() => stubs.calls.push('fitGraph'));
+
+        await useGraphAutoLayout({
+            graphId: computed(() => 'graph-id'),
+            fitGraph,
+        }).autoLayoutGraph();
+
+        expect(stubs.calculateGraphAutoLayout.mock.calls[0]![0]).toEqual([
+            expect.objectContaining({ id: 'child', type: 'prompt', parentNode: 'group' }),
+            expect.objectContaining({ id: 'group', type: 'group', parentNode: undefined }),
+            expect.objectContaining({ id: 'external', type: 'prompt', parentNode: undefined }),
+        ]);
+        const updated = stubs.setNodes.mock.calls[0]![0] as GraphNode[];
+        expect(updated.map(({ id }) => id)).toEqual(['child', 'group', 'external']);
+        expect(updated[0]).toBe(child);
+        expect(updated[0]).toEqual(child);
+        expect(updated[1]).toEqual({ ...group, position: { x: 100, y: 200 } });
+        expect(updated[1]?.selected).toBe(true);
+        expect(updated[2]).toEqual({ ...external, position: { x: 300, y: 700 } });
+        expect(stubs.setNodes).toHaveBeenCalledOnce();
+        expect(fitGraph).toHaveBeenCalledOnce();
+        expect(stubs.saveGraph).toHaveBeenCalledOnce();
+        expect(stubs.calls).toEqual(['setNodes', 'nextTick', 'fitGraph', 'saveGraph']);
+    });
+
+    it('returns false without updating or fitting an empty graph', async () => {
+        const fitGraph = vi.fn();
+
+        const result = await useGraphAutoLayout({
+            graphId: computed(() => 'graph-id'),
+            fitGraph,
+        }).autoLayoutGraph();
+
+        expect(result).toBe(false);
+        expect(stubs.calculateGraphAutoLayout).not.toHaveBeenCalled();
+        expect(stubs.setNodes).not.toHaveBeenCalled();
+        expect(fitGraph).not.toHaveBeenCalled();
+        expect(stubs.saveGraph).not.toHaveBeenCalled();
+    });
+
+    it('propagates save failures after layout and fit complete', async () => {
+        stubs.nodes.value = [node('prompt')];
+        const failure = new Error('save failed');
+        stubs.saveGraph.mockImplementation(async () => {
+            stubs.calls.push('saveGraph');
+            throw failure;
+        });
+        const fitGraph = vi.fn().mockImplementation(() => stubs.calls.push('fitGraph'));
+
+        await expect(
+            useGraphAutoLayout({
+                graphId: computed(() => 'graph-id'),
+                fitGraph,
+            }).autoLayoutGraph(),
+        ).rejects.toBe(failure);
+
+        expect(stubs.saveGraph).toHaveBeenCalledOnce();
+        expect(stubs.calls).toEqual(['setNodes', 'nextTick', 'fitGraph', 'saveGraph']);
+    });
+});

--- a/ui/tests/nuxt/useGraphChat.spec.ts
+++ b/ui/tests/nuxt/useGraphChat.spec.ts
@@ -1,13 +1,18 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import type { GraphNode } from '@vue-flow/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NodeTypeEnum } from '@/types/enums';
 import { useGraphChat } from '@/composables/useGraphChat';
 
 const stubs = vi.hoisted(() => ({
-    findNode: vi.fn((nodeId: string) => ({
-        id: nodeId,
-        position: { x: 100, y: 200 },
-    })),
+    nodes: { value: [] as GraphNode[] },
+    edges: { value: [] as Array<{ source: string; target: string }> },
+    findNode: vi.fn((nodeId: string) =>
+        stubs.nodes.value.find((node) => node.id === nodeId) ?? {
+            id: nodeId,
+            position: { x: 100, y: 200 },
+        },
+    ),
     placeBlock: vi.fn((options: { blocId: string }) => ({
         id:
             options.blocId === 'primary-prompt-text'
@@ -23,7 +28,11 @@ const stubs = vi.hoisted(() => ({
 }));
 
 vi.mock('@vue-flow/core', () => ({
-    useVueFlow: () => ({ findNode: stubs.findNode }),
+    useVueFlow: () => ({
+        findNode: stubs.findNode,
+        getNodes: stubs.nodes,
+        getEdges: stubs.edges,
+    }),
 }));
 
 mockNuxtImport('useRoute', () => () => ({ params: { id: 'graph-id' } }));
@@ -39,15 +48,79 @@ mockNuxtImport('useGraphActions', () => () => ({
 mockNuxtImport('useGraphOverlaps', () => () => ({
     resolveOverlaps: stubs.resolveOverlaps,
 }));
+mockNuxtImport('useBlocks', () => () => ({
+    getBlockByNodeType: () => ({ minSize: { width: 100, height: 100 } }),
+}));
 
 describe('useGraphChat createNodeFromVariant', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.useFakeTimers();
+        stubs.nodes.value = [
+            {
+                id: 'source-node-id',
+                type: NodeTypeEnum.TEXT_TO_TEXT,
+                position: { x: 100, y: 200 },
+            } as GraphNode,
+        ];
+        stubs.edges.value = [];
+        const parentElement = document.createElement('div');
+        parentElement.dataset.id = 'source-node-id';
+        parentElement.style.height = '180px';
+        document.body.append(parentElement);
     });
 
     afterEach(() => {
         vi.useRealTimers();
+        document.body.replaceChildren();
+    });
+
+    it('places a generator below a generator parent without direct generator children', () => {
+        const { createNodeFromVariant } = useGraphChat();
+
+        createNodeFromVariant(NodeTypeEnum.TEXT_TO_TEXT, 'source-node-id', {
+            submission: { message: 'Prompt text', files: [], githubContext: null },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'primary-model-text-to-text',
+                positionFrom: { x: 100, y: 530 },
+            }),
+        );
+    });
+
+    it('places a generator right of the rightmost direct generator child', () => {
+        stubs.nodes.value.push(
+            {
+                id: 'direct-child',
+                type: NodeTypeEnum.ROUTING,
+                position: { x: 500, y: 600 },
+                dimensions: { width: 350, height: 100 },
+            } as GraphNode,
+            {
+                id: 'descendant',
+                type: NodeTypeEnum.PARALLELIZATION,
+                position: { x: 1200, y: 1000 },
+                width: 300,
+            } as GraphNode,
+        );
+        stubs.edges.value = [
+            { source: 'source-node-id', target: 'direct-child' },
+            { source: 'direct-child', target: 'descendant' },
+        ];
+        const { createNodeFromVariant } = useGraphChat();
+
+        createNodeFromVariant(NodeTypeEnum.ROUTING, 'source-node-id', {
+            submission: { message: 'Prompt text', files: [], githubContext: null },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'primary-model-routing',
+                positionFrom: { x: 1000, y: 600 },
+            }),
+        );
     });
 
     it('resolves the main node and attached prompt below collisions after the placement delay', async () => {

--- a/ui/tests/nuxt/useQuickWorkflow.spec.ts
+++ b/ui/tests/nuxt/useQuickWorkflow.spec.ts
@@ -9,9 +9,16 @@ import type { BlockDefinition } from '@/types/graph';
 
 const stubs = vi.hoisted(() => ({
     nodes: { value: [] as GraphNode[] },
-    edges: { value: [] as Array<{ target: string; targetHandle: string }> },
+    edges: {
+        value: [] as Array<{
+            source: string;
+            target: string;
+            targetHandle?: string;
+        }>,
+    },
     placeBlock: vi.fn(),
     placeEdge: vi.fn(),
+    resolveOverlaps: vi.fn(),
 }));
 
 vi.mock('@vue-flow/core', () => ({
@@ -26,7 +33,7 @@ mockNuxtImport('useGraphActions', () => () => ({
 mockNuxtImport('useEdgeCompatibility', () => () => ({
     acceptsMultipleInputEdges: () => false,
 }));
-mockNuxtImport('useGraphOverlaps', () => () => ({ resolveOverlaps: vi.fn() }));
+mockNuxtImport('useGraphOverlaps', () => () => ({ resolveOverlaps: stubs.resolveOverlaps }));
 mockNuxtImport('useBlocks', () => () => ({
     getBlockByNodeType: (nodeType: NodeTypeEnum) =>
         ({
@@ -43,14 +50,28 @@ mockNuxtImport('useBlocks', () => () => ({
 
 describe('useQuickWorkflow availability', () => {
     beforeEach(() => {
+        vi.clearAllMocks();
         stubs.nodes.value = [
             {
                 id: 'anchor',
                 type: NodeTypeEnum.TEXT_TO_TEXT,
                 position: { x: 0, y: 0 },
+                dimensions: { width: 320, height: 180 },
             } as GraphNode,
         ];
         stubs.edges.value = [];
+        stubs.placeBlock.mockImplementation(
+            (options: {
+                positionFrom: { x: number; y: number };
+                positionOffset?: { x: number; y: number };
+            }) => ({
+                id: 'quick-main-id',
+                position: {
+                    x: options.positionFrom.x + (options.positionOffset?.x ?? 0),
+                    y: options.positionFrom.y + (options.positionOffset?.y ?? 0),
+                },
+            }),
+        );
     });
 
     it('uses creation validation for valid, invalid, missing, and occupied anchors', () => {
@@ -71,7 +92,96 @@ describe('useQuickWorkflow availability', () => {
         ).toBe(false);
         expect(canCreateQuickWorkflow({ ...validPayload, fromNodeId: 'missing' })).toBe(false);
 
-        stubs.edges.value = [{ target: 'anchor', targetHandle: 'prompt_anchor' }];
+        stubs.edges.value = [
+            { source: 'occupied-source', target: 'anchor', targetHandle: 'prompt_anchor' },
+        ];
         expect(canCreateQuickWorkflow(validPayload)).toBe(false);
+    });
+
+    it('places a context source generator below an anchor without generator children', () => {
+        const { createQuickWorkflow } = useQuickWorkflow(ref('graph-id'));
+
+        createQuickWorkflow({
+            fromNodeId: 'anchor',
+            category: NodeCategoryEnum.CONTEXT,
+            direction: 'source',
+            slot: {
+                name: 'Generator',
+                mainBloc: NodeTypeEnum.TEXT_TO_TEXT,
+                options: [],
+            },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'block-textToText',
+                positionFrom: { x: 0, y: 330 },
+                positionOffset: undefined,
+            }),
+        );
+    });
+
+    it('places a context source generator right of the rightmost direct generator child', () => {
+        stubs.nodes.value.push(
+            {
+                id: 'direct-child',
+                type: NodeTypeEnum.ROUTING,
+                position: { x: 500, y: 600 },
+                dimensions: { width: 350, height: 100 },
+            } as GraphNode,
+            {
+                id: 'descendant',
+                type: NodeTypeEnum.PARALLELIZATION,
+                position: { x: 1200, y: 1000 },
+                width: 300,
+            } as GraphNode,
+        );
+        stubs.edges.value = [
+            { source: 'anchor', target: 'direct-child' },
+            { source: 'direct-child', target: 'descendant' },
+        ];
+        const { createQuickWorkflow } = useQuickWorkflow(ref('graph-id'));
+
+        createQuickWorkflow({
+            fromNodeId: 'anchor',
+            category: NodeCategoryEnum.CONTEXT,
+            direction: 'source',
+            slot: {
+                name: 'Generator',
+                mainBloc: NodeTypeEnum.ROUTING,
+                options: [],
+            },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'block-routing',
+                positionFrom: { x: 1000, y: 600 },
+                positionOffset: undefined,
+            }),
+        );
+    });
+
+    it('keeps target-direction workflow placement unchanged', () => {
+        const { createQuickWorkflow } = useQuickWorkflow(ref('graph-id'));
+
+        createQuickWorkflow({
+            fromNodeId: 'anchor',
+            category: NodeCategoryEnum.CONTEXT,
+            direction: 'target',
+            slot: {
+                name: 'Generator',
+                mainBloc: NodeTypeEnum.PARALLELIZATION,
+                options: [],
+            },
+        });
+
+        expect(stubs.placeBlock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                blocId: 'block-parallelization',
+                positionFrom: { x: 0, y: 0 },
+                positionOffset: { x: 0, y: -250 },
+            }),
+        );
     });
 });

--- a/ui/tests/unit/graphAutoLayout.spec.ts
+++ b/ui/tests/unit/graphAutoLayout.spec.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it } from 'vitest';
+
+import { NodeTypeEnum } from '@/types/enums';
+import {
+    calculateGraphAutoLayout,
+    GRAPH_AUTO_LAYOUT_COMPONENT_SEPARATION,
+    GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+    type GraphAutoLayoutEdge,
+    type GraphAutoLayoutNode,
+} from '@/utils/graphAutoLayout';
+
+const node = (
+    id: string,
+    width = 100,
+    height = 100,
+    position = { x: 40, y: 60 },
+    parentNode?: string,
+): GraphAutoLayoutNode => ({ id, width, height, position, parentNode });
+
+const typedNode = (
+    id: string,
+    type: NodeTypeEnum,
+    width = 100,
+    height = 100,
+): GraphAutoLayoutNode => ({ ...node(id, width, height), type });
+
+const edge = (
+    id: string,
+    source: string,
+    target: string,
+    sourceHandle?: string | null,
+    targetHandle?: string | null,
+): GraphAutoLayoutEdge => ({
+    id,
+    source,
+    target,
+    sourceHandle,
+    targetHandle,
+});
+
+const overlap = (
+    left: GraphAutoLayoutNode,
+    leftPosition: { x: number; y: number },
+    right: GraphAutoLayoutNode,
+    rightPosition: { x: number; y: number },
+) =>
+    leftPosition.x < rightPosition.x + right.width &&
+    leftPosition.x + left.width > rightPosition.x &&
+    leftPosition.y < rightPosition.y + right.height &&
+    leftPosition.y + left.height > rightPosition.y;
+
+const expectNoOverlaps = (
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => {
+    for (let leftIndex = 0; leftIndex < nodes.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < nodes.length; rightIndex += 1) {
+            const left = nodes[leftIndex];
+            const right = nodes[rightIndex];
+            if (!left || !right) continue;
+            const leftPosition = positions.get(left.id);
+            const rightPosition = positions.get(right.id);
+            expect(leftPosition).toBeDefined();
+            expect(rightPosition).toBeDefined();
+            expect(overlap(left, leftPosition!, right, rightPosition!)).toBe(false);
+        }
+    }
+};
+
+describe('calculateGraphAutoLayout', () => {
+    it('lays out production GraphChat edges as ordered stages with a generator spine', () => {
+        const nodes = [
+            typedNode('prompt1', NodeTypeEnum.PROMPT, 180, 100),
+            typedNode('attachment', NodeTypeEnum.FILE_PROMPT, 140, 80),
+            typedNode('generator1', NodeTypeEnum.TEXT_TO_TEXT, 240, 140),
+            typedNode('prompt2', NodeTypeEnum.PROMPT, 200, 90),
+            typedNode('generator2', NodeTypeEnum.TEXT_TO_TEXT, 260, 160),
+        ];
+        const edges = [
+            edge('prompt1-generator1', 'prompt1', 'generator1', null, 'prompt_generator1'),
+            edge('attachment-generator1', 'attachment', 'generator1', null, 'attachment_generator1'),
+            edge('generator1-generator2', 'generator1', 'generator2', null, 'context_generator2'),
+            edge('prompt2-generator2', 'prompt2', 'generator2', null, 'prompt_generator2'),
+        ];
+        const originalNodes = structuredClone(nodes);
+        const originalEdges = structuredClone(edges);
+
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const shuffled = calculateGraphAutoLayout(
+            [nodes[4]!, nodes[2]!, nodes[0]!, nodes[3]!, nodes[1]!],
+            [edges[2]!, edges[0]!, edges[3]!, edges[1]!],
+        );
+        const position = (id: string) => positions.get(id)!;
+        const dimensions = (id: string) => nodes.find((candidate) => candidate.id === id)!;
+        const centerX = (id: string) => position(id).x + dimensions(id).width / 2;
+        const centerY = (id: string) => position(id).y + dimensions(id).height / 2;
+
+        expect([...shuffled]).toEqual([...positions]);
+        expect(nodes).toEqual(originalNodes);
+        expect(edges).toEqual(originalEdges);
+        expect(position('generator1').y).toBeGreaterThan(
+            position('prompt1').y + dimensions('prompt1').height,
+        );
+        expect(centerY('attachment')).toBe(centerY('generator1'));
+        expect(
+            position('attachment').x +
+                dimensions('attachment').width +
+                GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+        ).toBeLessThanOrEqual(position('generator1').x);
+        expect(centerX('generator1')).toBe(centerX('generator2'));
+        expect(position('prompt2').y).toBeGreaterThan(
+            position('generator1').y + dimensions('generator1').height,
+        );
+        expect(position('generator2').y).toBeGreaterThan(
+            position('prompt2').y + dimensions('prompt2').height,
+        );
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('aligns mixed serial generator types on one exact center-X spine', () => {
+        const nodes = [
+            typedNode('text', NodeTypeEnum.TEXT_TO_TEXT, 220, 120),
+            typedNode('parallel', NodeTypeEnum.PARALLELIZATION, 260, 140),
+            typedNode('routing', NodeTypeEnum.ROUTING, 180, 100),
+        ];
+        const positions = calculateGraphAutoLayout(nodes, [
+            edge('text-parallel', 'text', 'parallel', null, 'context_parallel'),
+            edge('parallel-routing', 'parallel', 'routing', null, 'context_routing'),
+        ]);
+        const centerX = (id: string) =>
+            positions.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width / 2;
+
+        expect(centerX('text')).toBe(centerX('parallel'));
+        expect(centerX('parallel')).toBe(centerX('routing'));
+        expect(positions.get('parallel')!.y).toBeGreaterThan(positions.get('text')!.y + 120);
+        expect(positions.get('routing')!.y).toBeGreaterThan(positions.get('parallel')!.y + 140);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('infers only compatible missing-source categories from production node types', () => {
+        const cases: Array<{ type: NodeTypeEnum; category: string; lateral: boolean }> = [
+            { type: NodeTypeEnum.PROMPT, category: 'prompt', lateral: false },
+            { type: NodeTypeEnum.FILE_PROMPT, category: 'attachment', lateral: true },
+            { type: NodeTypeEnum.GITHUB, category: 'attachment', lateral: true },
+            { type: NodeTypeEnum.TEXT_TO_TEXT, category: 'context', lateral: false },
+            { type: NodeTypeEnum.PARALLELIZATION, category: 'context', lateral: false },
+            { type: NodeTypeEnum.ROUTING, category: 'context', lateral: false },
+            { type: NodeTypeEnum.CONTEXT_MERGER, category: 'context', lateral: false },
+        ];
+        for (const { type, category, lateral } of cases) {
+            const nodes = [typedNode('source', type), node('target')];
+            const positions = calculateGraphAutoLayout(nodes, [
+                edge('edge', 'source', 'target', null, `${category}_target`),
+            ]);
+            if (lateral) {
+                expect(positions.get('source')!.y).toBe(positions.get('target')!.y);
+                expect(positions.get('source')!.x + 100).toBeLessThan(positions.get('target')!.x);
+            } else {
+                expect(positions.get('target')!.y).toBeGreaterThan(positions.get('source')!.y + 100);
+            }
+            expectNoOverlaps(nodes, positions);
+        }
+    });
+
+    it('keeps attachment-only chains on one row in left-to-right order', () => {
+        const nodes = [node('a', 80, 120), node('b', 160, 80), node('c', 110, 140)];
+        const positions = calculateGraphAutoLayout(nodes, [
+            edge('a-b', 'a', 'b', 'attachment_a', 'attachment_b'),
+            edge('b-c', 'b', 'c', 'attachment_b', 'attachment_c'),
+        ]);
+        const centerY = (id: string) =>
+            positions.get(id)!.y + nodes.find((candidate) => candidate.id === id)!.height / 2;
+
+        expect(centerY('a')).toBe(centerY('b'));
+        expect(centerY('b')).toBe(centerY('c'));
+        expect(positions.get('a')!.x + 80).toBeLessThan(positions.get('b')!.x);
+        expect(positions.get('b')!.x + 160).toBeLessThan(positions.get('c')!.x);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('flattens attachment fan-out and fan-in without overlap', () => {
+        const nodes = [node('source'), node('branch-a'), node('branch-b'), node('target')];
+        const positions = calculateGraphAutoLayout(nodes, [
+            edge('source-a', 'source', 'branch-a', 'attachment_source', 'attachment_branch-a'),
+            edge('source-b', 'source', 'branch-b', 'attachment_source', 'attachment_branch-b'),
+            edge('a-target', 'branch-a', 'target', 'attachment_branch-a', 'attachment_target'),
+            edge('b-target', 'branch-b', 'target', 'attachment_branch-b', 'attachment_target'),
+        ]);
+        const yValues = new Set([...positions.values()].map(({ y }) => y));
+
+        expect(yValues.size).toBe(1);
+        expect(positions.get('branch-a')!.x).toBeGreaterThan(positions.get('source')!.x + 100);
+        expect(positions.get('branch-b')!.x).toBeGreaterThan(positions.get('source')!.x + 100);
+        expect(positions.get('target')!.x).toBeGreaterThan(positions.get('branch-a')!.x + 100);
+        expect(positions.get('target')!.x).toBeGreaterThan(positions.get('branch-b')!.x + 100);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('uses vertical fallback for incomplete, malformed, unknown, and mixed handles', () => {
+        const handlePairs: Array<[string | null | undefined, string | null | undefined]> = [
+            [undefined, undefined],
+            ['attachment_source', undefined],
+            ['attachment_', 'attachment_target'],
+            ['unknown_source', 'unknown_target'],
+            ['attachment_source', 'prompt_target'],
+        ];
+
+        for (const [sourceHandle, targetHandle] of handlePairs) {
+            const nodes = [node('source'), node('target')];
+            const positions = calculateGraphAutoLayout(nodes, [
+                edge('edge', 'source', 'target', sourceHandle, targetHandle),
+            ]);
+            expect(positions.get('target')!.y).toBeGreaterThan(positions.get('source')!.y + 100);
+            expectNoOverlaps(nodes, positions);
+        }
+
+        const typedSource = typedNode('source', NodeTypeEnum.FILE_PROMPT);
+        for (const [sourceHandle, targetHandle] of [
+            ['', 'attachment_target'],
+            ['attachment_', 'attachment_target'],
+            ['prompt_source', 'attachment_target'],
+            [null, 'attachment_'],
+            [null, 'unknown_target'],
+        ] as Array<[string | null, string]>) {
+            const positions = calculateGraphAutoLayout([typedSource, node('target')], [
+                edge('edge', 'source', 'target', sourceHandle, targetHandle),
+            ]);
+            expect(positions.get('target')!.y).toBeGreaterThan(positions.get('source')!.y + 100);
+        }
+    });
+
+    it('keeps generator branches translated while aligning downstream serial segments', () => {
+        const nodes = [
+            typedNode('root', NodeTypeEnum.TEXT_TO_TEXT, 200, 100),
+            typedNode('branch-a', NodeTypeEnum.PARALLELIZATION, 180, 120),
+            typedNode('branch-b', NodeTypeEnum.ROUTING, 240, 120),
+            typedNode('after-a', NodeTypeEnum.TEXT_TO_TEXT, 220, 100),
+            typedNode('after-b', NodeTypeEnum.TEXT_TO_TEXT, 160, 100),
+        ];
+        const positions = calculateGraphAutoLayout(nodes, [
+            edge('root-a', 'root', 'branch-a', null, 'context_branch-a'),
+            edge('root-b', 'root', 'branch-b', null, 'context_branch-b'),
+            edge('a-after', 'branch-a', 'after-a', null, 'context_after-a'),
+            edge('b-after', 'branch-b', 'after-b', null, 'context_after-b'),
+        ]);
+        const centerX = (id: string) =>
+            positions.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width / 2;
+
+        expect(centerX('branch-a')).toBe(centerX('after-a'));
+        expect(centerX('branch-b')).toBe(centerX('after-b'));
+        expect(centerX('branch-a')).not.toBe(centerX('branch-b'));
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('falls back deterministically for generator cycles and conflicting prompt stages', () => {
+        const nodes = [
+            typedNode('generator-a', NodeTypeEnum.TEXT_TO_TEXT),
+            typedNode('generator-b', NodeTypeEnum.ROUTING),
+            typedNode('prompt-a', NodeTypeEnum.PROMPT),
+            typedNode('prompt-b', NodeTypeEnum.PROMPT),
+        ];
+        const edges = [
+            edge('a-b', 'generator-a', 'generator-b', null, 'context_generator-b'),
+            edge('b-a', 'generator-b', 'generator-a', null, 'context_generator-a'),
+            edge('prompt-a', 'prompt-a', 'generator-b', null, 'prompt_generator-b'),
+            edge('prompt-b', 'prompt-b', 'generator-b', null, 'prompt_generator-b'),
+        ];
+        const first = calculateGraphAutoLayout(nodes, edges);
+        const second = calculateGraphAutoLayout(nodes, edges);
+
+        expect([...second]).toEqual([...first]);
+        expect([...first.values()].every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(true);
+        expectNoOverlaps(nodes, first);
+    });
+
+    it('preserves vertical participant rows and uses stable nearest-anchor ties', () => {
+        const nodes = [node('anchor-a'), node('anchor-b'), node('middle', 120, 80)];
+        const positions = calculateGraphAutoLayout(nodes, [
+            edge('vertical', 'anchor-a', 'anchor-b', 'prompt_anchor-a', 'prompt_anchor-b'),
+            edge(
+                'lateral-a',
+                'anchor-a',
+                'middle',
+                'attachment_anchor-a',
+                'attachment_middle',
+            ),
+            edge(
+                'lateral-b',
+                'middle',
+                'anchor-b',
+                'attachment_middle',
+                'attachment_anchor-b',
+            ),
+        ]);
+        const centerY = (id: string) =>
+            positions.get(id)!.y + nodes.find((candidate) => candidate.id === id)!.height / 2;
+
+        expect(centerY('middle')).toBe(centerY('anchor-a'));
+        expect(centerY('anchor-b')).toBeGreaterThan(centerY('anchor-a'));
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('keeps same-pair mixed constraints and lateral cycles deterministic', () => {
+        const nodes = [node('a'), node('b'), node('c')];
+        const edges = [
+            edge('vertical-a-b', 'a', 'b', 'context_a', 'context_b'),
+            edge('lateral-a-b', 'a', 'b', 'attachment_a', 'attachment_b'),
+            edge('lateral-b-c', 'b', 'c', 'attachment_b', 'attachment_c'),
+            edge('lateral-c-a', 'c', 'a', 'attachment_c', 'attachment_a'),
+        ];
+        const originalEdges = structuredClone(edges);
+        const first = calculateGraphAutoLayout(nodes, edges);
+        const second = calculateGraphAutoLayout(nodes, edges);
+
+        expect([...second]).toEqual([...first]);
+        expect(first.get('b')!.y).toBeGreaterThan(first.get('a')!.y + 100);
+        expect(edges).toEqual(originalEdges);
+        expectNoOverlaps(nodes, first);
+    });
+
+    it('lays out a branched DAG top-to-bottom and ignores order and layout-only edge noise', () => {
+        const nodes = [node('root', 180, 80), node('left', 120, 140), node('right', 240, 90)];
+        const edges = [
+            edge('root-left', 'root', 'left'),
+            edge('root-right', 'root', 'right'),
+            edge('duplicate', 'root', 'right'),
+            edge('self', 'left', 'left'),
+            edge('dangling', 'missing', 'right'),
+        ];
+        const originalEdges = structuredClone(edges);
+
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const shuffled = calculateGraphAutoLayout(
+            [nodes[2]!, nodes[0]!, nodes[1]!],
+            [edges[4]!, edges[2]!, edges[1]!, edges[3]!, edges[0]!],
+        );
+
+        expect([...shuffled]).toEqual([...positions]);
+        expect(edges).toEqual(originalEdges);
+        expect(positions.get('left')!.y).toBeGreaterThan(
+            positions.get('root')!.y + nodes[0]!.height,
+        );
+        expect(positions.get('right')!.y).toBeGreaterThan(
+            positions.get('root')!.y + nodes[0]!.height,
+        );
+        expect(positions.get('left')!.x).not.toBe(positions.get('right')!.x);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('places multiple roots before their shared descendant', () => {
+        const nodes = [node('root-a'), node('root-b'), node('shared', 160, 120)];
+        const positions = calculateGraphAutoLayout(nodes, [
+            edge('a-shared', 'root-a', 'shared'),
+            edge('b-shared', 'root-b', 'shared'),
+        ]);
+
+        expect(positions.get('root-a')!.y).toBe(positions.get('root-b')!.y);
+        expect(positions.get('shared')!.y).toBeGreaterThan(positions.get('root-a')!.y + 100);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('produces finite deterministic non-overlapping positions for directed cycles', () => {
+        const nodes = [node('a', 110, 80), node('b', 160, 120), node('c', 90, 150)];
+        const edges = [edge('a-b', 'a', 'b'), edge('b-c', 'b', 'c'), edge('c-a', 'c', 'a')];
+        const originalEdges = structuredClone(edges);
+        const first = calculateGraphAutoLayout(nodes, edges);
+        const second = calculateGraphAutoLayout(nodes, edges);
+
+        expect([...second]).toEqual([...first]);
+        expect(edges).toEqual(originalEdges);
+        for (const position of first.values()) {
+            expect(Number.isFinite(position.x)).toBe(true);
+            expect(Number.isFinite(position.y)).toBe(true);
+        }
+        expectNoOverlaps(nodes, first);
+    });
+
+    it('packs disconnected components and isolated nodes into deterministic shelves', () => {
+        const nodes = Array.from({ length: 9 }, (_, index) =>
+            node(`isolated-${index}`, 100, 100, { x: -30, y: 15 }),
+        );
+        const positions = calculateGraphAutoLayout(nodes, []);
+        const xValues = [...new Set([...positions.values()].map(({ x }) => x))];
+        const yValues = [...new Set([...positions.values()].map(({ y }) => y))];
+
+        expect(xValues.length).toBeGreaterThan(1);
+        expect(yValues.length).toBeGreaterThan(1);
+        expect(Math.min(...xValues)).toBe(-30);
+        expect(Math.min(...yValues)).toBe(15);
+        expect(Math.max(...xValues) - Math.min(...xValues)).toBeLessThan(
+            nodes.length * (100 + GRAPH_AUTO_LAYOUT_COMPONENT_SEPARATION),
+        );
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('treats outer groups atomically and maps child edges to the group', () => {
+        const group = node('group', 420, 300, { x: 250, y: 175 });
+        const child = {
+            ...node('child', 100, 80, { x: 40, y: 50 }, 'group'),
+            type: NodeTypeEnum.FILE_PROMPT,
+        };
+        const external = node('external', 180, 100, { x: 900, y: 900 });
+        const positions = calculateGraphAutoLayout(
+            [child, external, group],
+            [edge('child-external', 'child', 'external'), edge('internal', 'group', 'child')],
+        );
+
+        expect([...positions.keys()].sort()).toEqual(['external', 'group']);
+        expect(positions.has('child')).toBe(false);
+        expect(positions.get('group')).toEqual({ x: 250, y: 175 });
+        expect(positions.get('external')!.y).toBeGreaterThan(175 + group.height);
+        expectNoOverlaps([group, external], positions);
+
+        const lateralPositions = calculateGraphAutoLayout(
+            [child, external, group],
+            [
+                edge(
+                    'external-child',
+                    'child',
+                    'external',
+                    null,
+                    'attachment_external',
+                ),
+            ],
+        );
+        expect([...lateralPositions.keys()].sort()).toEqual(['external', 'group']);
+        expect(lateralPositions.has('child')).toBe(false);
+        expect(
+            lateralPositions.get('external')!.y + external.height / 2,
+        ).toBe(lateralPositions.get('group')!.y + group.height / 2);
+        expect(lateralPositions.get('group')!.x + group.width).toBeLessThan(
+            lateralPositions.get('external')!.x,
+        );
+        expectNoOverlaps([group, external], lateralPositions);
+    });
+
+    it('accounts for variable dimensions and preserves the finite canvas anchor', () => {
+        const nodes = [
+            node('wide', 500, 70, { x: 400, y: 300 }),
+            node('tall', 90, 500, { x: 600, y: 700 }),
+            node('small', 40, 30, { x: 800, y: 900 }),
+        ];
+        const positions = calculateGraphAutoLayout(nodes, [
+            edge('wide-tall', 'wide', 'tall'),
+            edge('wide-small', 'wide', 'small'),
+        ]);
+
+        expect(Math.min(...[...positions.values()].map(({ x }) => x))).toBe(400);
+        expect(Math.min(...[...positions.values()].map(({ y }) => y))).toBe(300);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('handles a sizable deterministic graph with finite branch geometry', () => {
+        const nodes = Array.from({ length: 120 }, (_, index) =>
+            typedNode(`node-${index.toString().padStart(3, '0')}`, NodeTypeEnum.TEXT_TO_TEXT, 120, 80),
+        );
+        const edges = nodes.slice(1).map((target, index) =>
+            edge(
+                `edge-${index}`,
+                nodes[Math.floor(index / 2)]!.id,
+                target.id,
+                null,
+                `context_${target.id}`,
+            ),
+        );
+        const first = calculateGraphAutoLayout(nodes, edges);
+        const second = calculateGraphAutoLayout([...nodes].reverse(), [...edges].reverse());
+
+        expect(first.size).toBe(nodes.length);
+        expect([...second]).toEqual([...first]);
+        expect([...first.values()].every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(true);
+        expect(new Set([...first.values()].map(({ x }) => x)).size).toBeGreaterThan(2);
+    });
+});

--- a/ui/tests/unit/graphAutoLayoutAttachmentStacks.spec.ts
+++ b/ui/tests/unit/graphAutoLayoutAttachmentStacks.spec.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it } from 'vitest';
+
+import { NodeTypeEnum } from '@/types/enums';
+import {
+    calculateGraphAutoLayout,
+    GRAPH_AUTO_LAYOUT_EDGE_SEPARATION,
+    GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+    GRAPH_AUTO_LAYOUT_RANK_SEPARATION,
+    type GraphAutoLayoutEdge,
+    type GraphAutoLayoutNode,
+} from '@/utils/graphAutoLayout';
+import {
+    partitionAttachmentStackSubgraphs,
+    placeAttachmentStacks,
+} from '@/utils/graphAutoLayoutAttachmentStacks';
+
+const node = (
+    id: string,
+    type: NodeTypeEnum,
+    width: number,
+    height: number,
+): GraphAutoLayoutNode => ({ id, type, width, height, position: { x: 40, y: 60 } });
+
+const edge = (
+    id: string,
+    source: string,
+    target: string,
+    category: 'attachment' | 'context' | 'prompt',
+): GraphAutoLayoutEdge => ({
+    id,
+    source,
+    target,
+    sourceHandle: null,
+    targetHandle: `${category}_${target}`,
+});
+
+const expectNoOverlaps = (
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => {
+    for (let leftIndex = 0; leftIndex < nodes.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < nodes.length; rightIndex += 1) {
+            const left = nodes[leftIndex]!;
+            const right = nodes[rightIndex]!;
+            const leftPosition = positions.get(left.id)!;
+            const rightPosition = positions.get(right.id)!;
+            expect(
+                leftPosition.x < rightPosition.x + right.width &&
+                    leftPosition.x + left.width > rightPosition.x &&
+                    leftPosition.y < rightPosition.y + right.height &&
+                    leftPosition.y + left.height > rightPosition.y,
+            ).toBe(false);
+        }
+    }
+};
+
+describe('graph auto-layout attachment stacks', () => {
+    it('qualifies a direct singleton attachment group for target-local placement', () => {
+        const nodes = [
+            node('singleton-file', NodeTypeEnum.FILE_PROMPT, 140, 60),
+            node('generator', NodeTypeEnum.TEXT_TO_TEXT, 220, 120),
+        ];
+        const subgraph = {
+            members: ['generator', 'singleton-file'],
+            edges: [
+                { source: 'singleton-file', target: 'generator', category: 'attachment' as const },
+            ],
+        };
+
+        expect(partitionAttachmentStackSubgraphs([subgraph], nodes, new Set(['generator']))).toEqual({
+            stacks: [{ targetId: 'generator', sourceIds: ['singleton-file'] }],
+            fallback: [],
+        });
+    });
+
+    it('stacks production FilePrompt and GitHub inputs beside the generator spine', () => {
+        const nodes = [
+            node('prompt1', NodeTypeEnum.PROMPT, 280, 100),
+            node('attachment-file', NodeTypeEnum.FILE_PROMPT, 140, 80),
+            node('attachment-github', NodeTypeEnum.GITHUB, 200, 120),
+            node('generator1', NodeTypeEnum.TEXT_TO_TEXT, 240, 140),
+            node('prompt2', NodeTypeEnum.PROMPT, 180, 90),
+            node('generator2', NodeTypeEnum.TEXT_TO_TEXT, 260, 160),
+        ];
+        const edges = [
+            edge('prompt1-generator1', 'prompt1', 'generator1', 'prompt'),
+            edge('file-generator1', 'attachment-file', 'generator1', 'attachment'),
+            edge('github-generator1', 'attachment-github', 'generator1', 'attachment'),
+            edge('generator1-generator2', 'generator1', 'generator2', 'context'),
+            edge('prompt2-generator2', 'prompt2', 'generator2', 'prompt'),
+        ];
+        const originalNodes = structuredClone(nodes);
+        const originalEdges = structuredClone(edges);
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const shuffled = calculateGraphAutoLayout([...nodes].reverse(), [...edges].reverse());
+        const position = (id: string) => positions.get(id)!;
+        const dimensions = (id: string) => nodes.find((candidate) => candidate.id === id)!;
+        const centerX = (id: string) => position(id).x + dimensions(id).width / 2;
+        const centerY = (id: string) => position(id).y + dimensions(id).height / 2;
+        const right = (id: string) => position(id).x + dimensions(id).width;
+
+        expect([...shuffled]).toEqual([...positions]);
+        expect(nodes).toEqual(originalNodes);
+        expect(edges).toEqual(originalEdges);
+        expect(position('attachment-file').y + 80 + GRAPH_AUTO_LAYOUT_EDGE_SEPARATION).toBe(
+            position('attachment-github').y,
+        );
+        expect(right('attachment-file')).toBe(right('attachment-github'));
+        expect(
+            (position('attachment-file').y + position('attachment-github').y + 120) / 2,
+        ).toBe(centerY('generator1'));
+        expect(position('generator1').x - right('attachment-file')).toBe(
+            GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+        );
+        expect(centerX('generator1')).toBe(centerX('generator2'));
+        expect(position('generator1').y - (position('prompt1').y + 100)).toBe(
+            GRAPH_AUTO_LAYOUT_RANK_SEPARATION,
+        );
+        expect(position('prompt2').y - (position('generator1').y + 140)).toBe(
+            GRAPH_AUTO_LAYOUT_RANK_SEPARATION,
+        );
+        expect(position('generator2').y - (position('prompt2').y + 90)).toBe(
+            GRAPH_AUTO_LAYOUT_RANK_SEPARATION,
+        );
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('reserves local envelopes for mixed stacks inside a dense fan-out composite', () => {
+        const nodes = [
+            node('root', NodeTypeEnum.TEXT_TO_TEXT, 600, 300),
+            node('prompt-a', NodeTypeEnum.PROMPT, 500, 200),
+            node('top-a', NodeTypeEnum.TEXT_TO_TEXT, 600, 300),
+            node('a-file', NodeTypeEnum.FILE_PROMPT, 500, 275),
+            node('prompt-b', NodeTypeEnum.PROMPT, 500, 200),
+            node('top-b', NodeTypeEnum.ROUTING, 600, 300),
+            node('prompt-c', NodeTypeEnum.PROMPT, 500, 200),
+            node('top-c', NodeTypeEnum.TEXT_TO_TEXT, 600, 300),
+            node('c-file', NodeTypeEnum.FILE_PROMPT, 500, 275),
+            node('prompt-d', NodeTypeEnum.PROMPT, 500, 200),
+            node('top-d', NodeTypeEnum.ROUTING, 600, 300),
+            node('prompt-e', NodeTypeEnum.PROMPT, 500, 200),
+            node('top-e', NodeTypeEnum.ROUTING, 600, 300),
+            node('prompt-lower-d', NodeTypeEnum.PROMPT, 500, 200),
+            node('lower-d', NodeTypeEnum.TEXT_TO_TEXT, 600, 300),
+            node('d-file', NodeTypeEnum.FILE_PROMPT, 500, 275),
+            node('d-github', NodeTypeEnum.GITHUB, 500, 250),
+            node('prompt-tail-d', NodeTypeEnum.PROMPT, 500, 200),
+            node('tail-d', NodeTypeEnum.TEXT_TO_TEXT, 600, 300),
+            node('prompt-lower-e', NodeTypeEnum.PROMPT, 500, 200),
+            node('lower-e', NodeTypeEnum.TEXT_TO_TEXT, 600, 300),
+            node('e-file-a', NodeTypeEnum.FILE_PROMPT, 500, 275),
+            node('e-file-b', NodeTypeEnum.FILE_PROMPT, 500, 275),
+            node('e-github', NodeTypeEnum.GITHUB, 500, 250),
+            node('prompt-tail-e', NodeTypeEnum.PROMPT, 500, 200),
+            node('tail-e', NodeTypeEnum.TEXT_TO_TEXT, 600, 300),
+        ];
+        const edges = [
+            ...['a', 'b', 'c', 'd', 'e'].flatMap((suffix) => [
+                edge(`root-${suffix}`, 'root', `top-${suffix}`, 'context'),
+                edge(`prompt-${suffix}-edge`, `prompt-${suffix}`, `top-${suffix}`, 'prompt'),
+            ]),
+            edge('top-d-lower-d', 'top-d', 'lower-d', 'context'),
+            edge('prompt-lower-d-edge', 'prompt-lower-d', 'lower-d', 'prompt'),
+            edge('lower-d-tail-d', 'lower-d', 'tail-d', 'context'),
+            edge('prompt-tail-d-edge', 'prompt-tail-d', 'tail-d', 'prompt'),
+            edge('top-e-lower-e', 'top-e', 'lower-e', 'context'),
+            edge('prompt-lower-e-edge', 'prompt-lower-e', 'lower-e', 'prompt'),
+            edge('lower-e-tail-e', 'lower-e', 'tail-e', 'context'),
+            edge('prompt-tail-e-edge', 'prompt-tail-e', 'tail-e', 'prompt'),
+            edge('a-file-edge', 'a-file', 'top-a', 'attachment'),
+            edge('c-file-edge', 'c-file', 'top-c', 'attachment'),
+            edge('d-file-edge', 'd-file', 'lower-d', 'attachment'),
+            edge('d-github-edge', 'd-github', 'lower-d', 'attachment'),
+            edge('e-file-a-edge', 'e-file-a', 'lower-e', 'attachment'),
+            edge('e-file-b-edge', 'e-file-b', 'lower-e', 'attachment'),
+            edge('e-github-edge', 'e-github', 'lower-e', 'attachment'),
+        ];
+        const originalNodes = structuredClone(nodes);
+        const originalEdges = structuredClone(edges);
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const reversed = calculateGraphAutoLayout([...nodes].reverse(), [...edges].reverse());
+        const dimensions = (id: string) => nodes.find((candidate) => candidate.id === id)!;
+        const right = (id: string) => positions.get(id)!.x + dimensions(id).width;
+        const centerY = (id: string) => positions.get(id)!.y + dimensions(id).height / 2;
+        const groups = [
+            { targetId: 'top-a', sourceIds: ['a-file'] },
+            { targetId: 'top-c', sourceIds: ['c-file'] },
+            { targetId: 'lower-d', sourceIds: ['d-file', 'd-github'] },
+            { targetId: 'lower-e', sourceIds: ['e-file-a', 'e-file-b', 'e-github'] },
+        ];
+
+        expect([...reversed]).toEqual([...positions]);
+        expect(nodes).toEqual(originalNodes);
+        expect(edges).toEqual(originalEdges);
+        for (const { targetId, sourceIds } of groups) {
+            expect(new Set(sourceIds.map(right)).size).toBe(1);
+            expect(positions.get(targetId)!.x - right(sourceIds[0]!), targetId).toBe(
+                GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+            );
+            const groupTop = positions.get(sourceIds[0]!)!.y;
+            const lastSourceId = sourceIds[sourceIds.length - 1]!;
+            const groupBottom = positions.get(lastSourceId)!.y + dimensions(lastSourceId).height;
+            expect(
+                Math.abs((groupTop + groupBottom) / 2 - centerY(targetId)),
+                targetId,
+            ).toBeLessThanOrEqual(0.5);
+        }
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('right-aligns three variable-sized sources in stable lexical order', () => {
+        const nodes = [
+            node('prompt', NodeTypeEnum.PROMPT, 500, 80),
+            node('attachment-c', NodeTypeEnum.GITHUB, 120, 60),
+            node('attachment-a', NodeTypeEnum.FILE_PROMPT, 180, 90),
+            node('attachment-b', NodeTypeEnum.GITHUB, 100, 110),
+            node('generator', NodeTypeEnum.TEXT_TO_TEXT, 220, 130),
+        ];
+        const edges = [
+            edge('prompt-generator', 'prompt', 'generator', 'prompt'),
+            edge('c-generator', 'attachment-c', 'generator', 'attachment'),
+            edge('a-generator', 'attachment-a', 'generator', 'attachment'),
+            edge('b-generator', 'attachment-b', 'generator', 'attachment'),
+        ];
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const right = (id: string) =>
+            positions.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width;
+
+        expect(positions.get('attachment-a')!.y + 90 + 40).toBe(positions.get('attachment-b')!.y);
+        expect(positions.get('attachment-b')!.y + 110 + 40).toBe(positions.get('attachment-c')!.y);
+        expect(new Set(['attachment-a', 'attachment-b', 'attachment-c'].map(right)).size).toBe(1);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('assigns overlapping branch-target stacks to separate deterministic lanes', () => {
+        const nodes = [
+            node('root', NodeTypeEnum.TEXT_TO_TEXT, 220, 100),
+            node('generator-a', NodeTypeEnum.PARALLELIZATION, 200, 120),
+            node('generator-b', NodeTypeEnum.ROUTING, 200, 120),
+            node('a-file', NodeTypeEnum.FILE_PROMPT, 140, 100),
+            node('a-github', NodeTypeEnum.GITHUB, 160, 100),
+            node('b-file', NodeTypeEnum.FILE_PROMPT, 180, 100),
+            node('b-github', NodeTypeEnum.GITHUB, 120, 100),
+        ];
+        const edges = [
+            edge('root-a', 'root', 'generator-a', 'context'),
+            edge('root-b', 'root', 'generator-b', 'context'),
+            edge('a-file-edge', 'a-file', 'generator-a', 'attachment'),
+            edge('a-github-edge', 'a-github', 'generator-a', 'attachment'),
+            edge('b-file-edge', 'b-file', 'generator-b', 'attachment'),
+            edge('b-github-edge', 'b-github', 'generator-b', 'attachment'),
+        ];
+        const first = calculateGraphAutoLayout(nodes, edges);
+        const second = calculateGraphAutoLayout([...nodes].reverse(), [...edges].reverse());
+        const right = (id: string) =>
+            first.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width;
+
+        expect([...second]).toEqual([...first]);
+        expect(right('a-file')).toBe(right('a-github'));
+        expect(right('b-file')).toBe(right('b-github'));
+        expect(right('a-file')).not.toBe(right('b-file'));
+        expectNoOverlaps(nodes, first);
+    });
+
+    it('keeps screenshot-shaped distant stacks beside their own targets', () => {
+        const nodes = [
+            node('far-left-core', NodeTypeEnum.TEXT_TO_TEXT, 220, 900),
+            node('target-left', NodeTypeEnum.PARALLELIZATION, 240, 120),
+            node('left-file', NodeTypeEnum.FILE_PROMPT, 140, 80),
+            node('left-github', NodeTypeEnum.GITHUB, 180, 100),
+            node('target-right', NodeTypeEnum.ROUTING, 260, 120),
+            node('right-file', NodeTypeEnum.FILE_PROMPT, 160, 90),
+            node('right-github', NodeTypeEnum.GITHUB, 120, 70),
+        ];
+        const stacks = [
+            { targetId: 'target-left', sourceIds: ['left-file', 'left-github'] },
+            { targetId: 'target-right', sourceIds: ['right-file', 'right-github'] },
+        ];
+        const corePositions = new Map([
+            ['far-left-core', { x: -600, y: 0 }],
+            ['target-left', { x: 400, y: 100 }],
+            ['target-right', { x: 1300, y: 500 }],
+        ]);
+        const originalNodes = structuredClone(nodes);
+        const first = placeAttachmentStacks(stacks, nodes, corePositions, {
+            node: GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+            edge: GRAPH_AUTO_LAYOUT_EDGE_SEPARATION,
+        });
+        const second = placeAttachmentStacks(
+            [...stacks].reverse(),
+            [...nodes].reverse(),
+            new Map([...corePositions].reverse()),
+            {
+                node: GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+                edge: GRAPH_AUTO_LAYOUT_EDGE_SEPARATION,
+            },
+        );
+        const right = (id: string) =>
+            first.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width;
+
+        expect([...second]).toEqual([...first]);
+        expect(nodes).toEqual(originalNodes);
+        expect(right('left-file')).toBe(right('left-github'));
+        expect(right('right-file')).toBe(right('right-github'));
+        expect(corePositions.get('target-left')!.x - right('left-file')).toBe(
+            GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+        );
+        expect(corePositions.get('target-right')!.x - right('right-file')).toBe(
+            GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+        );
+        expect(right('right-file')).toBeGreaterThan(right('left-file'));
+    });
+
+    it('shifts a target-local stack left to clear an overlapping core node', () => {
+        const nodes = [
+            node('blocking-core', NodeTypeEnum.TEXT_TO_TEXT, 120, 160),
+            node('target', NodeTypeEnum.TEXT_TO_TEXT, 240, 120),
+            node('stack-file', NodeTypeEnum.FILE_PROMPT, 140, 80),
+            node('stack-github', NodeTypeEnum.GITHUB, 180, 100),
+        ];
+        const corePositions = new Map([
+            ['blocking-core', { x: 500, y: 80 }],
+            ['target', { x: 900, y: 100 }],
+        ]);
+        const positions = placeAttachmentStacks(
+            [{ targetId: 'target', sourceIds: ['stack-file', 'stack-github'] }],
+            nodes,
+            corePositions,
+            {
+                node: GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+                edge: GRAPH_AUTO_LAYOUT_EDGE_SEPARATION,
+            },
+        );
+        const right = positions.get('stack-file')!.x + 140;
+
+        expect(right).toBe(corePositions.get('blocking-core')!.x - GRAPH_AUTO_LAYOUT_NODE_SEPARATION);
+        expect(positions.get('stack-github')!.x + 180).toBe(right);
+        expectNoOverlaps(nodes, new Map([...corePositions, ...positions]));
+    });
+
+    it('keeps an ambiguous shared attachment source in the LR fallback', () => {
+        const nodes = [
+            node('root', NodeTypeEnum.TEXT_TO_TEXT, 200, 100),
+            node('generator-a', NodeTypeEnum.PARALLELIZATION, 180, 120),
+            node('generator-b', NodeTypeEnum.ROUTING, 220, 120),
+            node('shared-file', NodeTypeEnum.FILE_PROMPT, 140, 80),
+            node('github-a', NodeTypeEnum.GITHUB, 160, 100),
+        ];
+        const edges = [
+            edge('root-a', 'root', 'generator-a', 'context'),
+            edge('root-b', 'root', 'generator-b', 'context'),
+            edge('shared-a', 'shared-file', 'generator-a', 'attachment'),
+            edge('shared-b', 'shared-file', 'generator-b', 'attachment'),
+            edge('github-a', 'github-a', 'generator-a', 'attachment'),
+        ];
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const centerY = (id: string) =>
+            positions.get(id)!.y + nodes.find((candidate) => candidate.id === id)!.height / 2;
+
+        expect(centerY('shared-file')).toBe(centerY('generator-a'));
+        expect(centerY('github-a')).toBe(centerY('generator-a'));
+        expect(positions.get('shared-file')!.x).not.toBe(positions.get('github-a')!.x);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('keeps direct-star qualification bounded across many deterministic stacks', () => {
+        const nodes: GraphAutoLayoutNode[] = [];
+        const edges: GraphAutoLayoutEdge[] = [];
+        for (let index = 0; index < 24; index += 1) {
+            const suffix = index.toString().padStart(2, '0');
+            nodes.push(node(`generator-${suffix}`, NodeTypeEnum.TEXT_TO_TEXT, 180, 100));
+            nodes.push(node(`file-${suffix}`, NodeTypeEnum.FILE_PROMPT, 120, 70));
+            nodes.push(node(`github-${suffix}`, NodeTypeEnum.GITHUB, 140, 90));
+            edges.push(edge(`file-edge-${suffix}`, `file-${suffix}`, `generator-${suffix}`, 'attachment'));
+            edges.push(edge(`github-edge-${suffix}`, `github-${suffix}`, `generator-${suffix}`, 'attachment'));
+            if (index > 0) {
+                const previous = (index - 1).toString().padStart(2, '0');
+                edges.push(
+                    edge(
+                        `context-${suffix}`,
+                        `generator-${previous}`,
+                        `generator-${suffix}`,
+                        'context',
+                    ),
+                );
+            }
+        }
+        const first = calculateGraphAutoLayout(nodes, edges);
+        const second = calculateGraphAutoLayout([...nodes].reverse(), [...edges].reverse());
+
+        expect(first.size).toBe(nodes.length);
+        expect([...second]).toEqual([...first]);
+        expect([...first.values()].every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(true);
+    });
+});

--- a/ui/tests/unit/graphAutoLayoutBranchColumns.spec.ts
+++ b/ui/tests/unit/graphAutoLayoutBranchColumns.spec.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+
+import { NodeTypeEnum } from '@/types/enums';
+import {
+    calculateGraphAutoLayout,
+    GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+    type GraphAutoLayoutEdge,
+    type GraphAutoLayoutNode,
+} from '@/utils/graphAutoLayout';
+
+const node = (
+    id: string,
+    type: NodeTypeEnum,
+    width: number,
+    height: number,
+): GraphAutoLayoutNode => ({ id, type, width, height, position: { x: 30, y: 50 } });
+
+const edge = (
+    id: string,
+    source: string,
+    target: string,
+    category: 'context' | 'prompt',
+): GraphAutoLayoutEdge => ({
+    id,
+    source,
+    target,
+    sourceHandle: null,
+    targetHandle: `${category}_${target}`,
+});
+
+const fanout = (prefix = ''): { nodes: GraphAutoLayoutNode[]; edges: GraphAutoLayoutEdge[] } => {
+    const root = `${prefix}root`;
+    const promptWidths = [130, 210, 170, 250];
+    const childWidths = [220, 160, 280, 190];
+    const nodes = [node(root, NodeTypeEnum.TEXT_TO_TEXT, 240, 120)];
+    const edges: GraphAutoLayoutEdge[] = [];
+    for (let index = 1; index <= 4; index += 1) {
+        const promptId = `${prefix}prompt-${index}`;
+        const childId = `${prefix}child-${index}`;
+        nodes.push(node(promptId, NodeTypeEnum.PROMPT, promptWidths[index - 1]!, 70 + index * 5));
+        nodes.push(
+            node(childId, NodeTypeEnum.TEXT_TO_TEXT, childWidths[index - 1]!, 100 + index * 10),
+        );
+        edges.push(edge(`${prefix}root-child-${index}`, root, childId, 'context'));
+        edges.push(edge(`${prefix}prompt-child-${index}`, promptId, childId, 'prompt'));
+    }
+    return { nodes, edges };
+};
+
+const expectNoOverlaps = (
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => {
+    for (let leftIndex = 0; leftIndex < nodes.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < nodes.length; rightIndex += 1) {
+            const left = nodes[leftIndex]!;
+            const right = nodes[rightIndex]!;
+            const leftPosition = positions.get(left.id)!;
+            const rightPosition = positions.get(right.id)!;
+            const overlaps =
+                leftPosition.x < rightPosition.x + right.width &&
+                leftPosition.x + left.width > rightPosition.x &&
+                leftPosition.y < rightPosition.y + right.height &&
+                leftPosition.y + left.height > rightPosition.y;
+            expect(overlaps, `${left.id} overlaps ${right.id}`).toBe(false);
+        }
+    }
+};
+
+const expectFiniteCompleteLayout = (
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => {
+    expect(positions.size).toBe(nodes.length);
+    expect([...positions.values()].every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(
+        true,
+    );
+    expectNoOverlaps(nodes, positions);
+};
+
+describe('graph auto-layout prompted branch columns', () => {
+    it('keeps isolated fan-out geometry invariant inside connected rank-sharing topology', () => {
+        const isolated = fanout();
+        const originalNodes = structuredClone(isolated.nodes);
+        const originalEdges = structuredClone(isolated.edges);
+        const isolatedPositions = calculateGraphAutoLayout(isolated.nodes, isolated.edges);
+        const embeddedNodes = [
+            ...isolated.nodes,
+            node('upstream', NodeTypeEnum.TEXT_TO_TEXT, 180, 90),
+            node('side-1', NodeTypeEnum.TEXT_TO_TEXT, 150, 80),
+            node('side-2', NodeTypeEnum.TEXT_TO_TEXT, 140, 70),
+            node('side-3', NodeTypeEnum.TEXT_TO_TEXT, 160, 90),
+        ];
+        const embeddedEdges = [
+            ...isolated.edges,
+            edge('upstream-root', 'upstream', 'root', 'context'),
+            edge('upstream-side-1', 'upstream', 'side-1', 'context'),
+            edge('side-1-side-2', 'side-1', 'side-2', 'context'),
+            edge('side-2-side-3', 'side-2', 'side-3', 'context'),
+        ];
+        const embeddedPositions = calculateGraphAutoLayout(embeddedNodes, embeddedEdges);
+        const shuffledPositions = calculateGraphAutoLayout(
+            [...embeddedNodes].reverse(),
+            [...embeddedEdges].reverse(),
+        );
+        const cohortIds = [
+            'root',
+            ...Array.from({ length: 4 }, (_, index) => `prompt-${index + 1}`),
+            ...Array.from({ length: 4 }, (_, index) => `child-${index + 1}`),
+        ];
+        const relative = (
+            positions: ReadonlyMap<string, { x: number; y: number }>,
+            id: string,
+        ) => ({
+            x: positions.get(id)!.x - positions.get('root')!.x,
+            y: positions.get(id)!.y - positions.get('root')!.y,
+        });
+        const dimensions = (id: string) => embeddedNodes.find((candidate) => candidate.id === id)!;
+        const centerX = (id: string) =>
+            embeddedPositions.get(id)!.x + dimensions(id).width / 2;
+
+        expect(cohortIds.map((id) => relative(embeddedPositions, id))).toEqual(
+            cohortIds.map((id) => relative(isolatedPositions, id)),
+        );
+        expect([...shuffledPositions]).toEqual([...embeddedPositions]);
+        expect(isolated.nodes).toEqual(originalNodes);
+        expect(isolated.edges).toEqual(originalEdges);
+        for (let index = 1; index <= 4; index += 1) {
+            expect(centerX(`prompt-${index}`)).toBe(centerX(`child-${index}`));
+        }
+
+        const envelopes = Array.from({ length: 4 }, (_, index) => {
+            const ids = [`prompt-${index + 1}`, `child-${index + 1}`];
+            return {
+                left: Math.min(...ids.map((id) => embeddedPositions.get(id)!.x)),
+                right: Math.max(
+                    ...ids.map((id) => embeddedPositions.get(id)!.x + dimensions(id).width),
+                ),
+            };
+        });
+        for (let index = 1; index < envelopes.length; index += 1) {
+            expect(envelopes[index]!.left - envelopes[index - 1]!.right).toBeGreaterThanOrEqual(
+                GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+            );
+        }
+        expect(centerX('root')).toBe((envelopes[0]!.left + envelopes[3]!.right) / 2);
+        expectFiniteCompleteLayout(embeddedNodes, embeddedPositions);
+    });
+
+    it('preserves each child serial tail as part of its rigid branch', () => {
+        const nodes = [
+            node('root', NodeTypeEnum.TEXT_TO_TEXT, 220, 100),
+            node('prompt-1', NodeTypeEnum.PROMPT, 140, 80),
+            node('child-1', NodeTypeEnum.PARALLELIZATION, 200, 110),
+            node('tail-1', NodeTypeEnum.TEXT_TO_TEXT, 260, 120),
+            node('prompt-2', NodeTypeEnum.PROMPT, 230, 90),
+            node('child-2', NodeTypeEnum.ROUTING, 180, 130),
+            node('tail-2', NodeTypeEnum.TEXT_TO_TEXT, 150, 100),
+        ];
+        const edges = [
+            edge('root-child-1', 'root', 'child-1', 'context'),
+            edge('root-child-2', 'root', 'child-2', 'context'),
+            edge('prompt-child-1', 'prompt-1', 'child-1', 'prompt'),
+            edge('prompt-child-2', 'prompt-2', 'child-2', 'prompt'),
+            edge('child-tail-1', 'child-1', 'tail-1', 'context'),
+            edge('child-tail-2', 'child-2', 'tail-2', 'context'),
+        ];
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const centerX = (id: string) =>
+            positions.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width / 2;
+
+        expect(centerX('prompt-1')).toBe(centerX('child-1'));
+        expect(centerX('child-1')).toBe(centerX('tail-1'));
+        expect(centerX('prompt-2')).toBe(centerX('child-2'));
+        expect(centerX('child-2')).toBe(centerX('tail-2'));
+        expect(centerX('child-1')).not.toBe(centerX('child-2'));
+        expectFiniteCompleteLayout(nodes, positions);
+    });
+
+    it('falls back safely for multiple, missing, and multiply-parented prompts', () => {
+        const cases = [
+            () => {
+                const graph = fanout('multiple-');
+                graph.nodes.push(node('multiple-extra-prompt', NodeTypeEnum.PROMPT, 120, 80));
+                graph.edges.push(
+                    edge(
+                        'multiple-extra-edge',
+                        'multiple-extra-prompt',
+                        'multiple-child-1',
+                        'prompt',
+                    ),
+                );
+                return graph;
+            },
+            () => {
+                const graph = fanout('missing-');
+                graph.edges = graph.edges.filter((candidate) => candidate.id !== 'missing-prompt-child-4');
+                return graph;
+            },
+            () => {
+                const graph = fanout('parented-');
+                graph.nodes.push(node('parented-other', NodeTypeEnum.TEXT_TO_TEXT, 180, 100));
+                graph.edges.push(
+                    edge('parented-other-child', 'parented-other', 'parented-child-1', 'context'),
+                );
+                return graph;
+            },
+        ];
+
+        for (const createGraph of cases) {
+            const graph = createGraph();
+            const positions = calculateGraphAutoLayout(graph.nodes, graph.edges);
+            const shuffled = calculateGraphAutoLayout(
+                [...graph.nodes].reverse(),
+                [...graph.edges].reverse(),
+            );
+            expect([...shuffled]).toEqual([...positions]);
+            expectFiniteCompleteLayout(graph.nodes, positions);
+        }
+    });
+
+    it('lays out many disjoint qualifying cohorts completely and deterministically', () => {
+        const nodes: GraphAutoLayoutNode[] = [];
+        const edges: GraphAutoLayoutEdge[] = [];
+        for (let index = 0; index < 10; index += 1) {
+            const graph = fanout(`cohort-${index.toString().padStart(2, '0')}-`);
+            nodes.push(...graph.nodes);
+            edges.push(...graph.edges);
+        }
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const shuffled = calculateGraphAutoLayout([...nodes].reverse(), [...edges].reverse());
+
+        expect([...shuffled]).toEqual([...positions]);
+        expectFiniteCompleteLayout(nodes, positions);
+    });
+});

--- a/ui/tests/unit/graphAutoLayoutFanoutHierarchy.spec.ts
+++ b/ui/tests/unit/graphAutoLayoutFanoutHierarchy.spec.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'vitest';
+
+import { NodeTypeEnum } from '@/types/enums';
+import {
+    calculateGraphAutoLayout,
+    type GraphAutoLayoutEdge,
+    type GraphAutoLayoutNode,
+} from '@/utils/graphAutoLayout';
+import { mergePromptFanoutStageBlocks } from '@/utils/graphAutoLayoutBranchColumns';
+import type { LayoutConstraintEdge, LayoutHorizontalBlock } from '@/utils/graphAutoLayoutConstraints';
+import { discoverFanoutHierarchy } from '@/utils/graphAutoLayoutFanoutHierarchy';
+
+const node = (id: string, type: NodeTypeEnum, width: number, height: number): GraphAutoLayoutNode => ({
+    id,
+    type,
+    width,
+    height,
+    position: { x: 35, y: 55 },
+});
+const edge = (
+    id: string,
+    source: string,
+    target: string,
+    category: 'context' | 'prompt',
+): GraphAutoLayoutEdge => ({
+    id,
+    source,
+    target,
+    sourceHandle: null,
+    targetHandle: `${category}_${target}`,
+});
+const centerX = (
+    id: string,
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => positions.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width / 2;
+const bounds = (
+    ids: readonly string[],
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => ({
+    left: Math.min(...ids.map((id) => positions.get(id)!.x)),
+    right: Math.max(
+        ...ids.map((id) =>
+            positions.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width,
+        ),
+    ),
+});
+const expectNoOverlaps = (
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => {
+    for (let leftIndex = 0; leftIndex < nodes.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < nodes.length; rightIndex += 1) {
+            const left = nodes[leftIndex]!;
+            const right = nodes[rightIndex]!;
+            const leftPosition = positions.get(left.id)!;
+            const rightPosition = positions.get(right.id)!;
+            expect(
+                leftPosition.x < rightPosition.x + right.width &&
+                    leftPosition.x + left.width > rightPosition.x &&
+                    leftPosition.y < rightPosition.y + right.height &&
+                    leftPosition.y + left.height > rightPosition.y,
+                `${left.id} overlaps ${right.id}`,
+            ).toBe(false);
+        }
+    }
+};
+
+const screenshotCohort = () => {
+    const nodes = [
+        node('upper', NodeTypeEnum.TEXT_TO_TEXT, 240, 110),
+        node('shared-prompt', NodeTypeEnum.PROMPT, 180, 80),
+        node('child-a', NodeTypeEnum.TEXT_TO_TEXT, 170, 100),
+        node('child-b', NodeTypeEnum.ROUTING, 220, 120),
+        node('child-c', NodeTypeEnum.PARALLELIZATION, 260, 130),
+        ...[1, 2, 3, 4].flatMap((index) => [
+            node(`nested-prompt-${index}`, NodeTypeEnum.PROMPT, 120 + index * 20, 70),
+            node(`nested-child-${index}`, NodeTypeEnum.TEXT_TO_TEXT, 150 + index * 25, 100),
+        ]),
+        node('serial-prompt', NodeTypeEnum.PROMPT, 150, 70),
+        node('serial-tail', NodeTypeEnum.TEXT_TO_TEXT, 280, 120),
+    ];
+    const edges: GraphAutoLayoutEdge[] = [];
+    for (const childId of ['child-a', 'child-b', 'child-c']) {
+        edges.push(edge(`upper-${childId}`, 'upper', childId, 'context'));
+        edges.push(edge(`shared-${childId}`, 'shared-prompt', childId, 'prompt'));
+    }
+    for (let index = 1; index <= 4; index += 1) {
+        edges.push(edge(`nested-context-${index}`, 'child-c', `nested-child-${index}`, 'context'));
+        edges.push(
+            edge(
+                `nested-prompt-edge-${index}`,
+                `nested-prompt-${index}`,
+                `nested-child-${index}`,
+                'prompt',
+            ),
+        );
+    }
+    edges.push(edge('nested-4-tail', 'nested-child-4', 'serial-tail', 'context'));
+    edges.push(edge('serial-prompt-tail', 'serial-prompt', 'serial-tail', 'prompt'));
+    return { nodes, edges };
+};
+
+describe('graph auto-layout fan-out hierarchy', () => {
+    it('centers screenshot-shaped nested co-parent families isolated and embedded', () => {
+        const cohort = screenshotCohort();
+        const originalNodes = structuredClone(cohort.nodes);
+        const originalEdges = structuredClone(cohort.edges);
+        const isolated = calculateGraphAutoLayout(cohort.nodes, cohort.edges);
+        const embeddedNodes = [
+            ...cohort.nodes,
+            node('upstream', NodeTypeEnum.TEXT_TO_TEXT, 150, 70),
+            ...Array.from({ length: 7 }, (_, index) =>
+                node(`side-${index}`, NodeTypeEnum.TEXT_TO_TEXT, 100, 50),
+            ),
+        ];
+        const embeddedEdges = [
+            ...cohort.edges,
+            edge('upstream-upper', 'upstream', 'upper', 'context'),
+            edge('upstream-side-0', 'upstream', 'side-0', 'context'),
+            ...Array.from({ length: 6 }, (_, index) =>
+                edge(`side-edge-${index}`, `side-${index}`, `side-${index + 1}`, 'context'),
+            ),
+        ];
+        const embedded = calculateGraphAutoLayout(embeddedNodes, embeddedEdges);
+        const reversed = calculateGraphAutoLayout(
+            [...embeddedNodes].reverse(),
+            [...embeddedEdges].reverse(),
+        );
+        const relative = (positions: ReadonlyMap<string, { x: number; y: number }>, id: string) => ({
+            x: positions.get(id)!.x - positions.get('upper')!.x,
+            y: positions.get(id)!.y - positions.get('upper')!.y,
+        });
+        const cohortIds = cohort.nodes.map(({ id }) => id);
+
+        expect(cohortIds.map((id) => relative(embedded, id))).toEqual(
+            cohortIds.map((id) => relative(isolated, id)),
+        );
+        expect([...reversed]).toEqual([...embedded]);
+        expect(cohort.nodes).toEqual(originalNodes);
+        expect(cohort.edges).toEqual(originalEdges);
+        const nestedIds = cohortIds.filter((id) => id.startsWith('nested-') || id.startsWith('serial-'));
+        const upperBranches = [
+            bounds(['child-a'], embeddedNodes, embedded),
+            bounds(['child-b'], embeddedNodes, embedded),
+            bounds(['child-c', ...nestedIds], embeddedNodes, embedded),
+        ];
+        const upperMidpoint = (upperBranches[0]!.left + upperBranches[2]!.right) / 2;
+        expect(Math.abs(centerX('upper', embeddedNodes, embedded) - upperMidpoint)).toBeLessThanOrEqual(1);
+        expect(Math.abs(centerX('shared-prompt', embeddedNodes, embedded) - upperMidpoint)).toBeLessThanOrEqual(1);
+
+        const nestedBranches = [1, 2, 3, 4].map((index) =>
+            bounds(
+                index === 4
+                    ? [`nested-prompt-${index}`, `nested-child-${index}`, 'serial-prompt', 'serial-tail']
+                    : [`nested-prompt-${index}`, `nested-child-${index}`],
+                embeddedNodes,
+                embedded,
+            ),
+        );
+        expect(Math.abs(
+            centerX('child-c', embeddedNodes, embedded) -
+                (nestedBranches[0]!.left + nestedBranches[3]!.right) / 2,
+        )).toBeLessThanOrEqual(1);
+        for (let index = 1; index <= 4; index += 1) {
+            expect(Math.abs(
+                centerX(`nested-prompt-${index}`, embeddedNodes, embedded) -
+                    centerX(`nested-child-${index}`, embeddedNodes, embedded),
+            )).toBeLessThanOrEqual(1);
+        }
+        expect(centerX('nested-child-4', embeddedNodes, embedded)).toBe(
+            centerX('serial-tail', embeddedNodes, embedded),
+        );
+        expect(Math.abs(
+            centerX('serial-prompt', embeddedNodes, embedded) -
+                (embedded.get('serial-tail')!.x + 0.33 * 280),
+        )).toBeLessThanOrEqual(1);
+        expectNoOverlaps(embeddedNodes, embedded);
+    });
+
+    it('centers promptless and mixed generator fan-outs', () => {
+        for (const withDedicatedPrompt of [false, true]) {
+            const nodes = [
+                node('parent', NodeTypeEnum.TEXT_TO_TEXT, 220, 100),
+                node('a', NodeTypeEnum.TEXT_TO_TEXT, 140, 90),
+                node('b', NodeTypeEnum.ROUTING, 260, 120),
+                node('c', NodeTypeEnum.PARALLELIZATION, 180, 100),
+            ];
+            const edges = ['a', 'b', 'c'].map((id) => edge(`parent-${id}`, 'parent', id, 'context'));
+            if (withDedicatedPrompt) {
+                nodes.push(node('b-prompt', NodeTypeEnum.PROMPT, 200, 70));
+                edges.push(edge('b-prompt-edge', 'b-prompt', 'b', 'prompt'));
+            }
+            const positions = calculateGraphAutoLayout(nodes, edges);
+            const branchIds = withDedicatedPrompt ? ['a', 'b-prompt', 'b', 'c'] : ['a', 'b', 'c'];
+            const envelope = bounds(branchIds, nodes, positions);
+            expect(Math.abs(
+                centerX('parent', nodes, positions) - (envelope.left + envelope.right) / 2,
+            )).toBeLessThanOrEqual(1);
+            if (withDedicatedPrompt) {
+                expect(centerX('b-prompt', nodes, positions)).toBe(centerX('b', nodes, positions));
+            }
+            expectNoOverlaps(nodes, positions);
+        }
+    });
+
+    it('centers a standalone prompt parent over full child composites', () => {
+        const nodes = [
+            node('prompt-parent', NodeTypeEnum.PROMPT, 190, 80),
+            node('a', NodeTypeEnum.TEXT_TO_TEXT, 140, 90),
+            node('b', NodeTypeEnum.ROUTING, 250, 110),
+            node('c', NodeTypeEnum.PARALLELIZATION, 180, 100),
+            node('tail', NodeTypeEnum.TEXT_TO_TEXT, 300, 120),
+        ];
+        const edges = ['a', 'b', 'c'].map((id) =>
+            edge(`prompt-${id}`, 'prompt-parent', id, 'prompt'),
+        );
+        edges.push(edge('c-tail', 'c', 'tail', 'context'));
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const branches = [
+            bounds(['a'], nodes, positions),
+            bounds(['b'], nodes, positions),
+            bounds(['c', 'tail'], nodes, positions),
+        ];
+
+        expect(Math.abs(
+            centerX('prompt-parent', nodes, positions) -
+                (branches[0]!.left + branches[2]!.right) / 2,
+        )).toBeLessThanOrEqual(1);
+        expect(positions.size).toBe(nodes.length);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('rejects partial co-parent ownership and malformed block families atomically', () => {
+        const nodes = [
+            node('parent', NodeTypeEnum.TEXT_TO_TEXT, 200, 100),
+            node('shared', NodeTypeEnum.PROMPT, 160, 80),
+            node('a', NodeTypeEnum.TEXT_TO_TEXT, 140, 90),
+            node('b', NodeTypeEnum.TEXT_TO_TEXT, 160, 90),
+            node('c', NodeTypeEnum.TEXT_TO_TEXT, 180, 90),
+        ];
+        const edges: LayoutConstraintEdge[] = [
+            { source: 'parent', target: 'a', category: 'context' },
+            { source: 'parent', target: 'b', category: 'context' },
+            { source: 'parent', target: 'c', category: 'context' },
+            { source: 'shared', target: 'a', category: 'prompt' },
+            { source: 'shared', target: 'b', category: 'prompt' },
+        ];
+        const rows = new Map([
+            ['parent', 0], ['shared', 1], ['a', 2], ['b', 2], ['c', 1],
+        ]);
+        expect(discoverFanoutHierarchy(nodes, edges, rows)).toEqual([]);
+
+        const blocks: LayoutHorizontalBlock[] = nodes.map(({ id }) => ({
+            id,
+            preferredLeft: 10,
+            members: [{ id, left: 0 }],
+        }));
+        blocks.find(({ id }) => id === 'shared')!.members.push({ id: 'missing', left: 20 });
+        const original = structuredClone({ nodes, edges, blocks, rows: [...rows] });
+        expect(mergePromptFanoutStageBlocks(nodes, edges, blocks, rows, { node: 160 })).toEqual(blocks);
+        expect({ nodes, edges, blocks, rows: [...rows] }).toEqual(original);
+    });
+});

--- a/ui/tests/unit/graphAutoLayoutSerialPrompts.spec.ts
+++ b/ui/tests/unit/graphAutoLayoutSerialPrompts.spec.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from 'vitest';
+
+import { NodeTypeEnum } from '@/types/enums';
+import {
+    calculateGraphAutoLayout,
+    GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+    type GraphAutoLayoutEdge,
+    type GraphAutoLayoutNode,
+} from '@/utils/graphAutoLayout';
+import type {
+    LayoutConstraintEdge,
+    LayoutHorizontalBlock,
+} from '@/utils/graphAutoLayoutConstraints';
+import { mergeSerialSpinePromptBlocks } from '@/utils/graphAutoLayoutSerialPrompts';
+
+const node = (
+    id: string,
+    type: NodeTypeEnum,
+    width: number,
+    height: number,
+): GraphAutoLayoutNode => ({ id, type, width, height, position: { x: 25, y: 45 } });
+
+const edge = (
+    id: string,
+    source: string,
+    target: string,
+    category: 'context' | 'prompt',
+): GraphAutoLayoutEdge => ({
+    id,
+    source,
+    target,
+    sourceHandle: null,
+    targetHandle: `${category}_${target}`,
+});
+
+const expectNoOverlaps = (
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => {
+    for (let leftIndex = 0; leftIndex < nodes.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < nodes.length; rightIndex += 1) {
+            const left = nodes[leftIndex]!;
+            const right = nodes[rightIndex]!;
+            const leftPosition = positions.get(left.id)!;
+            const rightPosition = positions.get(right.id)!;
+            const overlaps =
+                leftPosition.x < rightPosition.x + right.width &&
+                leftPosition.x + left.width > rightPosition.x &&
+                leftPosition.y < rightPosition.y + right.height &&
+                leftPosition.y + left.height > rightPosition.y;
+            expect(overlaps, `${left.id} overlaps ${right.id}`).toBe(false);
+        }
+    }
+};
+
+const centerX = (
+    id: string,
+    nodes: readonly GraphAutoLayoutNode[],
+    positions: ReadonlyMap<string, { x: number; y: number }>,
+) => positions.get(id)!.x + nodes.find((candidate) => candidate.id === id)!.width / 2;
+
+describe('graph auto-layout serial prompts', () => {
+    it('keeps a downstream prompt handle-aligned in isolated and embedded serial stages', () => {
+        const serialNodes = [
+            node('generator', NodeTypeEnum.TEXT_TO_TEXT, 220, 110),
+            node('prompt', NodeTypeEnum.PROMPT, 160, 80),
+            node('downstream', NodeTypeEnum.TEXT_TO_TEXT, 300, 140),
+        ];
+        const serialEdges = [
+            edge('generator-downstream', 'generator', 'downstream', 'context'),
+            edge('prompt-downstream', 'prompt', 'downstream', 'prompt'),
+        ];
+        const originalNodes = structuredClone(serialNodes);
+        const originalEdges = structuredClone(serialEdges);
+        const isolated = calculateGraphAutoLayout(serialNodes, serialEdges);
+        const embeddedNodes = [
+            ...serialNodes,
+            node('upstream', NodeTypeEnum.TEXT_TO_TEXT, 180, 90),
+            node('side-1', NodeTypeEnum.TEXT_TO_TEXT, 150, 80),
+            node('side-2', NodeTypeEnum.TEXT_TO_TEXT, 140, 70),
+            node('side-3', NodeTypeEnum.TEXT_TO_TEXT, 160, 100),
+        ];
+        const embeddedEdges = [
+            ...serialEdges,
+            edge('upstream-generator', 'upstream', 'generator', 'context'),
+            edge('upstream-side-1', 'upstream', 'side-1', 'context'),
+            edge('side-1-side-2', 'side-1', 'side-2', 'context'),
+            edge('side-2-side-3', 'side-2', 'side-3', 'context'),
+        ];
+        const embedded = calculateGraphAutoLayout(embeddedNodes, embeddedEdges);
+        const reversed = calculateGraphAutoLayout(
+            [...embeddedNodes].reverse(),
+            [...embeddedEdges].reverse(),
+        );
+        const relative = (
+            positions: ReadonlyMap<string, { x: number; y: number }>,
+            id: string,
+        ) => ({
+            x: positions.get(id)!.x - positions.get('generator')!.x,
+            y: positions.get(id)!.y - positions.get('generator')!.y,
+        });
+
+        expect(['generator', 'prompt', 'downstream'].map((id) => relative(embedded, id))).toEqual(
+            ['generator', 'prompt', 'downstream'].map((id) => relative(isolated, id)),
+        );
+        expect([...reversed]).toEqual([...embedded]);
+        expect(serialNodes).toEqual(originalNodes);
+        expect(serialEdges).toEqual(originalEdges);
+        expect(centerX('generator', embeddedNodes, embedded)).toBe(
+            centerX('downstream', embeddedNodes, embedded),
+        );
+        expect(
+            Math.abs(
+                centerX('prompt', embeddedNodes, embedded) -
+                    (embedded.get('downstream')!.x + 0.33 * 300),
+            ),
+        ).toBeLessThanOrEqual(1);
+        expect(embedded.get('generator')!.y).toBeLessThan(embedded.get('prompt')!.y);
+        expect(embedded.get('prompt')!.y).toBeLessThan(embedded.get('downstream')!.y);
+        expect(embedded.size).toBe(embeddedNodes.length);
+        expectNoOverlaps(embeddedNodes, embedded);
+    });
+
+    it('keeps downstream prompts rigid inside prompted fan-out tail blocks', () => {
+        const nodes = [
+            node('root', NodeTypeEnum.TEXT_TO_TEXT, 220, 100),
+            node('branch-prompt-1', NodeTypeEnum.PROMPT, 140, 80),
+            node('child-1', NodeTypeEnum.PARALLELIZATION, 200, 110),
+            node('tail-prompt-1', NodeTypeEnum.PROMPT, 180, 80),
+            node('tail-1', NodeTypeEnum.TEXT_TO_TEXT, 300, 130),
+            node('branch-prompt-2', NodeTypeEnum.PROMPT, 230, 90),
+            node('child-2', NodeTypeEnum.ROUTING, 180, 120),
+            node('tail-prompt-2', NodeTypeEnum.PROMPT, 150, 70),
+            node('tail-2', NodeTypeEnum.TEXT_TO_TEXT, 240, 110),
+        ];
+        const edges = [
+            edge('root-child-1', 'root', 'child-1', 'context'),
+            edge('root-child-2', 'root', 'child-2', 'context'),
+            edge('branch-prompt-child-1', 'branch-prompt-1', 'child-1', 'prompt'),
+            edge('branch-prompt-child-2', 'branch-prompt-2', 'child-2', 'prompt'),
+            edge('child-tail-1', 'child-1', 'tail-1', 'context'),
+            edge('child-tail-2', 'child-2', 'tail-2', 'context'),
+            edge('tail-prompt-tail-1', 'tail-prompt-1', 'tail-1', 'prompt'),
+            edge('tail-prompt-tail-2', 'tail-prompt-2', 'tail-2', 'prompt'),
+        ];
+        const positions = calculateGraphAutoLayout(nodes, edges);
+        const targetOffset = (promptId: string, targetId: string) =>
+            Math.abs(
+                centerX(promptId, nodes, positions) -
+                    (positions.get(targetId)!.x +
+                        0.33 * nodes.find((candidate) => candidate.id === targetId)!.width),
+            );
+
+        expect(centerX('branch-prompt-1', nodes, positions)).toBe(
+            centerX('child-1', nodes, positions),
+        );
+        expect(centerX('branch-prompt-2', nodes, positions)).toBe(
+            centerX('child-2', nodes, positions),
+        );
+        expect(centerX('child-1', nodes, positions)).toBe(centerX('tail-1', nodes, positions));
+        expect(centerX('child-2', nodes, positions)).toBe(centerX('tail-2', nodes, positions));
+        expect(targetOffset('tail-prompt-1', 'tail-1')).toBeLessThanOrEqual(1);
+        expect(targetOffset('tail-prompt-2', 'tail-2')).toBeLessThanOrEqual(1);
+
+        const branchEnvelopes = [1, 2].map((index) => {
+            const ids = [
+                `branch-prompt-${index}`,
+                `child-${index}`,
+                `tail-prompt-${index}`,
+                `tail-${index}`,
+            ];
+            return {
+                left: Math.min(...ids.map((id) => positions.get(id)!.x)),
+                right: Math.max(
+                    ...ids.map(
+                        (id) =>
+                            positions.get(id)!.x +
+                            nodes.find((candidate) => candidate.id === id)!.width,
+                    ),
+                ),
+            };
+        });
+        expect(branchEnvelopes[1]!.left - branchEnvelopes[0]!.right).toBeGreaterThanOrEqual(
+            GRAPH_AUTO_LAYOUT_NODE_SEPARATION,
+        );
+        expect(centerX('root', nodes, positions)).toBe(
+            (branchEnvelopes[0]!.left + branchEnvelopes[1]!.right) / 2,
+        );
+        expect(positions.size).toBe(nodes.length);
+        expectNoOverlaps(nodes, positions);
+    });
+
+    it('returns blocks unchanged for conservative serial-prompt fallbacks', () => {
+        interface Fixture {
+            nodes: GraphAutoLayoutNode[];
+            edges: LayoutConstraintEdge[];
+            blocks: LayoutHorizontalBlock[];
+            rows: Map<string, number>;
+        }
+        const fixture = (): Fixture => ({
+            nodes: [
+                node('generator', NodeTypeEnum.TEXT_TO_TEXT, 200, 100),
+                node('prompt', NodeTypeEnum.PROMPT, 140, 80),
+                node('downstream', NodeTypeEnum.TEXT_TO_TEXT, 300, 120),
+            ],
+            edges: [
+                { source: 'generator', target: 'downstream', category: 'context' },
+                { source: 'prompt', target: 'downstream', category: 'prompt' },
+            ],
+            blocks: [
+                {
+                    id: 'generator',
+                    preferredLeft: 400,
+                    members: [
+                        { id: 'generator', left: -100 },
+                        { id: 'downstream', left: -150 },
+                    ],
+                },
+                { id: 'prompt', preferredLeft: 20, members: [{ id: 'prompt', left: 0 }] },
+            ],
+            rows: new Map([
+                ['generator', 0],
+                ['prompt', 1],
+                ['downstream', 2],
+            ]),
+        });
+        const cases: Fixture[] = [];
+
+        const multiple = fixture();
+        multiple.nodes.push(node('prompt-2', NodeTypeEnum.PROMPT, 120, 70));
+        multiple.edges.push({ source: 'prompt-2', target: 'downstream', category: 'prompt' });
+        multiple.blocks.push({ id: 'prompt-2', preferredLeft: 0, members: [{ id: 'prompt-2', left: 0 }] });
+        multiple.rows.set('prompt-2', 1);
+        cases.push(multiple);
+
+        const shared = fixture();
+        shared.nodes.push(
+            node('generator-2', NodeTypeEnum.TEXT_TO_TEXT, 180, 90),
+            node('downstream-2', NodeTypeEnum.TEXT_TO_TEXT, 220, 100),
+        );
+        shared.edges.push(
+            { source: 'generator-2', target: 'downstream-2', category: 'context' },
+            { source: 'prompt', target: 'downstream-2', category: 'prompt' },
+        );
+        shared.blocks.push({
+            id: 'generator-2',
+            preferredLeft: 0,
+            members: [
+                { id: 'generator-2', left: -90 },
+                { id: 'downstream-2', left: -110 },
+            ],
+        });
+        shared.rows.set('generator-2', 0);
+        shared.rows.set('downstream-2', 2);
+        cases.push(shared);
+
+        const nonPrompt = fixture();
+        nonPrompt.nodes[1] = node('prompt', NodeTypeEnum.FILE_PROMPT, 140, 80);
+        cases.push(nonPrompt);
+
+        const multiPredecessor = fixture();
+        multiPredecessor.nodes.push(node('other', NodeTypeEnum.TEXT_TO_TEXT, 180, 90));
+        multiPredecessor.edges.push({ source: 'other', target: 'downstream', category: 'context' });
+        cases.push(multiPredecessor);
+
+        const multiSuccessor = fixture();
+        multiSuccessor.nodes.push(node('other', NodeTypeEnum.TEXT_TO_TEXT, 180, 90));
+        multiSuccessor.edges.push({ source: 'generator', target: 'other', category: 'context' });
+        cases.push(multiSuccessor);
+
+        const cycle = fixture();
+        cycle.edges.push({ source: 'downstream', target: 'generator', category: 'context' });
+        cases.push(cycle);
+
+        const missingRow = fixture();
+        missingRow.rows.delete('prompt');
+        cases.push(missingRow);
+
+        const missingBlock = fixture();
+        missingBlock.blocks.pop();
+        cases.push(missingBlock);
+
+        const missingPrompt = fixture();
+        missingPrompt.edges.pop();
+        cases.push(missingPrompt);
+
+        const reusedBlock = fixture();
+        reusedBlock.nodes.push(node('prompt-2', NodeTypeEnum.PROMPT, 120, 70));
+        reusedBlock.edges.push({ source: 'prompt-2', target: 'downstream', category: 'prompt' });
+        reusedBlock.blocks[1]!.members.push({ id: 'prompt-2', left: 10 });
+        reusedBlock.rows.set('prompt-2', 1);
+        cases.push(reusedBlock);
+
+        for (const input of cases) {
+            const original = structuredClone({
+                nodes: input.nodes,
+                edges: input.edges,
+                blocks: input.blocks,
+                rows: [...input.rows],
+            });
+            const result = mergeSerialSpinePromptBlocks(
+                input.nodes,
+                input.edges,
+                input.blocks,
+                input.rows,
+            );
+            expect(result).toEqual(input.blocks);
+            expect({
+                nodes: input.nodes,
+                edges: input.edges,
+                blocks: input.blocks,
+                rows: [...input.rows],
+            }).toEqual(original);
+        }
+    });
+});

--- a/ui/tests/unit/graphGeometry.spec.ts
+++ b/ui/tests/unit/graphGeometry.spec.ts
@@ -1,10 +1,123 @@
 import { describe, expect, it } from 'vitest';
-import { NodeCategoryEnum } from '@/types/enums';
+import { NodeCategoryEnum, NodeTypeEnum } from '@/types/enums';
 import {
+    calculateGeneratorChildPosition,
     calculateOverlapTranslation,
     calculateQuickWorkflowPositionOffset,
     calculateWheelSectorGeometry,
 } from '@/utils/graphGeometry';
+
+describe('calculateGeneratorChildPosition', () => {
+    const parent = {
+        id: 'parent',
+        type: NodeTypeEnum.TEXT_TO_TEXT,
+        position: { x: 100, y: 200 },
+        width: 320,
+        height: 180,
+    };
+
+    it('keeps below-parent placement when no direct generator child exists', () => {
+        expect(
+            calculateGeneratorChildPosition({ parent, nodes: [parent], edges: [], gap: 150 }),
+        ).toEqual({ x: 100, y: 530 });
+    });
+
+    it('uses right edge of rightmost direct generator child and ignores other topology', () => {
+        const nodes = [
+            parent,
+            {
+                id: 'wide-child',
+                type: NodeTypeEnum.TEXT_TO_TEXT,
+                position: { x: 450, y: 600 },
+                width: 400,
+                height: 100,
+            },
+            {
+                id: 'higher-x-child',
+                type: NodeTypeEnum.ROUTING,
+                position: { x: 700, y: 650 },
+                width: 100,
+                height: 100,
+            },
+            {
+                id: 'descendant',
+                type: NodeTypeEnum.PARALLELIZATION,
+                position: { x: 1200, y: 1000 },
+                width: 300,
+                height: 100,
+            },
+            {
+                id: 'non-generator',
+                type: NodeTypeEnum.PROMPT,
+                position: { x: 1600, y: 1200 },
+                width: 200,
+                height: 100,
+            },
+            {
+                id: 'incoming-generator',
+                type: NodeTypeEnum.ROUTING,
+                position: { x: 2000, y: 1400 },
+                width: 200,
+                height: 100,
+            },
+        ];
+        const edges = [
+            { source: parent.id, target: 'wide-child' },
+            { source: parent.id, target: 'higher-x-child' },
+            { source: 'wide-child', target: 'descendant' },
+            { source: parent.id, target: 'non-generator' },
+            { source: 'incoming-generator', target: parent.id },
+        ];
+
+        expect(calculateGeneratorChildPosition({ parent, nodes, edges, gap: 150 })).toEqual({
+            x: 1000,
+            y: 600,
+        });
+    });
+
+    it.each([
+        NodeTypeEnum.TEXT_TO_TEXT,
+        NodeTypeEnum.PARALLELIZATION,
+        NodeTypeEnum.ROUTING,
+    ])('accepts direct %s children', (type) => {
+        const child = {
+            id: 'child',
+            type,
+            position: { x: 500, y: 700 },
+            width: 250,
+            height: 100,
+        };
+
+        expect(
+            calculateGeneratorChildPosition({
+                parent,
+                nodes: [parent, child],
+                edges: [{ source: parent.id, target: child.id }],
+                gap: 150,
+            }),
+        ).toEqual({ x: 900, y: 700 });
+    });
+
+    it('keeps below-parent placement for a non-generator parent', () => {
+        const promptParent = { ...parent, type: NodeTypeEnum.PROMPT };
+        const child = {
+            id: 'child',
+            type: NodeTypeEnum.TEXT_TO_TEXT,
+            position: { x: 500, y: 700 },
+            width: 250,
+            height: 100,
+        };
+
+        expect(
+            calculateGeneratorChildPosition({
+                parent: promptParent,
+                nodes: [promptParent, child],
+                edges: [{ source: promptParent.id, target: child.id }],
+                gap: 150,
+            }),
+        ).toEqual({ x: 100, y: 530 });
+    });
+});
 
 describe('calculateQuickWorkflowPositionOffset', () => {
     it.each([


### PR DESCRIPTION
# Meridian 1.7.10-beta

Meridian `1.7.10-beta` adds canvas graph auto layout, improves generator chain placement to reduce overlap, and tightens release changelog validation to require an exact match.

## Highlights

### Graph Auto Layout

The canvas now supports automatic arrangement of graph nodes with a deterministic, multi-strategy layout.

- Use **Auto layout** from the canvas toolbar (`Controls` top-left) or from the quick-action wheel (right-click / `Shift+F10` on the canvas). The toolbar control is disabled when the graph is empty; the wheel action appears alongside **Fit graph**.
- Layout normalizes grouped nodes to their outer container, deduplicates constraints, splits disconnected components, and arranges each component with layered strategies for vertical ranking, branch columns, attachment stacks, fanout hierarchy, and serial prompt spines before packing components into rows.
- Running auto layout repositions nodes via `@dagrejs/dagre` (`network-simplex` ranking, `greedy` acyclicer), fits the viewport (`maxZoom: 1`, `minZoom: 0.4`, `padding: 0.2`), and persists the new positions through the existing graph save path. Layout anchoring preserves the previous minimum `x`/`y` so the graph remains in its existing coordinate context, with positions rounded to whole pixels.

### Smarter Generator Chain Placement

Creating generator nodes from an existing generator parent now avoids stacking directly below the parent when a chain already exists.

- Applies to chat actions that create `text-to-text`, `parallelization`, and `routing` nodes and to quick-workflow creation when `category` is `CONTEXT`, `direction` is `source`, and the target block is a generator type.
- When the parent is a generator (`text-to-text`, `parallelization`, `routing`) and has directly-connected generator children, the new node is placed to the right of the rightmost child (`child.x + child.width + gap`) at the same `y`; otherwise it is placed below the parent (`parent.y + parent.height + gap`).
- Non-generator parents and all other quick-workflow directions/categories keep the original offset calculation, including `calculateQuickWorkflowPositionOffset` handling. Node dimensions are resolved from rendered dimensions, explicit width/height, style dimensions, or block `minSize`.

### Stricter Release Changelog Validation

Release publishing now requires byte-exact equality between the merged release pull request body and the versioned changelog.

- `scripts/release_automation.py` no longer normalizes `CRLF` (`\r\n`) to `LF` (`\n`) before comparison; `pull.get("body") != changelog` now fails the publish step before tag or release mutation.
- `docs/releasing.md` is updated to state that the PR body must exactly match the changelog, including trailing newline. The previous wording that treated `CRLF` and `LF` as equivalent is removed.

## Self-Hosting and Upgrade Notes

Meridian `1.7.10-beta` is a non-breaking frontend and release-tooling update with no database migration, new configuration keys, or new secrets. UI dependency manifests and lockfile are updated to include the layout engine.

- Rebuild and redeploy the UI to include `ui/package.json` addition `@dagrejs/dagre@^3.1.0` and `ui/pnpm-lock.yaml` updates. Frontend Docker builds include the new `graphAutoLayout` utilities (`graphAutoLayout.ts`, `graphAutoLayoutAttachmentStacks.ts`, `graphAutoLayoutBranchColumns.ts`, `graphAutoLayoutComponent.ts`, `graphAutoLayoutConstraints.ts`, `graphAutoLayoutFanoutHierarchy.ts`, `graphAutoLayoutSerialPrompts.ts`) and updated `graphGeometry.ts` / canvas wiring.
- Existing graphs, accounts, and server data require no migration. Auto layout is manual-only and saves through the existing `saveGraph` path; no automatic re-layout occurs on load.
- Release maintainers must preserve the generated release PR body exactly as the changelog, including line endings and final trailing newline, for publish validation to succeed. Mismatched bodies stop publication before any tag or release is written.
- No API image rebuild is required for the layout changes alone, but rebuilding all images from the same commit remains the standard deployment path.

