### PR TITLE
Release Meridian 1.7.13-beta

### DIFF
--- a/docs/changelogs/Update-1.7.13-beta.md
+++ b/docs/changelogs/Update-1.7.13-beta.md
@@ -1,0 +1,26 @@
+# Meridian 1.7.13-beta
+
+Meridian `1.7.13-beta` keeps newly streamed chat content visible as conversations move from temporary sessions to generated nodes and removes blank spacing from filtered model menus.
+
+## Highlights
+
+### Reliable Live Chat Updates
+
+New conversations now remain reactive while their temporary chat session transitions to the generated node that owns the response.
+
+- The first streamed assistant message appears when a temporary session is assigned its generated node.
+- In-place updates to streamed message text now render immediately after that session transition.
+
+### Continuous Model Search Results
+
+Model dropdown results now stay consecutive while searching, navigating with the keyboard, and scrolling through the list.
+
+- Filtered options no longer develop blank gaps after repeated query changes or scrolling, including selectors opened from a zoomed canvas.
+- Subscription quick-jump controls continue to move directly to their provider section, and keyboard navigation keeps the active option visible.
+
+## Self-Hosting and Upgrade Notes
+
+Meridian `1.7.13-beta` is a non-breaking frontend fix with no database migration, new configuration keys, new secrets, dependency-file changes, API changes, or data conversion steps.
+
+- Rebuild and redeploy the UI to apply the chat reactivity and model-menu fixes; the API requires no release-specific configuration or migration work.
+- Existing conversations, model settings, and provider connections require no migration or manual updates.

