### PR TITLE
Release Meridian 1.7.12-beta

### DIFF
--- a/docs/changelogs/Update-1.7.12-beta.md
+++ b/docs/changelogs/Update-1.7.12-beta.md
@@ -1,0 +1,20 @@
+# Meridian 1.7.12-beta
+
+Meridian `1.7.12-beta` restores reliable Markdown rendering after the frontend runtime-safety migration by explicitly binding runtime helpers in both the Marked worker and its composable.
+
+## Highlights
+
+### Reliable Worker-Based Markdown Rendering
+
+Markdown containing fenced code blocks or math can again use the dedicated worker with all runtime validation helpers available in the modules that call them.
+
+- The Marked worker now imports its string validation and conversion helpers directly, preventing missing runtime bindings while processing worker requests and highlighted code output.
+- The Marked composable now imports its string and undefined-value guards directly for worker initialization, worker responses, and main-thread Markdown results.
+- A focused worker regression test renders a fenced TypeScript block and verifies that highlighted HTML is returned through the worker message boundary.
+
+## Self-Hosting and Upgrade Notes
+
+Meridian `1.7.12-beta` is a non-breaking frontend fix with no database migration, new configuration keys, new secrets, dependency-file changes, API changes, or data conversion steps.
+
+- Rebuild and redeploy the UI to apply the Markdown worker fix; the API requires no release-specific configuration or migration work.
+- Maintainers using the repository release automation must keep the release pull request body exactly equal to the merged changelog, including its trailing newline; CRLF and LF bodies are no longer treated as equivalent during publication validation.

--- a/ui/app/assets/worker/marked.worker.ts
+++ b/ui/app/assets/worker/marked.worker.ts
@@ -2,6 +2,7 @@ import { Marked, type Tokens } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 import type { BundledLanguage, Highlighter } from 'shiki';
 import type katexType from 'katex';
+import { isRuntimeString, runtimeString } from '@/utils/runtimeTypes';
 
 // --- Constants ---
 const SHIKI_THEME = 'vitesse-dark';

--- a/ui/app/composables/useMarkedWorker.ts
+++ b/ui/app/composables/useMarkedWorker.ts
@@ -1,4 +1,5 @@
 import { Marked } from 'marked';
+import { isRuntimeString, isRuntimeUndefined } from '@/utils/runtimeTypes';
 
 // A map to store pending promises, keyed by a unique request ID.
 const pendingPromises = new Map<

--- a/ui/tests/unit/markedWorker.spec.ts
+++ b/ui/tests/unit/markedWorker.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type MarkedWorkerRequest = {
+    id: string;
+    markdown: string;
+};
+
+type MarkedWorkerHandler = (event: MessageEvent<MarkedWorkerRequest>) => Promise<void>;
+
+interface MarkedWorkerScope {
+    onmessage: MarkedWorkerHandler | null;
+    postMessage: ReturnType<typeof vi.fn>;
+}
+
+describe('marked worker entry', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('renders highlighted markdown with runtime helpers bound inside worker scope', async () => {
+        const postMessage = vi.fn();
+        const workerScope: MarkedWorkerScope = {
+            onmessage: null,
+            postMessage,
+        };
+        vi.stubGlobal('self', workerScope);
+
+        await import('@/assets/worker/marked.worker');
+
+        expect(workerScope.onmessage).not.toBeNull();
+        await workerScope.onmessage!(new MessageEvent<MarkedWorkerRequest>('message', {
+            data: {
+                id: 'request-1',
+                markdown: '```typescript\nconst answer = 42;\n```',
+            },
+        }));
+
+        expect(postMessage).toHaveBeenCalledOnce();
+        expect(postMessage).toHaveBeenCalledWith({
+            id: 'request-1',
+            html: expect.stringContaining('not-prose'),
+        });
+    });
+});


### PR DESCRIPTION
# Meridian 1.7.12-beta

Meridian `1.7.12-beta` restores reliable Markdown rendering after the frontend runtime-safety migration by explicitly binding runtime helpers in both the Marked worker and its composable.

## Highlights

### Reliable Worker-Based Markdown Rendering

Markdown containing fenced code blocks or math can again use the dedicated worker with all runtime validation helpers available in the modules that call them.

- The Marked worker now imports its string validation and conversion helpers directly, preventing missing runtime bindings while processing worker requests and highlighted code output.
- The Marked composable now imports its string and undefined-value guards directly for worker initialization, worker responses, and main-thread Markdown results.
- A focused worker regression test renders a fenced TypeScript block and verifies that highlighted HTML is returned through the worker message boundary.

## Self-Hosting and Upgrade Notes

Meridian `1.7.12-beta` is a non-breaking frontend fix with no database migration, new configuration keys, new secrets, dependency-file changes, API changes, or data conversion steps.

- Rebuild and redeploy the UI to apply the Markdown worker fix; the API requires no release-specific configuration or migration work.
- Maintainers using the repository release automation must keep the release pull request body exactly equal to the merged changelog, including its trailing newline; CRLF and LF bodies are no longer treated as equivalent during publication validation.