--- a/ui/app/components/ui/chat/chatBox.vue
+++ b/ui/app/components/ui/chat/chatBox.vue
@@ -38,7 +38,7 @@ const isTemporaryGraph = computed(() => props.isTemporary === true || route.quer
 const COLLAPSE_THRESHOLD = 500;
 const isRenderingMessages = ref(true);
 const renderedMessageCount = ref(0);
-const session = shallowRef(getSession(openChatId.value || ''));
+const session = ref(getSession(openChatId.value || ''));
 const isAtTop = ref(false);
 const isAtBottom = ref(true);
 const chatContainer: Ref<HTMLElement | null> = ref(null);

--- a/ui/app/components/ui/models/select.vue
+++ b/ui/app/components/ui/models/select.vue
@@ -1,7 +1,4 @@
 <script lang="ts" setup>
-import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
-import { RecycleScroller } from 'vue-virtual-scroller';
-
 import {
     MODEL_DROPDOWN_ALL_SECTION_ID,
     MODEL_DROPDOWN_PINNED_SECTION_ID,
@@ -14,10 +11,9 @@ import {
 import { SavingStatus } from '@/types/enums';
 import type { ModelInfo } from '@/types/model';
 
-type VirtualizedModelRow = {
+type ModelRow = {
     id: string;
     model: ModelInfo;
-    size: number;
     headerMeta?: string;
     headerTitle?: string;
     headerTooltip?: string;
@@ -75,16 +71,13 @@ const selected = ref<ModelInfo | undefined>();
 const query = ref<string>('');
 const buttonRef = ref<HTMLElement | null>(null);
 const panelRef = ref<HTMLElement | null>(null);
-const scrollerRef = ref<{ scrollToItem: (index: number) => void } | null>(null);
+const scrollerRef = ref<HTMLElement | null>(null);
 const menuPosition = ref({ top: 0, left: 0, zoom: 1 });
 const activeJumpSection = ref<string | null>(null);
 
 const TELEPORTED_MENU_WIDTH = 640;
 const TELEPORTED_MENU_OFFSET = 4;
 const TELEPORTED_MENU_FALLBACK_HEIGHT = 276;
-const MODEL_ROW_HEIGHT = 40;
-const MODEL_ROW_WITH_HEADER_HEIGHT = 70;
-
 let transformPaneObserver: MutationObserver | null = null;
 let buttonResizeObserver: ResizeObserver | null = null;
 let panelResizeObserver: ResizeObserver | null = null;
@@ -217,7 +210,7 @@ const subscriptionModelsByProvider = computed(() => {
 });
 
 const rowData = computed(() => {
-    const rows: VirtualizedModelRow[] = [];
+    const rows: ModelRow[] = [];
     const sectionStartIndices: Record<string, number> = {};
     const subscriptionSections: SubscriptionSectionButton[] = [];
 
@@ -251,7 +244,6 @@ const rowData = computed(() => {
             rows.push({
                 id: `${sectionId}:${model.id}`,
                 model,
-                size: index === 0 ? MODEL_ROW_WITH_HEADER_HEIGHT : MODEL_ROW_HEIGHT,
                 headerTitle: index === 0 ? options.headerTitle : undefined,
                 headerMeta: index === 0 ? options.headerMeta : undefined,
                 headerTooltip: index === 0 ? options.headerTooltip : undefined,
@@ -303,7 +295,7 @@ const rowData = computed(() => {
     };
 });
 
-const virtualizedMergedModels = computed(() => rowData.value.rows);
+const modelRows = computed(() => rowData.value.rows);
 const subscriptionSectionButtons = computed(() => rowData.value.subscriptionSections);
 
 // --- Methods ---
@@ -448,13 +440,19 @@ const handleTriggerClick = (event: MouseEvent) => {
 
 const jumpToSubscriptionSection = (sectionId: string) => {
     const targetIndex = rowData.value.sectionStartIndices[sectionId];
+    const list = scrollerRef.value;
 
-    if (targetIndex === undefined) {
+    if (targetIndex === undefined || !list) {
+        return;
+    }
+
+    const target = list.querySelector(`[data-model-row-index="${targetIndex}"]`);
+    if (!(target instanceof HTMLElement)) {
         return;
     }
 
     activeJumpSection.value = sectionId;
-    scrollerRef.value?.scrollToItem(targetIndex);
+    list.scrollTop = target.offsetTop;
 };
 
 const getPinShortcutTargetModel = (activeOption: RuntimeValue) => {
@@ -714,34 +712,32 @@ onUnmounted(() => {
                         </div>
 
                         <!-- List -->
-                        <RecycleScroller
-                            v-if="virtualizedMergedModels.length"
+                        <div
+                            v-if="modelRows.length"
                             ref="scrollerRef"
-                            :items="virtualizedMergedModels"
-                            :item-size="null"
-                            :min-item-size="MODEL_ROW_HEIGHT"
-                            key-field="id"
-                            class="nowheel custom_scroll max-h-64 px-1.5 py-1"
+                            class="nowheel custom_scroll relative max-h-64 overflow-y-auto px-1.5
+                                py-1"
                         >
-                            <template #default="{ item: modelRow }">
-                                <HeadlessComboboxOption
-                                    v-slot="{ selected: isSelected, active: isActive }"
-                                    :value="modelRow.model"
-                                    as="template"
-                                >
-                                    <UiModelsSelectItem
-                                        :model="modelRow.model"
-                                        :active="isActive"
-                                        :selected="isSelected"
-                                        :header-title="modelRow.headerTitle"
-                                        :header-meta="modelRow.headerMeta"
-                                        :header-tooltip="modelRow.headerTooltip"
-                                        :hide-tool="hideTool"
-                                        :warning-label="modelRow.warningLabel"
-                                    />
-                                </HeadlessComboboxOption>
-                            </template>
-                        </RecycleScroller>
+                            <HeadlessComboboxOption
+                                v-for="(modelRow, index) in modelRows"
+                                :key="modelRow.id"
+                                v-slot="{ selected: isSelected, active: isActive }"
+                                :value="modelRow.model"
+                                as="template"
+                            >
+                                <UiModelsSelectItem
+                                    :data-model-row-index="index"
+                                    :model="modelRow.model"
+                                    :active="isActive"
+                                    :selected="isSelected"
+                                    :header-title="modelRow.headerTitle"
+                                    :header-meta="modelRow.headerMeta"
+                                    :header-tooltip="modelRow.headerTooltip"
+                                    :hide-tool="hideTool"
+                                    :warning-label="modelRow.warningLabel"
+                                />
+                            </HeadlessComboboxOption>
+                        </div>
 
                         <!-- Empty state -->
                         <div

--- a/ui/app/pages/auth/model-catalog-fixture.vue
+++ b/ui/app/pages/auth/model-catalog-fixture.vue
@@ -25,6 +25,7 @@ const decoded = import.meta.client
     : decodeModelCatalog(MODEL_CATALOG_FIXTURE_RESPONSE);
 
 modelStore.setModels(decoded.data);
+modelStore.triggerFilter();
 if (import.meta.client) {
     modelStore.showModelDiscoveryWarnings(decoded.warnings ?? []);
 }
@@ -33,6 +34,7 @@ const fixtureIds = Object.keys(MODEL_CATALOG_MODALITY_EXPECTATIONS);
 const fixtureModels = decoded.data.filter((model) => fixtureIds.includes(model.id));
 const allCapabilitiesModel = modelStore.getModel('fixture-all-capabilities');
 const defaultedModel = modelStore.getModel('fixture-text');
+const selectedModelId = ref('spacing-flash-ling');
 
 const rejectionResult = (value: RuntimeValue) => {
     const countBefore = modelStore.models.length;
@@ -135,6 +137,25 @@ const renderedSummary = {
         class="bg-obsidian text-soft-silk min-h-screen overflow-auto p-6"
     >
         <h1 class="text-lg font-semibold">Model catalog fixture</h1>
+        <ClientOnly>
+            <div
+                data-testid="model-selector-spacing-fixture"
+                class="vue-flow__transformationpane mt-4 h-10 w-80 origin-top-left"
+                style="transform: scale(0.8); pointer-events: auto"
+            >
+                <div class="h-10 w-80">
+                    <UiModelsSelect
+                        :model="selectedModelId"
+                        :set-model="(model: string) => (selectedModelId = model)"
+                        :disabled="false"
+                        to="left"
+                        from="bottom"
+                        variant="grey"
+                        prevent-trigger-on-mount
+                    />
+                </div>
+            </div>
+        </ClientOnly>
         <ClientOnly>
             <pre data-testid="model-catalog-summary" class="mt-4 whitespace-pre-wrap text-xs">{{
                 JSON.stringify(renderedSummary)

--- a/ui/e2e/fixtures/modelCatalogFixture.ts
+++ b/ui/e2e/fixtures/modelCatalogFixture.ts
@@ -3,7 +3,7 @@ import type { CompactModelCatalogResponse, CompactModelInfo } from '../../app/ty
 export const MODEL_CATALOG_FIXTURE_ROUTE = '/auth/model-catalog-fixture';
 export const MODEL_CATALOG_PERFORMANCE_FIXTURE_ROUTE =
     '/auth/model-catalog-performance-fixture';
-export const MODEL_CATALOG_FIXTURE_MODEL_COUNT = 8;
+export const MODEL_CATALOG_FIXTURE_MODEL_COUNT = 25;
 export const MODEL_CATALOG_PERFORMANCE_MODEL_COUNT = 500;
 
 const namedModels: CompactModelInfo[] = [
@@ -65,9 +65,158 @@ const namedModels: CompactModelInfo[] = [
     },
 ];
 
+const selectorSpacingModels: CompactModelInfo[] = [
+    {
+        id: 'spacing-flash-ling',
+        name: 'Ling-3.0-flash',
+        pricing: { prompt: '0.00000002', completion: '0.00000006' },
+        capabilities: 17,
+        supportedTools: 1,
+        contextLength: 262144,
+    },
+    {
+        id: 'spacing-flash-gemini-36',
+        name: 'Google: Gemini 3.6 Flash',
+        pricing: { prompt: '0.00000075', completion: '0.00000375' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'google',
+        contextLength: 1000000,
+    },
+    {
+        id: 'spacing-flash-gemini-35-lite',
+        name: 'Google: Gemini 3.5 Flash Lite',
+        pricing: { prompt: '0.0000003', completion: '0.0000025' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'google',
+        contextLength: 1000000,
+    },
+    {
+        id: 'spacing-flash-step-37',
+        name: 'StepFun: Step 3.7 Flash',
+        pricing: { prompt: '0.0000002', completion: '0.00000115' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'stepfun-ai',
+        contextLength: 256000,
+    },
+    {
+        id: 'spacing-flash-qwen-coder',
+        name: 'Qwen: Qwen3 Coder Flash',
+        pricing: { prompt: '0.0000002', completion: '0.00000097' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'qwen',
+        contextLength: 1000000,
+    },
+    {
+        id: 'spacing-flash-gemini-preview',
+        name: 'Google: Gemini 3 Flash Preview',
+        pricing: { prompt: '0.0000005', completion: '0.000003' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'google',
+        contextLength: 1000000,
+    },
+    {
+        id: 'spacing-flash-mistral',
+        name: 'Mistral: Codestral Flash',
+        pricing: { prompt: '0.00000015', completion: '0.0000006' },
+        capabilities: 1,
+        icon: 'mistralai',
+        contextLength: 131072,
+    },
+    {
+        id: 'spacing-flash-deepseek',
+        name: 'DeepSeek: V3 Flash',
+        pricing: { prompt: '0.00000014', completion: '0.00000028' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'deepseek',
+        contextLength: 65536,
+    },
+    {
+        id: 'spacing-flash-llama',
+        name: 'Meta: Llama Flash',
+        pricing: { prompt: '0', completion: '0' },
+        capabilities: 1,
+        icon: 'meta-llama',
+        contextLength: 32768,
+    },
+    {
+        id: 'spacing-flash-minimax',
+        name: 'MiniMax: M2 Flash',
+        pricing: { prompt: '0.0000001', completion: '0.0000004' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'minimax',
+        contextLength: 204800,
+    },
+    {
+        id: 'spacing-flash-nova',
+        name: 'Nova Flash',
+        pricing: { prompt: '0.00000008', completion: '0.00000024' },
+        capabilities: 1,
+        contextLength: 128000,
+    },
+    {
+        id: 'spacing-flash-command',
+        name: 'Cohere: Command Flash',
+        pricing: { prompt: '0.00000025', completion: '0.000001' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'cohere',
+        contextLength: 128000,
+    },
+    {
+        id: 'spacing-flash-grok',
+        name: 'xAI: Grok Flash',
+        pricing: { prompt: '0.0000002', completion: '0.0000005' },
+        capabilities: 1,
+        icon: 'x-ai',
+        contextLength: 131072,
+    },
+    {
+        id: 'spacing-flash-phi',
+        name: 'Microsoft: Phi Flash',
+        pricing: { prompt: '0', completion: '0' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'microsoft',
+        contextLength: 65536,
+    },
+    {
+        id: 'spacing-flash-kimi',
+        name: 'Moonshot: Kimi Flash',
+        pricing: { prompt: '0.00000012', completion: '0.0000005' },
+        capabilities: 1,
+        icon: 'moonshotai',
+        contextLength: 262144,
+    },
+    {
+        id: 'spacing-flash-long-context',
+        name: 'OpenRouter: Long Context Flash',
+        pricing: { prompt: '0.0000004', completion: '0.0000012' },
+        capabilities: 17,
+        supportedTools: 1,
+        icon: 'openrouter',
+        contextLength: 2000000,
+    },
+    {
+        id: 'spacing-github-subscription',
+        name: 'GitHub Subscription Text',
+        pricing: { prompt: '0', completion: '0' },
+        capabilities: 65,
+        provider: 'github_copilot',
+        icon: 'github',
+        contextLength: 128000,
+    },
+];
+
 export const MODEL_CATALOG_FIXTURE_RESPONSE: CompactModelCatalogResponse = {
     version: 1,
-    data: namedModels,
+    data: [...selectorSpacingModels, ...namedModels],
     warnings: [
         {
             provider: 'github_copilot',

--- a/ui/e2e/tests/model-catalog.spec.ts
+++ b/ui/e2e/tests/model-catalog.spec.ts
@@ -54,6 +54,20 @@ const mountFixture = async (page: Page) => {
         modelRequestCount += 1;
         await route.fulfill({ json: MODEL_CATALOG_FIXTURE_RESPONSE });
     });
+    await page.route('**/api/inference/providers/status', (route) =>
+        route.fulfill({
+            json: {
+                providers: [
+                    {
+                        provider: 'github_copilot',
+                        label: 'GitHub Copilot',
+                        isConnected: true,
+                        requiresUserToken: false,
+                    },
+                ],
+            },
+        }),
+    );
     await page.goto(MODEL_CATALOG_FIXTURE_ROUTE);
 
     const fixturePage = page.getByTestId('model-catalog-fixture-page');
@@ -202,6 +216,101 @@ test('applies optional defaults, retains warnings, and rejects invalid catalogs 
     expect(summary.malformedRequiredValue.countAfter).toBe(
         summary.malformedRequiredValue.countBefore,
     );
+});
+
+test('keeps filtered model rows consecutive after activation and scrolling', async ({ page }) => {
+    await mountFixture(page);
+
+    const selector = page.getByTestId('model-selector-spacing-fixture');
+    const input = selector.locator('input');
+    await input.click();
+
+    const panel = page.locator('.ui-models-panel');
+    await expect(panel).toBeVisible();
+    const list = panel.locator('.custom_scroll');
+    const lingOption = panel.getByRole('option', { name: /Ling-3\.0-flash/ });
+    const githubJump = panel.getByRole('button', { name: /GitHub Copilot 1/ });
+
+    await expect
+        .poll(() =>
+            panel.evaluate((element) => {
+                const transform = new DOMMatrixReadOnly(window.getComputedStyle(element).transform);
+                return transform.a;
+            }),
+        )
+        .toBeCloseTo(0.8, 2);
+
+    await githubJump.click();
+    await expect(
+        panel.getByRole('option', { name: /GitHub Copilot.*GitHub Subscription Text/ }),
+    ).toBeVisible();
+
+    await input.fill('Flash');
+    await expect(lingOption).toBeVisible();
+    await expect(lingOption).toHaveAttribute('aria-selected', 'true');
+    await input.press('ArrowDown');
+    await input.press('ArrowDown');
+
+    await list.evaluate((element) => {
+        element.scrollTop = element.scrollHeight;
+        element.dispatchEvent(new Event('scroll'));
+    });
+    await expect(panel.getByRole('option', { name: /OpenRouter: Long Context Flash/ })).toBeVisible();
+    await input.press('ArrowUp');
+
+    await input.fill('Gemini');
+    await expect(panel.getByRole('option', { name: /Gemini 3\.6 Flash/ })).toBeVisible();
+    await input.fill('Flash');
+    await expect(lingOption).toBeVisible();
+
+    for (let index = 0; index < 8; index += 1) {
+        await input.press('ArrowDown');
+    }
+
+    const activeOptionId = await input.getAttribute('aria-activedescendant');
+    expect(activeOptionId).not.toBeNull();
+    await expect(panel.locator(`#${activeOptionId}`)).toBeVisible();
+
+    await list.evaluate((element) => {
+        element.scrollTop = Math.min(180, element.scrollHeight - element.clientHeight);
+        element.dispatchEvent(new Event('scroll'));
+    });
+
+    const geometry = await panel.getByRole('option').evaluateAll((elements) => {
+        const listElement = elements[0]?.closest('.custom_scroll');
+        if (!(listElement instanceof HTMLElement)) {
+            throw new TypeError('Model options are missing their scrolling container');
+        }
+
+        const viewport = listElement.getBoundingClientRect();
+        const rows = elements
+            .map((element) => {
+                const bounds = element.getBoundingClientRect();
+                return {
+                    name: element.getAttribute('title') ?? element.textContent ?? '',
+                    top: bounds.top,
+                    bottom: bounds.bottom,
+                    visibility: window.getComputedStyle(element).visibility,
+                };
+            })
+            .filter(
+                (row) =>
+                    row.visibility !== 'hidden' &&
+                    row.bottom > viewport.top &&
+                    row.top < viewport.bottom,
+            );
+        const errors = rows.slice(1).map((row, index) => Math.abs(row.top - rows[index].bottom));
+
+        return {
+            rows,
+            maxError: errors.length ? Math.max(...errors) : Number.POSITIVE_INFINITY,
+            scrollTop: listElement.scrollTop,
+            scrollHeight: listElement.scrollHeight,
+        };
+    });
+
+    expect(geometry.rows.length).toBeGreaterThanOrEqual(3);
+    expect(geometry.maxError, JSON.stringify(geometry, null, 2)).toBeLessThanOrEqual(2);
 });
 
 test('decodes 500 models within the browser timing budget after warm-up', {

--- a/ui/tests/nuxt/chatBox.spec.ts
+++ b/ui/tests/nuxt/chatBox.spec.ts
@@ -1,27 +1,49 @@
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime';
-import { defineComponent, h, ref } from 'vue';
+import { defineComponent, h, nextTick, ref, type Ref } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ChatBox from '@/components/ui/chat/chatBox.vue';
-import { NodeTypeEnum } from '@/types/enums';
-import type { ChatInputSubmission } from '@/types/chat';
+import { DEFAULT_NODE_ID } from '@/constants';
+import { MessageContentTypeEnum, MessageRoleEnum, NodeTypeEnum } from '@/types/enums';
+import type { ChatInputSubmission, ChatSession } from '@/types/chat';
+import type { Message } from '@/types/graph';
 
-const stubs = vi.hoisted(() => ({
+interface ChatBoxTestStubs {
+    callOrder: string[];
+    generateNew: ReturnType<typeof vi.fn>;
+    graphEmit: ReturnType<typeof vi.fn>;
+    initialOpenChatId: string;
+    openChatId: Ref<string | null> | null;
+    session: ChatSession;
+    sessionRef: Ref<ChatSession> | null;
+}
+
+const stubs = vi.hoisted((): ChatBoxTestStubs => ({
     callOrder: Array<string>(),
     generateNew: vi.fn(),
     graphEmit: vi.fn(),
+    initialOpenChatId: 'chat-id',
+    openChatId: null,
+    session: {
+        fromNodeId: 'chat-id',
+        messages: [],
+    },
+    sessionRef: null,
 }));
 
-mockNuxtImport('useChatGenerator', () => () => ({
-            isStreaming: ref(false),
-            streamingSession: ref(null),
-            generationError: ref(null),
-            selectedNodeType: ref(NodeTypeEnum.STREAMING),
-            generateNew: stubs.generateNew,
-            generateFollowUp: vi.fn(),
-            regenerate: vi.fn(),
-            handleCancelStream: vi.fn(),
-            restoreStreamingState: vi.fn(),
-        }));
+mockNuxtImport('useChatGenerator', () => (session: Ref<ChatSession>) => {
+    stubs.sessionRef = session;
+    return {
+        isStreaming: ref(false),
+        streamingSession: ref(null),
+        generationError: ref(null),
+        selectedNodeType: ref(NodeTypeEnum.STREAMING),
+        generateNew: stubs.generateNew,
+        generateFollowUp: vi.fn(),
+        regenerate: vi.fn(),
+        handleCancelStream: vi.fn(),
+        restoreStreamingState: vi.fn(),
+    };
+});
 
 mockNuxtImport('useMessageEditing', () => () => ({
             currentEditModeIdx: ref(null),
@@ -29,15 +51,19 @@ mockNuxtImport('useMessageEditing', () => () => ({
         }));
 
 mockNuxtImport('storeToRefs', () => <Store extends Record<string, RuntimeValue>>(store: Store) => store);
-mockNuxtImport('useChatStore', () => () => ({
-    openChatId: ref('chat-id'),
-    isFetching: ref(false),
-    isCanvasReady: ref(false),
-    lastOpenedChatId: ref('chat-id'),
-    closeChat: vi.fn(),
-    loadAndOpenChat: vi.fn(),
-    getSession: vi.fn(() => ({ fromNodeId: null, messages: [] })),
-}));
+mockNuxtImport('useChatStore', () => () => {
+    const openChatId = ref<string | null>(stubs.initialOpenChatId);
+    stubs.openChatId = openChatId;
+    return {
+        openChatId,
+        isFetching: ref(false),
+        isCanvasReady: ref(false),
+        lastOpenedChatId: ref('chat-id'),
+        closeChat: vi.fn(),
+        loadAndOpenChat: vi.fn(),
+        getSession: vi.fn(() => stubs.session),
+    };
+});
 mockNuxtImport('useSidebarCanvasStore', () => () => ({
     isRightOpen: ref(false),
     isLeftOpen: ref(false),
@@ -87,9 +113,30 @@ const TextInputStub = defineComponent({
     },
 });
 
+const MarkdownRendererStub = (props: { message: Message }) =>
+    h('span', { class: 'message-text' }, props.message.content[0]?.text ?? '');
+
+const NodeTypeIndicatorStub = defineComponent({
+    name: 'UiChatNodeTypeIndicator',
+    props: {
+        nodeType: {
+            type: String,
+            required: true,
+        },
+    },
+    setup() {
+        return () => h('span');
+    },
+});
+
 describe('chatBox manual message generation', () => {
     beforeEach(() => {
         stubs.callOrder.length = 0;
+        stubs.initialOpenChatId = 'chat-id';
+        stubs.openChatId = null;
+        stubs.session.fromNodeId = 'chat-id';
+        stubs.session.messages.splice(0);
+        stubs.sessionRef = null;
         stubs.graphEmit.mockReset().mockImplementation(() => {
             stubs.callOrder.push('open-upcoming-node-data');
         });
@@ -131,5 +178,52 @@ describe('chatBox manual message generation', () => {
         } finally {
             wrapper.unmount();
         }
+    });
+
+    it('renders nested streamed text after migrating the temporary session', async () => {
+        stubs.initialOpenChatId = DEFAULT_NODE_ID;
+        stubs.session.fromNodeId = DEFAULT_NODE_ID;
+        const wrapper = await mountSuspended(ChatBox, {
+            shallow: true,
+            global: {
+                stubs: {
+                    UiChatMarkdownRenderer: MarkdownRendererStub,
+                    UiChatNodeTypeIndicator: NodeTypeIndicatorStub,
+                    UiChatTextInput: TextInputStub,
+                },
+            },
+        });
+
+        const generatedNodeId = 'generated-node-id';
+        const assistantMessage: Message = {
+            role: MessageRoleEnum.assistant,
+            content: [{ type: MessageContentTypeEnum.TEXT, text: '' }],
+            model: 'test-model',
+            node_id: generatedNodeId,
+            type: NodeTypeEnum.TEXT_TO_TEXT,
+            data: null,
+            usageData: null,
+        };
+        const activeSession = stubs.sessionRef;
+        const openChatId = stubs.openChatId;
+        expect(activeSession).not.toBeNull();
+        expect(openChatId).not.toBeNull();
+        if (!activeSession || !openChatId) return;
+
+        activeSession.value.fromNodeId = generatedNodeId;
+        activeSession.value.messages.push(assistantMessage);
+        openChatId.value = generatedNodeId;
+        await nextTick();
+
+        expect(wrapper.find('.message-text').exists()).toBe(true);
+        expect(wrapper.text()).not.toContain('First streamed chunk');
+
+        const textContent = activeSession.value.messages[0]?.content[0];
+        expect(textContent?.type).toBe(MessageContentTypeEnum.TEXT);
+        if (!textContent || textContent.type !== MessageContentTypeEnum.TEXT) return;
+        textContent.text += 'First streamed chunk';
+        await nextTick();
+
+        expect(wrapper.text()).toContain('First streamed chunk');
     });
 });


### PR DESCRIPTION
# Meridian 1.7.13-beta

Meridian `1.7.13-beta` keeps newly streamed chat content visible as conversations move from temporary sessions to generated nodes and removes blank spacing from filtered model menus.

## Highlights

### Reliable Live Chat Updates

New conversations now remain reactive while their temporary chat session transitions to the generated node that owns the response.

- The first streamed assistant message appears when a temporary session is assigned its generated node.
- In-place updates to streamed message text now render immediately after that session transition.

### Continuous Model Search Results

Model dropdown results now stay consecutive while searching, navigating with the keyboard, and scrolling through the list.

- Filtered options no longer develop blank gaps after repeated query changes or scrolling, including selectors opened from a zoomed canvas.
- Subscription quick-jump controls continue to move directly to their provider section, and keyboard navigation keeps the active option visible.

## Self-Hosting and Upgrade Notes

Meridian `1.7.13-beta` is a non-breaking frontend fix with no database migration, new configuration keys, new secrets, dependency-file changes, API changes, or data conversion steps.

- Rebuild and redeploy the UI to apply the chat reactivity and model-menu fixes; the API requires no release-specific configuration or migration work.
- Existing conversations, model settings, and provider connections require no migration or manual updates.
